### PR TITLE
fix: remove _register_toolset() methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.4] - 2025-02-12
+
+### Fixed
+
+- **Compatibility**: Replaced all `agent._register_toolset()` calls with proper pydantic-ai API (#5)
+  - `_compile_subagent()`: toolsets now passed directly to `Agent()` constructor via `toolsets=` parameter
+  - `task()` runtime toolsets: collected from factory and passed to `agent.run(toolsets=...)` instead of registering on agent instance
+  - `create_agent_factory_toolset()`: toolsets from factory/capabilities passed to `Agent()` constructor
+  - Fixes `AttributeError: 'Agent' object has no attribute '_register_toolset'` with pydantic-ai >= 0.1.x
+
 ## [0.0.3] - 2025-01-23
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "subagents-pydantic-ai"
-version = "0.0.3"
+version = "0.0.4"
 description = "Subagent toolset for pydantic-ai with dual-mode execution and dynamic agent creation"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/subagents_pydantic_ai/factory.py
+++ b/src/subagents_pydantic_ai/factory.py
@@ -153,23 +153,20 @@ def create_agent_factory_toolset(
 
         # Create agent
         try:
-            agent: Agent[Any, str] = Agent(
-                actual_model,
-                system_prompt=instructions,
-            )
-
-            # Apply toolsets from factory if provided (takes priority)
+            # Collect toolsets from factory or capabilities
+            agent_toolsets: list[Any] = []
             if toolsets_factory:
-                runtime_toolsets = toolsets_factory(ctx.deps)
-                for ts in runtime_toolsets:
-                    agent._register_toolset(ts)  # type: ignore[attr-defined]
-            # Otherwise, apply toolsets from capabilities
+                agent_toolsets.extend(toolsets_factory(ctx.deps))
             elif capabilities and capabilities_map:
                 for cap_name in capabilities:
                     cap_factory = capabilities_map[cap_name]
-                    cap_toolsets = cap_factory(ctx.deps)
-                    for ts in cap_toolsets:
-                        agent._register_toolset(ts)  # type: ignore[attr-defined]
+                    agent_toolsets.extend(cap_factory(ctx.deps))
+
+            agent: Agent[Any, str] = Agent(
+                actual_model,
+                system_prompt=instructions,
+                toolsets=agent_toolsets or None,
+            )
 
             registry.register(config, agent)
 

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -179,9 +179,7 @@ class TestCreateAgentFactoryToolset:
         ctx = MockRunContext(deps=MockDeps())
 
         with patch("subagents_pydantic_ai.factory.Agent") as mock_agent_class:
-            mock_agent = MagicMock()
-            mock_agent._register_toolset = MagicMock()
-            mock_agent_class.return_value = mock_agent
+            mock_agent_class.return_value = MagicMock()
 
             result = await create_tool.function(
                 ctx,
@@ -193,6 +191,10 @@ class TestCreateAgentFactoryToolset:
 
         assert "created successfully" in result
         assert "filesystem" in result
+        # Verify toolsets were passed to Agent constructor
+        call_kwargs = mock_agent_class.call_args
+        passed_toolsets = call_kwargs.kwargs.get("toolsets")
+        assert passed_toolsets is not None
 
     @pytest.mark.asyncio
     async def test_create_agent_invalid_capability(self, registry: DynamicAgentRegistry):
@@ -234,9 +236,7 @@ class TestCreateAgentFactoryToolset:
         ctx = MockRunContext(deps=MockDeps())
 
         with patch("subagents_pydantic_ai.factory.Agent") as mock_agent_class:
-            mock_agent = MagicMock()
-            mock_agent._register_toolset = MagicMock()
-            mock_agent_class.return_value = mock_agent
+            mock_agent_class.return_value = MagicMock()
 
             result = await create_tool.function(
                 ctx,
@@ -246,6 +246,10 @@ class TestCreateAgentFactoryToolset:
             )
 
         assert "created successfully" in result
+        # Verify toolsets were passed to Agent constructor
+        call_kwargs = mock_agent_class.call_args
+        passed_toolsets = call_kwargs.kwargs.get("toolsets")
+        assert passed_toolsets is not None
 
     @pytest.mark.asyncio
     async def test_list_agents_empty(self, registry: DynamicAgentRegistry):


### PR DESCRIPTION
## [0.0.4] - 2025-02-12

### Fixed

- **Compatibility**: Replaced all `agent._register_toolset()` calls with proper pydantic-ai API (#5)
  - `_compile_subagent()`: toolsets now passed directly to `Agent()` constructor via `toolsets=` parameter
  - `task()` runtime toolsets: collected from factory and passed to `agent.run(toolsets=...)` instead of registering on agent instance
  - `create_agent_factory_toolset()`: toolsets from factory/capabilities passed to `Agent()` constructor
  - Fixes `AttributeError: 'Agent' object has no attribute '_register_toolset'` with pydantic-ai >= 0.1.x
