### PR TITLE
feat: support structured output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.1] - 2026-03-29
+## [0.2.0] - 2026-03-30
 
 ### Added
 
-- **`SubAgentSpec`** — Pydantic model for declarative subagent configuration via YAML/JSON. Enables defining subagents in spec files instead of Python code:
+- **Custom agent support** via `agent` and `agent_factory` fields on `SubAgentConfig`:
+  ```python
+  SubAgentConfig(
+      name="researcher",
+      description="Deep research agent",
+      instructions="...",
+      agent=my_prebuilt_agent,  # pre-built agent, used as-is
+  )
+  # OR
+  SubAgentConfig(
+      name="researcher",
+      description="Deep research agent",
+      instructions="...",
+      agent_factory=lambda cfg: create_deep_agent(  # factory creates agent from config
+          model=cfg["model"], instructions=cfg["instructions"],
+      ),
+  )
+  ```
+  - Priority chain in `_compile_subagent()`: `agent` > `agent_factory` > default `Agent()`
+  - Enables frameworks like pydantic-deep to create full-featured agents as subagents
+- **`default_agent_factory`** parameter on `create_agent_factory_toolset()` — overrides default `Agent()` creation for dynamically spawned agents
+- **`SubAgentSpec`** — Pydantic model for declarative subagent configuration via YAML/JSON:
   ```yaml
   subagents:
     - name: researcher
@@ -17,10 +38,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
       instructions: You research topics thoroughly.
       model: openai:gpt-4.1-mini
   ```
-  - `to_config()` — convert spec to `SubAgentConfig` dict
-  - `from_config()` — create spec from `SubAgentConfig` dict
-  - Full round-trip support: spec -> config -> spec and config -> spec -> config
+  - `to_config()` / `from_config()` round-trip conversion
   - JSON/YAML serialization via Pydantic's `model_dump()` / `model_validate()`
