### PR TITLE
fix: documentation incorrect imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.3] - 2025-01-23
+
+### Fixed
+
+- **Documentation**: Fixed incorrect import `from pydantic_ai import Toolset` → `from pydantic_ai.toolsets import FunctionToolset`
+- **Documentation**: Fixed typo `BuitinTools` → `WebSearchTool` from `pydantic_ai.builtin_tools`
+
 ## [0.0.2] - 2025-01-22
 
 ### Added

--- a/docs/concepts/subagents.md
+++ b/docs/concepts/subagents.md
@@ -107,13 +107,13 @@ SubAgentConfig(
 ### With Built-in Tools
 
 ```python
-from pydantic_ai import BuitinTools
+from pydantic_ai.builtin_tools import WebSearchTool
 
 SubAgentConfig(
     name="web-researcher",
     description="Researches using web search",
     instructions="You research topics using web search.",
-    agent_kwargs={"builtin_tools": [BuitinTools.web_search]},
+    agent_kwargs={"builtin_tools": [WebSearchTool()]},
 )
 ```
 

--- a/docs/examples/toolsets.md
+++ b/docs/examples/toolsets.md
@@ -30,9 +30,9 @@ class Deps:
 # Custom toolset for file operations
 def create_file_tools():
     """Create simple file operation tools."""
-    from pydantic_ai import Toolset
+    from pydantic_ai.toolsets import FunctionToolset
 
-    toolset = Toolset()
+    toolset = FunctionToolset()
 
     @toolset.tool
     async def read_file(path: str) -> str:
@@ -173,7 +173,7 @@ toolset = create_subagent_toolset(
 Use Pydantic AI's built-in tools:
 
 ```python
-from pydantic_ai import BuitinTools
+from pydantic_ai.builtin_tools import WebSearchTool
 
 subagents = [
     SubAgentConfig(
@@ -181,7 +181,7 @@ subagents = [
         description="Researches using web search",
         instructions="You research topics using web search.",
         agent_kwargs={
-            "builtin_tools": [BuitinTools.web_search],
+            "builtin_tools": [WebSearchTool()],
         },
     ),
 ]

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -13,6 +13,13 @@
   --md-accent-fg-color: #ff4081;
 }
 
+[data-md-color-scheme="slate"] {
+  --md-primary-fg-color: #e91e63;
+  --md-primary-fg-color--light: #f48fb1;
+  --md-primary-fg-color--dark: #c2185b;
+  --md-accent-fg-color: #ff4081;
+}
+
 /* --------------------------------------------
    Announcement Bar
    -------------------------------------------- */

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "subagents-pydantic-ai"
-version = "0.0.2"
+version = "0.0.3"
 description = "Subagent toolset for pydantic-ai with dual-mode execution and dynamic agent creation"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -1287,7 +1287,7 @@ wheels = [
 
 [[package]]
 name = "subagents-pydantic-ai"
-version = "0.0.2"
+version = "0.0.3"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## [0.0.3] - 2025-01-23

### Fixed

- **Documentation**: Fixed incorrect import `from pydantic_ai import Toolset` → `from pydantic_ai.toolsets import FunctionToolset`
- **Documentation**: Fixed typo `BuitinTools` → `WebSearchTool` from `pydantic_ai.builtin_tools`
