### PR TITLE
Bump minimum  to  for compatibility with async  on toolsets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2026-03-31
+
+### Changed
+
+- Bump minimum `pydantic-ai-slim` to `>=1.74.0` for compatibility with async `get_instructions` on toolsets
+
 ## [0.2.0] - 2026-03-30
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "subagents-pydantic-ai"
-version = "0.2.0"
+version = "0.2.1"
 description = "Subagent toolset for pydantic-ai with dual-mode execution and dynamic agent creation"
 readme = "README.md"
 license = { file = "LICENSE" }
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Typing :: Typed",
 ]
-dependencies = ["pydantic>=2.0", "pydantic-ai-slim>=1.71.0"]
+dependencies = ["pydantic>=2.0", "pydantic-ai-slim>=1.74.0"]
 
 [project.urls]
 Homepage = "https://github.com/vstorm-co/subagents-pydantic-ai"


### PR DESCRIPTION
## [0.2.1] - 2026-03-31

### Changed

- Bump minimum `pydantic-ai-slim` to `>=1.74.0` for compatibility with async `get_instructions` on toolsets