+
+- **Token usage tracking** (issue [#45](https://github.com/vstorm-co/pydantic-deepagents/issues/45)):
+  - `TaskHandle.usage` — stores `RunUsage` from each subagent run
+  - `check_task` displays token usage (input/output) for completed tasks
+  - `get_total_usage()` on toolset — aggregates usage across all task handles
+  - `TaskManager.list_handles()` — returns all task handles
+- **Structured output serialization** (issue [#46](https://github.com/vstorm-co/pydantic-deepagents/issues/46)):
+  - `_serialize_output()` uses `model_dump_json()` for Pydantic models and `json.dumps(asdict())` for dataclasses instead of `str()`, preserving JSON structure for the parent agent
+
+### Changed
+
+- `_compile_subagent()` now checks for custom `agent`/`agent_factory` before creating default `Agent()`
+- Subagent results are now proper JSON when `output_type` is a Pydantic model (previously flattened to Python repr string)
 
 ## [0.1.0] - 2026-03-26
 

--- a/docs/advanced/dynamic-agents.md
+++ b/docs/advanced/dynamic-agents.md
@@ -45,6 +45,7 @@ agent = Agent(
 | `allowed_models` | `list[str]` | All | Models agents can use |
 | `max_agents` | `int` | `10` | Maximum dynamic agents |
 | `default_model` | `str \| None` | `None` | Default model for new agents |
+| `default_agent_factory` | `Callable \| None` | `None` | Factory used to build every dynamic agent |
 
 ## DynamicAgentRegistry
 
@@ -174,6 +175,43 @@ With this setup:
 - The parent can create new subagents at runtime via `create_agent()`
 - Newly created agents are immediately available to `task()` because both toolsets share the same `registry` instance
 - When the parent removes a dynamic agent, it is no longer discoverable by `task()`
+
+## Default Agent Factory
+
+By default, `create_agent_factory_toolset` builds a plain `pydantic_ai.Agent` for every
+dynamically created agent. Pass `default_agent_factory` to override this with your own
+builder. The factory receives a `SubAgentConfig` and must return an agent instance.
+
+This is useful when you want every dynamically created agent to be built with a specific
+framework (e.g., pydantic-deep) instead of a bare `Agent`:
+
+```python
+from pydantic_deep import create_deep_agent
+from subagents_pydantic_ai import (
+    create_agent_factory_toolset,
+    DynamicAgentRegistry,
+    SubAgentConfig,
+)
+
+def my_factory(config: SubAgentConfig):
+    return create_deep_agent(
+        model=config.get("model", "openai:gpt-4.1"),
+        system_prompt=config["instructions"],
+    )
+
+factory_toolset = create_agent_factory_toolset(
+    registry=DynamicAgentRegistry(),
+    default_agent_factory=my_factory,
+)
+```
+
+When `default_agent_factory` is set, it is called for **every** `create_agent()` invocation.
+If it is `None` (the default), the toolset falls back to creating a standard `pydantic_ai.Agent`.
+
+!!! note
+    `default_agent_factory` on `create_agent_factory_toolset` applies to dynamically created
+    agents only. For pre-configured subagents, use the `agent` or `agent_factory` fields on
+    [`SubAgentConfig`](../concepts/types.md#subagentconfig) instead.
 
 ## Creating Agents at Runtime
 

--- a/docs/concepts/capability.md
+++ b/docs/concepts/capability.md
@@ -91,6 +91,52 @@ agent = Agent(
 )
 ```
 
+## Custom Agents via SubAgentConfig
+
+`SubAgentCapability` supports using custom agent instances through the `agent` and
+`agent_factory` fields on `SubAgentConfig`. When the capability compiles subagents
+internally, it follows the same resolution priority as `_compile_subagent`:
+`agent` > `agent_factory` > default `Agent()`.
+
+```python
+from pydantic_ai import Agent
+from pydantic_deep import create_deep_agent
+from subagents_pydantic_ai import SubAgentCapability, SubAgentConfig
+
+agent = Agent(
+    "openai:gpt-4.1",
+    capabilities=[SubAgentCapability(
+        subagents=[
+            # Pre-built agent
+            SubAgentConfig(
+                name="researcher",
+                description="Researches topics",
+                instructions="You are a research assistant.",
+                agent=create_deep_agent(model="openai:gpt-4.1"),
+            ),
+            # Agent factory
+            SubAgentConfig(
+                name="coder",
+                description="Writes code",
+                instructions="You write Python code.",
+                agent_factory=lambda cfg: create_deep_agent(
+                    model=cfg.get("model", "openai:gpt-4.1"),
+                    system_prompt=cfg["instructions"],
+                ),
+            ),
+            # Default: plain Agent is created automatically
+            SubAgentConfig(
+                name="writer",
+                description="Writes content",
+                instructions="You write clear documentation.",
+            ),
+        ],
+    )],
+)
+```
+
+See [SubAgentConfig](types.md#subagentconfig) for full details on these fields.
+
 ## AgentSpec (YAML)
 
 ```yaml

--- a/docs/concepts/toolset.md
+++ b/docs/concepts/toolset.md
@@ -42,6 +42,48 @@ agent = Agent(
 )
 ```
 
+## Custom Agent Resolution
+
+When the toolset compiles a `SubAgentConfig`, the internal `_compile_subagent` function
+decides which agent instance to use. The resolution priority is:
+
+1. **`config["agent"]`** -- a pre-built agent instance, used as-is.
+2. **`config["agent_factory"]`** -- a `(config: SubAgentConfig) -> Agent` callable, invoked at compile time.
+3. **Default** -- a new `pydantic_ai.Agent` is created from the config's `model`, `instructions`, `toolsets`, and `agent_kwargs` fields.
+
+This means you can mix pre-built agents, factory-built agents, and default agents in the
+same subagent list:
+
+```python
+from pydantic_ai import Agent
+from subagents_pydantic_ai import create_subagent_toolset, SubAgentConfig
+
+toolset = create_subagent_toolset(
+    subagents=[
+        SubAgentConfig(
+            name="custom",
+            description="Uses a pre-built agent",
+            instructions="...",
+            agent=my_prebuilt_agent,
+        ),
+        SubAgentConfig(
+            name="factory-built",
+            description="Built via factory",
+            instructions="...",
+            agent_factory=lambda cfg: build_agent(cfg),
+        ),
+        SubAgentConfig(
+            name="default",
+            description="Default Agent created automatically",
+            instructions="...",
+        ),
+    ],
+)
+```
+
+See [SubAgentConfig](types.md#subagentconfig) for full documentation of the `agent` and
+`agent_factory` fields.
+
 ## Available Tools
 
 The toolset provides these tools to your agent:

--- a/docs/concepts/types.md
+++ b/docs/concepts/types.md
@@ -23,6 +23,49 @@ config = SubAgentConfig(
 
 See [Subagents](subagents.md) for full documentation.
 
+#### Custom Agent Support
+
+By default, `_compile_subagent` creates a plain `pydantic_ai.Agent` from the config fields. You can override this behavior with two optional fields: `agent` and `agent_factory`. The resolution priority is:
+
+1. **`agent`** -- a pre-built agent instance, used as-is.
+2. **`agent_factory`** -- a callable `(config: SubAgentConfig) -> Agent`, called at compile time.
+3. **Default** -- a new `pydantic_ai.Agent` is created from the config fields.
+
+**Using a pre-built agent:**
+
+```python
+from pydantic_ai import Agent
+from subagents_pydantic_ai import SubAgentConfig
+
+my_agent = Agent("openai:gpt-4.1", system_prompt="You are a custom researcher.")
+
+config = SubAgentConfig(
+    name="researcher",
+    description="Researches topics",
+    instructions="You are a research assistant.",
+    agent=my_agent,  # This agent is used directly
+)
+```
+
+**Using an agent factory:**
+
+```python
+from pydantic_deep import create_deep_agent
+from subagents_pydantic_ai import SubAgentConfig
+
+config = SubAgentConfig(
+    name="researcher",
+    description="Researches topics",
+    instructions="You are a research assistant.",
+    agent_factory=lambda cfg: create_deep_agent(
+        model=cfg.get("model", "openai:gpt-4.1"),
+        system_prompt=cfg["instructions"],
+    ),
+)
+```
+
+The `agent_factory` callable receives the full `SubAgentConfig` as its argument, so it can read any field (model, instructions, toolsets, extra, etc.) to configure the agent.
+
 ### CompiledSubAgent
 
 A pre-compiled subagent ready for use. Created internally by the toolset.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "subagents-pydantic-ai"
-version = "0.1.1"
+version = "0.2.0"
 description = "Subagent toolset for pydantic-ai with dual-mode execution and dynamic agent creation"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/subagents_pydantic_ai/factory.py
+++ b/src/subagents_pydantic_ai/factory.py
@@ -165,9 +165,9 @@ def create_agent_factory_toolset(
         # Create agent
         try:
             if default_agent_factory is not None:
-                agent = default_agent_factory(config)
+                agent: Any = default_agent_factory(config)
             else:
-                agent: Agent[Any, str] = Agent(
+                agent = Agent(
                     actual_model,
                     system_prompt=instructions,
                     toolsets=agent_toolsets or None,

--- a/src/subagents_pydantic_ai/factory.py
+++ b/src/subagents_pydantic_ai/factory.py
@@ -28,6 +28,7 @@ def create_agent_factory_toolset(
     toolsets_factory: ToolsetFactory | None = None,
     capabilities_map: dict[str, CapabilityFactory] | None = None,
     id: str | None = None,
+    default_agent_factory: Any | None = None,
 ) -> FunctionToolset[Any]:
     """Create a toolset for dynamic agent creation.
 
@@ -163,11 +164,14 @@ def create_agent_factory_toolset(
 
         # Create agent
         try:
-            agent: Agent[Any, str] = Agent(
-                actual_model,
-                system_prompt=instructions,
-                toolsets=agent_toolsets or None,
-            )
+            if default_agent_factory is not None:
+                agent = default_agent_factory(config)
+            else:
+                agent: Agent[Any, str] = Agent(
+                    actual_model,
+                    system_prompt=instructions,
+                    toolsets=agent_toolsets or None,
+                )
 
             registry.register(config, agent)
 

--- a/src/subagents_pydantic_ai/message_bus.py
+++ b/src/subagents_pydantic_ai/message_bus.py
@@ -472,3 +472,11 @@ class TaskManager:
             List of task IDs for tasks that haven't completed.
         """
         return [task_id for task_id, task in self.tasks.items() if not task.done()]
+
+    def list_handles(self) -> list[Any]:
+        """Get all task handles (completed and active).
+
+        Returns:
+            List of TaskHandle objects.
+        """
+        return list(self.handles.values())

--- a/src/subagents_pydantic_ai/toolset.py
+++ b/src/subagents_pydantic_ai/toolset.py
@@ -401,9 +401,7 @@ def create_subagent_toolset(  # noqa: C901
                 u = handle.usage
                 inp = getattr(u, "input_tokens", 0)
                 out = getattr(u, "output_tokens", 0)
-                status_info.append(
-                    f"Usage: {inp + out} tokens ({inp} in / {out} out)"
-                )
+                status_info.append(f"Usage: {inp + out} tokens ({inp} in / {out} out)")
         elif handle.status == TaskStatus.FAILED:
             status_info.append(f"Error: {handle.error}")
         elif handle.status == TaskStatus.WAITING_FOR_ANSWER:

--- a/src/subagents_pydantic_ai/toolset.py
+++ b/src/subagents_pydantic_ai/toolset.py
@@ -51,7 +51,7 @@ def _serialize_output(output: Any) -> str:
     For everything else, returns ``str(output)``.
     """
     if hasattr(output, "model_dump_json"):
-        return output.model_dump_json()
+        return output.model_dump_json()  # type: ignore[no-any-return]
     if hasattr(output, "__dataclass_fields__"):
         import dataclasses
         import json
@@ -100,11 +100,11 @@ def _compile_subagent(
     # 2. Agent factory — call it
     factory = config.get("agent_factory")
     if factory is not None:
-        agent = factory(config)
+        custom_agent = factory(config)
         return CompiledSubAgent(
             name=config["name"],
             description=config["description"],
-            agent=agent,
+            agent=custom_agent,
             config=config,
         )
 

--- a/src/subagents_pydantic_ai/toolset.py
+++ b/src/subagents_pydantic_ai/toolset.py
@@ -43,6 +43,23 @@ from subagents_pydantic_ai.types import (
 )
 
 
+def _serialize_output(output: Any) -> str:
+    """Serialize subagent output preserving structure for Pydantic models.
+
+    For Pydantic models (BaseModel), returns JSON via ``model_dump_json()``.
+    For dataclasses with ``__dataclass_fields__``, returns JSON via ``json.dumps``.
+    For everything else, returns ``str(output)``.
+    """
+    if hasattr(output, "model_dump_json"):
+        return output.model_dump_json()
+    if hasattr(output, "__dataclass_fields__"):
+        import dataclasses
+        import json
+
+        return json.dumps(dataclasses.asdict(output), default=str)
+    return str(output)
+
+
 def _create_general_purpose_config() -> SubAgentConfig:
     """Create the default general-purpose subagent config."""
     return SubAgentConfig(
@@ -59,6 +76,11 @@ def _compile_subagent(
 ) -> CompiledSubAgent:
     """Compile a subagent configuration into a ready-to-use agent.
 
+    Agent resolution priority:
+    1. ``config["agent"]`` — pre-built agent instance, used as-is
+    2. ``config["agent_factory"]`` — callable(config) -> agent
+    3. Default — creates ``pydantic_ai.Agent`` from config fields
+
     Args:
         config: The subagent configuration.
         default_model: Default model to use if not specified in config.
@@ -66,22 +88,36 @@ def _compile_subagent(
     Returns:
         CompiledSubAgent with agent instance.
     """
+    # 1. Pre-built agent — use as-is
+    if config.get("agent") is not None:
+        return CompiledSubAgent(
+            name=config["name"],
+            description=config["description"],
+            agent=config["agent"],
+            config=config,
+        )
+
+    # 2. Agent factory — call it
+    factory = config.get("agent_factory")
+    if factory is not None:
+        agent = factory(config)
+        return CompiledSubAgent(
+            name=config["name"],
+            description=config["description"],
+            agent=agent,
+            config=config,
+        )
+
+    # 3. Default: create plain pydantic-ai Agent
     model = config.get("model", default_model)
 
-    # Build toolsets list
     toolsets: list[Any] = []
-
-    # Add ask_parent tool for sync mode communication
     ask_parent_toolset = _create_ask_parent_toolset()
     toolsets.append(ask_parent_toolset)
 
-    # Add custom toolsets from config
     if config.get("toolsets"):
         toolsets.extend(config["toolsets"])
 
-    # Note: toolsets_factory will be called at runtime with deps
-
-    # Get additional agent kwargs (e.g., builtin_tools)
     agent_kwargs = config.get("agent_kwargs", {})
 
     agent: Agent[Any, str] = Agent(
@@ -361,6 +397,10 @@ def create_subagent_toolset(  # noqa: C901
 
         if handle.status == TaskStatus.COMPLETED:
             status_info.append(f"Result: {handle.result}")
+            if handle.usage is not None:
+                u = handle.usage
+                tokens = getattr(u, "input_tokens", 0) + getattr(u, "output_tokens", 0)
+                status_info.append(f"Usage: {tokens} tokens ({getattr(u, 'input_tokens', 0)} in / {getattr(u, 'output_tokens', 0)} out)")
         elif handle.status == TaskStatus.FAILED:
             status_info.append(f"Error: {handle.error}")
         elif handle.status == TaskStatus.WAITING_FOR_ANSWER:
@@ -502,6 +542,22 @@ def create_subagent_toolset(  # noqa: C901
     # Expose task_manager for external monitoring (e.g., push notifications)
     toolset.task_manager = task_manager  # type: ignore[attr-defined]
 
+    def get_total_usage() -> dict[str, int]:
+        """Get aggregate token usage across all completed subagent tasks.
+
+        Returns dict with ``input_tokens``, ``output_tokens``, ``total_tokens``, ``requests``.
+        """
+        totals: dict[str, int] = {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0, "requests": 0}
+        for handle in task_manager.list_handles():
+            if handle.usage is not None:
+                totals["input_tokens"] += getattr(handle.usage, "input_tokens", 0)
+                totals["output_tokens"] += getattr(handle.usage, "output_tokens", 0)
+                totals["requests"] += getattr(handle.usage, "requests", 0)
+        totals["total_tokens"] = totals["input_tokens"] + totals["output_tokens"]
+        return totals
+
+    toolset.get_total_usage = get_total_usage  # type: ignore[attr-defined]
+
     return toolset
 
 
@@ -541,7 +597,7 @@ async def _run_sync(
 
     try:
         result = await agent.run(prompt, **run_kwargs)
-        return str(result.output)
+        return _serialize_output(result.output)
     except Exception as e:
         return f"Error executing task: {e}"
 
@@ -612,7 +668,9 @@ async def _run_async(
 
         try:
             result = await agent.run(prompt, **run_kwargs)
-            handle.result = str(result.output)
+            handle.result = _serialize_output(result.output)
+            if hasattr(result, "usage"):
+                handle.usage = result.usage()
             handle.status = TaskStatus.COMPLETED
         except asyncio.CancelledError:
             handle.status = TaskStatus.CANCELLED

--- a/src/subagents_pydantic_ai/toolset.py
+++ b/src/subagents_pydantic_ai/toolset.py
@@ -399,9 +399,10 @@ def create_subagent_toolset(  # noqa: C901
             status_info.append(f"Result: {handle.result}")
             if handle.usage is not None:
                 u = handle.usage
-                tokens = getattr(u, "input_tokens", 0) + getattr(u, "output_tokens", 0)
+                inp = getattr(u, "input_tokens", 0)
+                out = getattr(u, "output_tokens", 0)
                 status_info.append(
-                    f"Usage: {tokens} tokens ({getattr(u, 'input_tokens', 0)} in / {getattr(u, 'output_tokens', 0)} out)"
+                    f"Usage: {inp + out} tokens ({inp} in / {out} out)"
                 )
         elif handle.status == TaskStatus.FAILED:
             status_info.append(f"Error: {handle.error}")

--- a/src/subagents_pydantic_ai/toolset.py
+++ b/src/subagents_pydantic_ai/toolset.py
@@ -400,7 +400,9 @@ def create_subagent_toolset(  # noqa: C901
             if handle.usage is not None:
                 u = handle.usage
                 tokens = getattr(u, "input_tokens", 0) + getattr(u, "output_tokens", 0)
-                status_info.append(f"Usage: {tokens} tokens ({getattr(u, 'input_tokens', 0)} in / {getattr(u, 'output_tokens', 0)} out)")
+                status_info.append(
+                    f"Usage: {tokens} tokens ({getattr(u, 'input_tokens', 0)} in / {getattr(u, 'output_tokens', 0)} out)"
+                )
         elif handle.status == TaskStatus.FAILED:
             status_info.append(f"Error: {handle.error}")
         elif handle.status == TaskStatus.WAITING_FOR_ANSWER:
@@ -547,7 +549,12 @@ def create_subagent_toolset(  # noqa: C901
 
         Returns dict with ``input_tokens``, ``output_tokens``, ``total_tokens``, ``requests``.
         """
-        totals: dict[str, int] = {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0, "requests": 0}
+        totals: dict[str, int] = {
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "total_tokens": 0,
+            "requests": 0,
+        }
         for handle in task_manager.list_handles():
             if handle.usage is not None:
                 totals["input_tokens"] += getattr(handle.usage, "input_tokens", 0)

--- a/src/subagents_pydantic_ai/types.py
+++ b/src/subagents_pydantic_ai/types.py
@@ -144,6 +144,12 @@ class SubAgentConfig(TypedDict, total=False):
 
     Optional fields:
         model: LLM model to use (defaults to parent's default)
+        agent: Pre-built agent instance. When provided, ``_compile_subagent``
+            uses this instead of creating a new ``Agent``. Useful for passing
+            agents created by frameworks like pydantic-deep.
+        agent_factory: Callable that receives the SubAgentConfig and returns
+            an agent instance. Called by ``_compile_subagent`` if ``agent``
+            is not provided. Signature: ``(config: SubAgentConfig) -> Agent``.
         can_ask_questions: Whether subagent can ask parent questions
         max_questions: Maximum questions per task
         preferred_mode: Default execution mode preference for this subagent
@@ -185,6 +191,8 @@ class SubAgentConfig(TypedDict, total=False):
     description: str
     instructions: str
     model: NotRequired[str | Model]
+    agent: NotRequired[Any]
+    agent_factory: NotRequired[Callable[..., Any]]
     can_ask_questions: NotRequired[bool]
     max_questions: NotRequired[int]
     preferred_mode: NotRequired[Literal["sync", "async", "auto"]]
@@ -258,6 +266,8 @@ class TaskHandle:
     result: str | None = None
     error: str | None = None
     pending_question: str | None = None
+    usage: Any = None
+    """Token usage from the subagent run (``RunUsage`` from pydantic-ai)."""
 
 
 @dataclass

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -474,3 +474,28 @@ class TestCreateAgentFactoryToolset:
 
         assert "Error creating agent" in result
         assert "Something went wrong" in result
+
+    async def test_create_agent_with_default_agent_factory(self, registry: DynamicAgentRegistry):
+        """default_agent_factory is used instead of Agent() when provided."""
+        mock_agent = MagicMock()
+        factory = MagicMock(return_value=mock_agent)
+
+        toolset = create_agent_factory_toolset(
+            registry=registry,
+            default_agent_factory=factory,
+        )
+        create_tool = toolset.tools["create_agent"]
+        ctx = MockRunContext(deps=MockDeps())
+
+        result = await create_tool.function(
+            ctx,
+            name="custom-agent",
+            description="Custom",
+            instructions="Do things",
+        )
+
+        assert "created successfully" in result
+        factory.assert_called_once()
+        # The factory receives a SubAgentConfig
+        call_arg = factory.call_args[0][0]
+        assert call_arg["name"] == "custom-agent"

--- a/tests/test_toolset.py
+++ b/tests/test_toolset.py
@@ -37,11 +37,24 @@ class MockRunContext:
     _subagent_state: dict[str, Any] | None = None
 
 
+class MockUsage:
+    """Mock RunUsage."""
+
+    def __init__(self, input_tokens: int = 100, output_tokens: int = 50, requests: int = 1):
+        self.input_tokens = input_tokens
+        self.output_tokens = output_tokens
+        self.requests = requests
+
+
 class MockResult:
     """Mock agent result."""
 
-    def __init__(self, output: str):
+    def __init__(self, output: Any = "mock result"):
         self.output = output
+        self._usage = MockUsage()
+
+    def usage(self) -> MockUsage:
+        return self._usage
 
 
 def _make_mock_compiled_subagent(config: SubAgentConfig) -> CompiledSubAgent:
@@ -201,6 +214,55 @@ class TestCompileSubagent:
             call_kwargs = mock_agent_class.call_args
             assert call_kwargs.kwargs.get("retries") == 3
             assert call_kwargs.kwargs.get("result_retries") == 2
+
+
+    def test_compile_with_prebuilt_agent(self):
+        """Pre-built agent in config is used as-is, skipping default creation."""
+        from subagents_pydantic_ai.toolset import _compile_subagent
+
+        mock_agent = MagicMock()
+        config = SubAgentConfig(
+            name="custom",
+            description="Custom agent",
+            instructions="Do stuff",
+            agent=mock_agent,
+        )
+        compiled = _compile_subagent(config, "openai:gpt-4")
+        assert compiled.agent is mock_agent
+        assert compiled.name == "custom"
+
+    def test_compile_with_agent_factory(self):
+        """Agent factory in config is called to create agent."""
+        from subagents_pydantic_ai.toolset import _compile_subagent
+
+        mock_agent = MagicMock()
+        factory = MagicMock(return_value=mock_agent)
+        config = SubAgentConfig(
+            name="factory-agent",
+            description="Factory agent",
+            instructions="Do stuff",
+            agent_factory=factory,
+        )
+        compiled = _compile_subagent(config, "openai:gpt-4")
+        assert compiled.agent is mock_agent
+        factory.assert_called_once_with(config)
+
+    def test_compile_priority_agent_over_factory(self):
+        """Pre-built agent takes priority over agent_factory."""
+        from subagents_pydantic_ai.toolset import _compile_subagent
+
+        prebuilt = MagicMock()
+        factory = MagicMock()
+        config = SubAgentConfig(
+            name="priority",
+            description="Priority test",
+            instructions="Test",
+            agent=prebuilt,
+            agent_factory=factory,
+        )
+        compiled = _compile_subagent(config, "openai:gpt-4")
+        assert compiled.agent is prebuilt
+        factory.assert_not_called()
 
 
 class TestCreateAskParentToolset:
@@ -728,6 +790,8 @@ class TestRunAsync:
         assert handle is not None
         assert handle.status == TaskStatus.COMPLETED
         assert handle.result == "task completed"
+        assert handle.usage is not None
+        assert handle.usage.input_tokens == 100
 
     @pytest.mark.asyncio
     async def test_run_async_task_fails(self):
@@ -2344,3 +2408,177 @@ class TestMessageBusBranchCoverage:
         # Get messages from empty queue
         messages = await message_bus.get_messages("agent", timeout=0.0)
         assert messages == []
+
+
+class TestSerializeOutput:
+    """Tests for _serialize_output helper."""
+
+    def test_str_passthrough(self):
+        from subagents_pydantic_ai.toolset import _serialize_output
+
+        assert _serialize_output("hello") == "hello"
+
+    def test_pydantic_model(self):
+        from pydantic import BaseModel
+
+        from subagents_pydantic_ai.toolset import _serialize_output
+
+        class MyModel(BaseModel):
+            name: str
+            value: int
+
+        result = _serialize_output(MyModel(name="test", value=42))
+        assert '"name":"test"' in result or '"name": "test"' in result
+        assert '"value":42' in result or '"value": 42' in result
+
+    def test_dataclass(self):
+        from subagents_pydantic_ai.toolset import _serialize_output
+
+        @dataclass
+        class MyData:
+            x: int
+            y: str
+
+        result = _serialize_output(MyData(x=1, y="hello"))
+        assert '"x": 1' in result or '"x":1' in result
+        assert '"y": "hello"' in result or '"y":"hello"' in result
+
+    def test_int(self):
+        from subagents_pydantic_ai.toolset import _serialize_output
+
+        assert _serialize_output(42) == "42"
+
+    def test_list(self):
+        from subagents_pydantic_ai.toolset import _serialize_output
+
+        assert _serialize_output([1, 2, 3]) == "[1, 2, 3]"
+
+
+class TestUsageTracking:
+    """Tests for subagent token usage tracking."""
+
+    @pytest.mark.anyio
+    async def test_check_task_shows_usage(self):
+        """check_task displays usage info for completed tasks."""
+        from subagents_pydantic_ai.types import TaskHandle, TaskStatus
+
+        toolset = create_subagent_toolset(default_model="test")
+        tm = toolset.task_manager  # type: ignore[attr-defined]
+        handle = TaskHandle(
+            task_id="test-usage",
+            subagent_name="worker",
+            description="test task",
+            status=TaskStatus.COMPLETED,
+            result="done",
+            usage=MockUsage(input_tokens=500, output_tokens=200),
+        )
+        tm.handles["test-usage"] = handle
+
+        check_tool = toolset.tools["check_task"]
+        ctx = MockRunContext(deps=MockDeps())
+        result = await check_tool.function(ctx, "test-usage")
+        assert "500" in result
+        assert "200" in result
+        assert "Usage:" in result
+
+    @pytest.mark.anyio
+    async def test_list_handles(self):
+        """TaskManager.list_handles returns all handles."""
+        from subagents_pydantic_ai.message_bus import TaskManager, InMemoryMessageBus
+        from subagents_pydantic_ai.types import TaskHandle, TaskStatus
+
+        bus = InMemoryMessageBus()
+        tm = TaskManager(message_bus=bus)
+        h1 = TaskHandle(task_id="t1", subagent_name="a", description="task1")
+        h2 = TaskHandle(task_id="t2", subagent_name="b", description="task2", status=TaskStatus.COMPLETED)
+        tm.handles["t1"] = h1
+        tm.handles["t2"] = h2
+
+        handles = tm.list_handles()
+        assert len(handles) == 2
+
+    @pytest.mark.anyio
+    async def test_get_total_usage(self):
+        """get_total_usage aggregates across completed tasks."""
+        from subagents_pydantic_ai.types import TaskHandle, TaskStatus
+
+        toolset = create_subagent_toolset(default_model="test")
+        tm = toolset.task_manager  # type: ignore[attr-defined]
+
+        h1 = TaskHandle(
+            task_id="t1", subagent_name="a", description="task1",
+            status=TaskStatus.COMPLETED, usage=MockUsage(input_tokens=100, output_tokens=50, requests=1),
+        )
+        h2 = TaskHandle(
+            task_id="t2", subagent_name="b", description="task2",
+            status=TaskStatus.COMPLETED, usage=MockUsage(input_tokens=200, output_tokens=100, requests=2),
+        )
+        h3 = TaskHandle(
+            task_id="t3", subagent_name="c", description="task3",
+            status=TaskStatus.FAILED, usage=None,
+        )
+        tm.handles["t1"] = h1
+        tm.handles["t2"] = h2
+        tm.handles["t3"] = h3
+
+        totals = toolset.get_total_usage()  # type: ignore[attr-defined]
+        assert totals["input_tokens"] == 300
+        assert totals["output_tokens"] == 150
+        assert totals["total_tokens"] == 450
+        assert totals["requests"] == 3
+
+    @pytest.mark.anyio
+    async def test_check_task_completed_no_usage(self):
+        """check_task works for completed tasks without usage data."""
+        from subagents_pydantic_ai.types import TaskHandle, TaskStatus
+
+        toolset = create_subagent_toolset(default_model="test")
+        tm = toolset.task_manager  # type: ignore[attr-defined]
+        handle = TaskHandle(
+            task_id="no-usage",
+            subagent_name="worker",
+            description="test",
+            status=TaskStatus.COMPLETED,
+            result="done",
+            usage=None,
+        )
+        tm.handles["no-usage"] = handle
+
+        check_tool = toolset.tools["check_task"]
+        ctx = MockRunContext(deps=MockDeps())
+        result = await check_tool.function(ctx, "no-usage")
+        assert "Result: done" in result
+        assert "Usage:" not in result
+
+    @pytest.mark.anyio
+    async def test_run_async_no_usage_attr(self):
+        """Async run handles results without usage() method."""
+        import asyncio
+
+        from subagents_pydantic_ai import InMemoryMessageBus, TaskManager
+
+        class BareResult:
+            def __init__(self, output: str):
+                self.output = output
+
+        mock_agent = MagicMock()
+        mock_agent.run = AsyncMock(return_value=BareResult("bare output"))
+
+        config = SubAgentConfig(
+            name="test", description="Test", instructions="Do test",
+        )
+        message_bus = InMemoryMessageBus()
+        task_manager = TaskManager(message_bus=message_bus)
+
+        await _run_async(
+            agent=mock_agent, config=config, description="test",
+            deps=MockDeps(), task_id="bare-1",
+            task_manager=task_manager, message_bus=message_bus,
+        )
+        await asyncio.sleep(0.1)
+
+        handle = task_manager.get_handle("bare-1")
+        assert handle is not None
+        assert handle.status == TaskStatus.COMPLETED
+        assert handle.result == "bare output"
+        assert handle.usage is None

--- a/tests/test_toolset.py
+++ b/tests/test_toolset.py
@@ -215,7 +215,6 @@ class TestCompileSubagent:
             assert call_kwargs.kwargs.get("retries") == 3
             assert call_kwargs.kwargs.get("result_retries") == 2
 
-
     def test_compile_with_prebuilt_agent(self):
         """Pre-built agent in config is used as-is, skipping default creation."""
         from subagents_pydantic_ai.toolset import _compile_subagent
@@ -2490,7 +2489,9 @@ class TestUsageTracking:
         bus = InMemoryMessageBus()
         tm = TaskManager(message_bus=bus)
         h1 = TaskHandle(task_id="t1", subagent_name="a", description="task1")
-        h2 = TaskHandle(task_id="t2", subagent_name="b", description="task2", status=TaskStatus.COMPLETED)
+        h2 = TaskHandle(
+            task_id="t2", subagent_name="b", description="task2", status=TaskStatus.COMPLETED
+        )
         tm.handles["t1"] = h1
         tm.handles["t2"] = h2
 
@@ -2506,16 +2507,25 @@ class TestUsageTracking:
         tm = toolset.task_manager  # type: ignore[attr-defined]
 
         h1 = TaskHandle(
-            task_id="t1", subagent_name="a", description="task1",
-            status=TaskStatus.COMPLETED, usage=MockUsage(input_tokens=100, output_tokens=50, requests=1),
+            task_id="t1",
+            subagent_name="a",
+            description="task1",
+            status=TaskStatus.COMPLETED,
+            usage=MockUsage(input_tokens=100, output_tokens=50, requests=1),
         )
         h2 = TaskHandle(
-            task_id="t2", subagent_name="b", description="task2",
-            status=TaskStatus.COMPLETED, usage=MockUsage(input_tokens=200, output_tokens=100, requests=2),
+            task_id="t2",
+            subagent_name="b",
+            description="task2",
+            status=TaskStatus.COMPLETED,
+            usage=MockUsage(input_tokens=200, output_tokens=100, requests=2),
         )
         h3 = TaskHandle(
-            task_id="t3", subagent_name="c", description="task3",
-            status=TaskStatus.FAILED, usage=None,
+            task_id="t3",
+            subagent_name="c",
+            description="task3",
+            status=TaskStatus.FAILED,
+            usage=None,
         )
         tm.handles["t1"] = h1
         tm.handles["t2"] = h2
@@ -2565,15 +2575,21 @@ class TestUsageTracking:
         mock_agent.run = AsyncMock(return_value=BareResult("bare output"))
 
         config = SubAgentConfig(
-            name="test", description="Test", instructions="Do test",
+            name="test",
+            description="Test",
+            instructions="Do test",
         )
         message_bus = InMemoryMessageBus()
         task_manager = TaskManager(message_bus=message_bus)
 
         await _run_async(
-            agent=mock_agent, config=config, description="test",
-            deps=MockDeps(), task_id="bare-1",
-            task_manager=task_manager, message_bus=message_bus,
+            agent=mock_agent,
+            config=config,
+            description="test",
+            deps=MockDeps(),
+            task_id="bare-1",
+            task_manager=task_manager,
+            message_bus=message_bus,
         )
         await asyncio.sleep(0.1)
 

--- a/tests/test_toolset.py
+++ b/tests/test_toolset.py
@@ -2483,7 +2483,7 @@ class TestUsageTracking:
     @pytest.mark.anyio
     async def test_list_handles(self):
         """TaskManager.list_handles returns all handles."""
-        from subagents_pydantic_ai.message_bus import TaskManager, InMemoryMessageBus
+        from subagents_pydantic_ai.message_bus import InMemoryMessageBus, TaskManager
         from subagents_pydantic_ai.types import TaskHandle, TaskStatus
 
         bus = InMemoryMessageBus()

--- a/uv.lock
+++ b/uv.lock
@@ -1296,7 +1296,7 @@ wheels = [
 
 [[package]]
 name = "subagents-pydantic-ai"
-version = "0.1.1"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## [0.2.0] - 2026-03-30

### Added

- **Custom agent support** via `agent` and `agent_factory` fields on `SubAgentConfig`:
  ```python
  SubAgentConfig(
      name="researcher",
      description="Deep research agent",
      instructions="...",
      agent=my_prebuilt_agent,  # pre-built agent, used as-is
  )
  # OR
  SubAgentConfig(
      name="researcher",
      description="Deep research agent",
      instructions="...",
      agent_factory=lambda cfg: create_deep_agent(  # factory creates agent from config
          model=cfg["model"], instructions=cfg["instructions"],
      ),
  )
  ```
  - Priority chain in `_compile_subagent()`: `agent` > `agent_factory` > default `Agent()`
  - Enables frameworks like pydantic-deep to create full-featured agents as subagents
- **`default_agent_factory`** parameter on `create_agent_factory_toolset()` — overrides default `Agent()` creation for dynamically spawned agents
- **`SubAgentSpec`** — Pydantic model for declarative subagent configuration via YAML/JSON:
  ```yaml
  subagents:
    - name: researcher
      description: Research assistant
      instructions: You research topics thoroughly.
      model: openai:gpt-4.1-mini
  ```
  - `to_config()` / `from_config()` round-trip conversion
  - JSON/YAML serialization via Pydantic's `model_dump()` / `model_validate()`

- **Token usage tracking** (issue [#45](https://github.com/vstorm-co/pydantic-deepagents/issues/45)):
  - `TaskHandle.usage` — stores `RunUsage` from each subagent run
  - `check_task` displays token usage (input/output) for completed tasks
  - `get_total_usage()` on toolset — aggregates usage across all task handles
  - `TaskManager.list_handles()` — returns all task handles
- **Structured output serialization** (issue [#46](https://github.com/vstorm-co/pydantic-deepagents/issues/46)):
  - `_serialize_output()` uses `model_dump_json()` for Pydantic models and `json.dumps(asdict())` for dataclasses instead of `str()`, preserving JSON structure for the parent agent

### Changed

- `_compile_subagent()` now checks for custom `agent`/`agent_factory` before creating default `Agent()`
- Subagent results are now proper JSON when `output_type` is a Pydantic model (previously flattened to Python repr string)
