### PR TITLE
fix: agent communication #23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.2] - 2026-04-20
+
+### Added
+
+- **`ask_user` parameter on `create_subagent_toolset`** — `Callable[[str], Awaitable[str]]` invoked when a subagent calls `ask_parent` in sync mode. The callback is attached to the cloned subagent deps via `_subagent_state["ask_callback"]`, so `ask_parent` resolves through the same path as async mode. Required for sync-mode subagents with `can_ask_questions=True`. Exported as `AskUserCallback`.
+
+### Fixed
+
+- **`ask_parent` no longer silently fails in sync mode** — previously, when a subagent with `can_ask_questions=True` ran in sync mode without an `ask_user` method on deps, `ask_parent` returned `"Error: Cannot ask parent - no communication channel configured"` — which the subagent LLM tended to launder into an invented answer. The error message now points to the fix and a first-class `ask_user` hook exists. ([#23](https://github.com/vstorm-co/subagents-pydantic-ai/issues/23))
+
+### Changed
+
+- **Docs: corrected sync-mode question semantics** — `docs/advanced/questions.md` previously claimed the parent could respond via `answer_subagent` in sync mode. That is architecturally impossible because the parent's run loop is blocked inside the subagent's `task` call. The docs now describe the `ask_user` callback flow.
+
 ## [0.2.1] - 2026-03-31
 
 ### Changed

--- a/docs/advanced/questions.md
+++ b/docs/advanced/questions.md
@@ -72,20 +72,32 @@ If the limit is reached, the subagent should proceed with best judgment or retur
 
 ### Sync Mode
 
-In sync mode, questions block the parent immediately:
+In sync mode the parent's run loop is blocked inside the `task` call for the
+entire duration of the subagent, so the parent agent itself cannot answer the
+question. Questions are routed to an `ask_user` callback you provide to
+`create_subagent_toolset`:
 
 ```python
+from subagents_pydantic_ai import create_subagent_toolset
+
+async def ask_user(question: str) -> str:
+    # Wire this to your UI, CLI prompt, websocket, etc.
+    return input(f"Subagent asks: {question}\n> ")
+
+toolset = create_subagent_toolset(
+    subagents=subagents,
+    ask_user=ask_user,
+)
+
 # Parent calls:
 task(description="Analyze the report", subagent_type="analyst", mode="sync")
-
-# If subagent asks a question, the task pauses and parent sees:
-# "Subagent question: What time period should I focus on?"
-
-# Parent must answer to continue:
-answer_subagent(task_id="...", answer="Focus on Q4 2024")
-
-# Task continues and eventually returns result
+# When the subagent calls ask_parent, ask_user runs and its return value
+# is delivered back to the subagent as the answer.
 ```
+
+If sync mode is used without an `ask_user` callback, `ask_parent` returns a
+configuration error to the subagent. Either provide the callback, drop
+`can_ask_questions` on that subagent, or switch to async mode.
 
 ### Async Mode
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "subagents-pydantic-ai"
-version = "0.2.1"
+version = "0.2.2"
 description = "Subagent toolset for pydantic-ai with dual-mode execution and dynamic agent creation"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/subagents_pydantic_ai/__init__.py
+++ b/src/subagents_pydantic_ai/__init__.py
@@ -103,6 +103,9 @@ from subagents_pydantic_ai.types import (
     AgentMessage as AgentMessage,
 )
 from subagents_pydantic_ai.types import (
+    AskUserCallback as AskUserCallback,
+)
+from subagents_pydantic_ai.types import (
     CompiledSubAgent as CompiledSubAgent,
 )
 from subagents_pydantic_ai.types import (
@@ -150,6 +153,7 @@ __all__ = [
     "TaskCharacteristics",
     "ExecutionMode",
     "ToolsetFactory",
+    "AskUserCallback",
     "CompiledSubAgent",
     # Functions
     "decide_execution_mode",

--- a/src/subagents_pydantic_ai/toolset.py
+++ b/src/subagents_pydantic_ai/toolset.py
@@ -31,6 +31,7 @@ from subagents_pydantic_ai.prompts import (
 )
 from subagents_pydantic_ai.protocols import SubAgentDepsProtocol
 from subagents_pydantic_ai.types import (
+    AskUserCallback,
     CompiledSubAgent,
     ExecutionMode,
     SubAgentConfig,
@@ -187,12 +188,16 @@ def _create_ask_parent_toolset() -> FunctionToolset[Any]:
                         _task_manager.clear_answer_future(_task_id)
                         return "Error: Parent did not respond in time"
 
-        # Fallback: use deps.ask_user callback (sync mode / plan toolset)
+        # Fallback: use deps.ask_user callback (plan toolset compatibility)
         ask_user = getattr(ctx.deps, "ask_user", None)
         if ask_user:
             return str(await ask_user(question, []))
 
-        return "Error: Cannot ask parent - no communication channel configured"
+        return (
+            "Error: Cannot ask parent - no communication channel configured. "
+            "In sync mode, pass `ask_user=...` to create_subagent_toolset(), "
+            "or use mode='async' so the parent can respond via answer_subagent()."
+        )
 
     return toolset
 
@@ -206,6 +211,7 @@ def create_subagent_toolset(  # noqa: C901
     id: str | None = None,
     registry: Any | None = None,
     descriptions: dict[str, str] | None = None,
+    ask_user: AskUserCallback | None = None,
 ) -> FunctionToolset[Any]:
     """Create a toolset for delegating tasks to subagents.
 
@@ -233,6 +239,11 @@ def create_subagent_toolset(  # noqa: C901
             Keys are tool names (task, check_task, answer_subagent,
             list_active_tasks, wait_tasks, soft_cancel_task, hard_cancel_task).
             When provided, the custom description replaces the built-in default.
+        ask_user: Optional callback invoked when a subagent calls ``ask_parent``
+            in sync mode. Receives the question and must return the answer.
+            Required for sync-mode subagents with ``can_ask_questions=True``;
+            without it the subagent gets a configuration error. In async mode
+            the parent answers via ``answer_subagent`` instead.
 
     Returns:
         FunctionToolset configured with subagent management tools.
@@ -359,6 +370,7 @@ def create_subagent_toolset(  # noqa: C901
                 deps=subagent_deps,
                 task_id=task_id,
                 extra_toolsets=runtime_toolsets,
+                ask_user=ask_user,
             )
         else:
             return await _run_async(
@@ -574,6 +586,7 @@ async def _run_sync(
     deps: Any,
     task_id: str,
     extra_toolsets: list[Any] | None = None,
+    ask_user: AskUserCallback | None = None,
 ) -> str:
     """Run a subagent task synchronously (blocking).
 
@@ -584,12 +597,22 @@ async def _run_sync(
         deps: Dependencies for the subagent.
         task_id: Unique task identifier.
         extra_toolsets: Additional toolsets to pass to agent.run().
+        ask_user: Optional callback for `ask_parent` in sync mode. When
+            provided, it is attached to the cloned subagent deps via
+            ``_subagent_state["ask_callback"]`` so `ask_parent` resolves to
+            it. The parent agent cannot answer directly in sync mode because
+            its run loop is blocked here.
 
     Returns:
         The subagent's response.
     """
     can_ask = config.get("can_ask_questions", True)
     max_questions = config.get("max_questions")
+
+    if ask_user is not None:
+        # Reuse the async-mode `_subagent_state["ask_callback"]` path so
+        # `ask_parent` has a single resolution order across both modes.
+        deps._subagent_state = {"ask_callback": ask_user}
 
     prompt = get_task_instructions_prompt(
         description,

--- a/src/subagents_pydantic_ai/types.py
+++ b/src/subagents_pydantic_ai/types.py
@@ -7,7 +7,7 @@ including configuration types, message types, and task management types.
 from __future__ import annotations
 
 import uuid
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
@@ -127,6 +127,26 @@ Example:
             create_file_toolset(deps.backend),
             create_todo_toolset(),
         ]
+    ```
+"""
+
+
+AskUserCallback = Callable[[str], Awaitable[str]]
+"""Callback invoked when a subagent calls ``ask_parent`` in sync mode.
+
+Receives the subagent's question and must return the answer. Typically wired
+to a human-in-the-loop UI, a CLI ``input()`` prompt, or a pre-canned answerer
+for tests.
+
+Example:
+    ```python
+    async def ask_user(question: str) -> str:
+        return input(f"Subagent asks: {question}\n> ")
+
+    toolset = create_subagent_toolset(
+        subagents=subagents,
+        ask_user=ask_user,
+    )
     ```
 """
 

--- a/tests/test_toolset.py
+++ b/tests/test_toolset.py
@@ -718,6 +718,63 @@ class TestRunSync:
         assert "Error" in result
         assert "Something went wrong" in result
 
+    @pytest.mark.asyncio
+    async def test_run_sync_injects_ask_user_into_state(self):
+        """ask_user wires into _subagent_state so ask_parent can resolve it."""
+        captured: dict[str, Any] = {}
+
+        async def fake_run(prompt: str, **kwargs: Any) -> MockResult:
+            captured["deps"] = kwargs["deps"]
+            return MockResult("done")
+
+        mock_agent = MagicMock()
+        mock_agent.run = AsyncMock(side_effect=fake_run)
+
+        async def ask_user(question: str) -> str:
+            return f"answer: {question}"
+
+        deps = MockDeps()
+        config = SubAgentConfig(
+            name="test",
+            description="Test agent",
+            instructions="Do test",
+            can_ask_questions=True,
+        )
+
+        await _run_sync(
+            agent=mock_agent,
+            config=config,
+            description="do the thing",
+            deps=deps,
+            task_id="task-123",
+            ask_user=ask_user,
+        )
+
+        state = captured["deps"]._subagent_state
+        assert state["ask_callback"] is ask_user
+
+    @pytest.mark.asyncio
+    async def test_run_sync_no_ask_user_does_not_touch_deps(self):
+        """Without ask_user, _run_sync must not mutate deps state."""
+        mock_agent = MagicMock()
+        mock_agent.run = AsyncMock(return_value=MockResult("done"))
+        deps = MockDeps()
+        config = SubAgentConfig(
+            name="test",
+            description="Test agent",
+            instructions="Do test",
+        )
+
+        await _run_sync(
+            agent=mock_agent,
+            config=config,
+            description="do the thing",
+            deps=deps,
+            task_id="task-123",
+        )
+
+        assert not hasattr(deps, "_subagent_state")
+
 
 class TestRunAsync:
     """Tests for _run_async function."""
@@ -864,6 +921,41 @@ class TestToolsetIntegration:
             result = await task_tool.function(ctx, "do something", "helper", "sync")
 
             assert result == "Sync result"
+
+    @pytest.mark.asyncio
+    async def test_task_sync_forwards_ask_user(self):
+        """create_subagent_toolset threads ask_user into _run_sync calls."""
+        config = SubAgentConfig(
+            name="helper",
+            description="Helps with tasks",
+            instructions="Help with things",
+        )
+
+        async def ask_user(question: str) -> str:
+            return "answer"
+
+        with (
+            patch(
+                "subagents_pydantic_ai.toolset._compile_subagent",
+                return_value=_make_mock_compiled_subagent(config),
+            ),
+            patch(
+                "subagents_pydantic_ai.toolset._run_sync",
+                new_callable=AsyncMock,
+                return_value="ok",
+            ) as mock_run_sync,
+        ):
+            toolset = create_subagent_toolset(
+                subagents=[config],
+                include_general_purpose=False,
+                ask_user=ask_user,
+            )
+
+            task_tool = toolset.tools["task"]
+            ctx = MockRunContext(deps=MockDeps())
+            await task_tool.function(ctx, "do something", "helper", "sync")
+
+            assert mock_run_sync.call_args.kwargs["ask_user"] is ask_user
 
     @pytest.mark.asyncio
     async def test_task_async_execution(self):


### PR DESCRIPTION
## [0.2.2] - 2026-04-20

### Added

- **`ask_user` parameter on `create_subagent_toolset`** — `Callable[[str], Awaitable[str]]` invoked when a subagent calls `ask_parent` in sync mode. The callback is attached to the cloned subagent deps via `_subagent_state["ask_callback"]`, so `ask_parent` resolves through the same path as async mode. Required for sync-mode subagents with `can_ask_questions=True`. Exported as `AskUserCallback`.

### Fixed

- **`ask_parent` no longer silently fails in sync mode** — previously, when a subagent with `can_ask_questions=True` ran in sync mode without an `ask_user` method on deps, `ask_parent` returned `"Error: Cannot ask parent - no communication channel configured"` — which the subagent LLM tended to launder into an invented answer. The error message now points to the fix and a first-class `ask_user` hook exists. ([#23](https://github.com/vstorm-co/subagents-pydantic-ai/issues/23))

### Changed

- **Docs: corrected sync-mode question semantics** — `docs/advanced/questions.md` previously claimed the parent could respond via `answer_subagent` in sync mode. That is architecturally impossible because the parent's run loop is blocked inside the subagent's `task` call. The docs now describe the `ask_user` callback flow.
