### PR TITLE
feat: add early-return mode to wait_tasks for reactive orchestration

### DIFF
--- a/docs/concepts/toolset.md
+++ b/docs/concepts/toolset.md
@@ -140,6 +140,54 @@ list_active_tasks()
 
 **Returns:** List of task IDs, subagent names, and statuses.
 
+### wait_tasks
+
+Wait for one or more background tasks to finish.
+
+**Parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `task_ids` | `list[str]` | — | Task IDs to wait on |
+| `timeout` | `float` | `300.0` | Max seconds to wait |
+| `mode` | `"all" \| "any"` | `"all"` | When to return |
+
+A task is considered "finished" when it is completed, failed, or cancelled.
+
+#### `mode="all"` (default)
+
+Block until every task in `task_ids` is finished, or the timeout fires.
+Use when you need every result together before the next step (e.g. a
+final synthesis across all subagents).
+
+```python
+# Wait for both research subagents before writing the report
+result = wait_tasks(task_ids=["abc123", "def456"], mode="all")
+```
+
+#### `mode="any"` — reactive orchestration
+
+Return as soon as ONE task finishes. Use when the subagents are
+independent and you can act on each result as it arrives — this avoids
+stalling on the slowest task.
+
+```python
+# Dispatch 4 independent research tasks in parallel
+ids = [task(...) for _ in range(4)]
+
+remaining = list(ids)
+while remaining:
+    # Return as soon as one finishes — don't wait on the slowest
+    result = wait_tasks(task_ids=remaining, mode="any")
+    # ... react to the finished task (synthesize, dispatch follow-up, etc.)
+    remaining = [tid for tid in remaining if check_task(tid).is_running]
+```
+
+The output includes a header like
+`Task results (mode=any, 1/4 finished, 3 still running):` so the
+orchestrator can see which tasks are still in flight and decide whether
+to keep waiting or do other work first.
+
 ### soft_cancel_task
 
 Request cooperative cancellation.

--- a/src/subagents_pydantic_ai/prompts.py
+++ b/src/subagents_pydantic_ai/prompts.py
@@ -111,11 +111,35 @@ List all currently active background tasks with their status.
 Use this to see what async tasks are running and their current state."""
 
 WAIT_TASKS_DESCRIPTION = """\
-Wait for multiple background tasks to complete before continuing.
+Wait for one or more background tasks to finish before continuing.
 
-Blocks until ALL specified tasks are done (completed, failed, or cancelled), \
-or until the timeout is reached. Use after dispatching multiple async tasks \
-when you need all results before proceeding."""
+A task is "finished" when it is completed, failed, or cancelled.
+
+## Modes
+
+- **mode="all"** (default): block until every task in `task_ids` is \
+finished, or the timeout is reached. Use when you genuinely need every \
+result together before the next step (e.g. final synthesis across all \
+subagents).
+- **mode="any"**: return as soon as ONE task finishes. Use when the \
+subagents are independent and you can start acting on each finisher \
+immediately — this avoids stalling on the slowest task. After reacting to \
+the finisher, call `wait_tasks` again on the remaining ids (or use \
+`check_task`) to handle the rest.
+
+## When to prefer `mode="any"`
+
+When you've dispatched several async tasks in parallel and any individual \
+result is independently useful (e.g. routing decisions, progressive \
+synthesis, fan-out research). Reactive orchestration is almost always \
+faster than waiting on the slowest agent.
+
+## Output
+
+The result lists every requested task with its current state and a header \
+showing `mode`, `<finished>/<total> finished`, and how many are still \
+running. Unfinished tasks remain in the background — you can keep working \
+or wait on them again later."""
 
 SOFT_CANCEL_TASK_DESCRIPTION = """\
 Request cooperative cancellation of a background task. The subagent will be \

--- a/src/subagents_pydantic_ai/toolset.py
+++ b/src/subagents_pydantic_ai/toolset.py
@@ -491,6 +491,7 @@ def create_subagent_toolset(  # noqa: C901
         ctx: RunContext[SubAgentDepsProtocol],
         task_ids: list[str],
         timeout: float = 300.0,
+        mode: Literal["all", "any"] = "all",
     ) -> str:
         """Wait for multiple background tasks to complete.
 
@@ -498,6 +499,11 @@ def create_subagent_toolset(  # noqa: C901
             ctx: The run context.
             task_ids: List of task IDs to wait for.
             timeout: Maximum seconds to wait (default 300s / 5 minutes).
+            mode: ``"all"`` (default) waits for every task to finish.
+                ``"any"`` returns as soon as one task reaches a terminal
+                state (completed, failed, or cancelled), so the orchestrator
+                can react to the first finisher without stalling on the
+                slowest one.
         """
         # Collect asyncio.Task objects for the requested task_ids
         tasks_to_await: list[tuple[str, asyncio.Task[Any]]] = []
@@ -506,19 +512,28 @@ def create_subagent_toolset(  # noqa: C901
             if t is not None and not t.done():
                 tasks_to_await.append((tid, t))
 
-        # Wait for all with timeout
         if tasks_to_await:
             aws = [t for _, t in tasks_to_await]
-            try:
-                await asyncio.wait_for(
-                    asyncio.gather(*aws, return_exceptions=True),
-                    timeout=timeout,
+            if mode == "any":
+                # asyncio.wait with FIRST_COMPLETED naturally returns on the
+                # first finish (success or exception) and never raises on
+                # timeout — both pending and timed-out cases fall through to
+                # the result collection below.
+                await asyncio.wait(
+                    aws, timeout=timeout, return_when=asyncio.FIRST_COMPLETED
                 )
-            except asyncio.TimeoutError:
-                pass  # Report what we have so far
+            else:
+                try:
+                    await asyncio.wait_for(
+                        asyncio.gather(*aws, return_exceptions=True),
+                        timeout=timeout,
+                    )
+                except asyncio.TimeoutError:
+                    pass  # Report what we have so far
 
         # Collect results
         lines: list[str] = []
+        finished_count = 0
         for tid in task_ids:
             handle = task_manager.get_handle(tid)
             if handle is None:
@@ -526,14 +541,26 @@ def create_subagent_toolset(  # noqa: C901
                 continue
             status = handle.status
             if status == "completed":
+                finished_count += 1
                 result_preview = (handle.result or "")[:2000]
                 lines.append(f"- {tid} ({handle.subagent_name}): COMPLETED\n{result_preview}")
             elif status == "failed":
+                finished_count += 1
                 lines.append(f"- {tid} ({handle.subagent_name}): FAILED - {handle.error}")
+            elif status == "cancelled":
+                finished_count += 1
+                lines.append(f"- {tid} ({handle.subagent_name}): CANCELLED - {handle.error}")
             else:
                 lines.append(f"- {tid} ({handle.subagent_name}): {status}")
 
-        return "Task results:\n" + "\n\n".join(lines)
+        total = len(task_ids)
+        still_running = total - finished_count
+        header_parts = [f"mode={mode}", f"{finished_count}/{total} finished"]
+        if still_running > 0:
+            header_parts.append(f"{still_running} still running")
+        header = f"Task results ({', '.join(header_parts)}):"
+
+        return header + "\n" + "\n\n".join(lines)
 
     @toolset.tool(description=_descs.get("soft_cancel_task", SOFT_CANCEL_TASK_DESCRIPTION))
     async def soft_cancel_task(

--- a/tests/test_toolset.py
+++ b/tests/test_toolset.py
@@ -2036,10 +2036,205 @@ class TestToolsetFunctionsCoverage:
 
             # Wait with very short timeout — should hit TimeoutError branch
             result = await wait_tool.function(ctx, ["slow-1"], 0.05)
-            assert "Task results:" in result
+            assert "Task results" in result
+            assert "mode=all" in result
+            assert "0/1 finished" in result
+            assert "1 still running" in result
             assert "slow-1" in result
             # Task is still running, so status should be reported
             assert "running" in result
+
+    @pytest.mark.asyncio
+    async def test_wait_tasks_any_returns_on_first_completion(self):
+        """`mode="any"` returns as soon as one task finishes, even if others are slow."""
+        config = SubAgentConfig(
+            name="worker",
+            description="Worker",
+            instructions="Work",
+        )
+
+        mock_compiled = CompiledSubAgent(
+            name=config["name"],
+            description=config["description"],
+            config=config,
+            agent=MagicMock(),
+        )
+
+        with patch(
+            "subagents_pydantic_ai.toolset._compile_subagent",
+            return_value=mock_compiled,
+        ):
+            toolset = create_subagent_toolset(
+                subagents=[config],
+                include_general_purpose=False,
+            )
+
+            wait_tool = toolset.tools["wait_tasks"]
+            ctx = MockRunContext(deps=MockDeps())
+
+            from subagents_pydantic_ai.types import TaskHandle
+
+            tm = toolset.task_manager  # type: ignore[attr-defined]
+
+            async def fast_coro() -> None:
+                await asyncio.sleep(0.01)
+                fast_handle.result = "fast result"
+                fast_handle.status = TaskStatus.COMPLETED
+
+            async def slow_coro() -> None:
+                await asyncio.sleep(100)
+                slow_handle.status = TaskStatus.COMPLETED
+
+            fast_handle = TaskHandle(
+                task_id="fast-1",
+                subagent_name="worker",
+                description="fast task",
+                status="running",
+            )
+            slow_handle = TaskHandle(
+                task_id="slow-1",
+                subagent_name="worker",
+                description="slow task",
+                status="running",
+            )
+            tm.create_task("fast-1", fast_coro(), fast_handle)
+            tm.create_task("slow-1", slow_coro(), slow_handle)
+
+            # Generous timeout — should return as soon as fast finishes,
+            # not wait for the 100s slow_coro.
+            result = await wait_tool.function(
+                ctx, ["fast-1", "slow-1"], 5.0, "any"
+            )
+
+            assert "mode=any" in result
+            assert "1/2 finished" in result
+            assert "1 still running" in result
+            assert "fast-1" in result
+            assert "COMPLETED" in result
+            assert "fast result" in result
+            assert "slow-1" in result
+            # slow task should still be reported as running
+            assert "running" in result
+
+            # Cleanup: cancel the slow task so it doesn't leak between tests
+            slow_task = tm.tasks.get("slow-1")
+            if slow_task is not None and not slow_task.done():
+                slow_task.cancel()
+
+    @pytest.mark.asyncio
+    async def test_wait_tasks_any_returns_on_first_failure(self):
+        """`mode="any"` returns when the first task fails too, not just on success."""
+        config = SubAgentConfig(
+            name="worker",
+            description="Worker",
+            instructions="Work",
+        )
+
+        mock_compiled = CompiledSubAgent(
+            name=config["name"],
+            description=config["description"],
+            config=config,
+            agent=MagicMock(),
+        )
+
+        with patch(
+            "subagents_pydantic_ai.toolset._compile_subagent",
+            return_value=mock_compiled,
+        ):
+            toolset = create_subagent_toolset(
+                subagents=[config],
+                include_general_purpose=False,
+            )
+
+            wait_tool = toolset.tools["wait_tasks"]
+            ctx = MockRunContext(deps=MockDeps())
+
+            from subagents_pydantic_ai.types import TaskHandle
+
+            tm = toolset.task_manager  # type: ignore[attr-defined]
+
+            async def failing_coro() -> None:
+                await asyncio.sleep(0.01)
+                fail_handle.status = TaskStatus.FAILED
+                fail_handle.error = "boom"
+
+            async def slow_coro() -> None:
+                await asyncio.sleep(100)
+                slow_handle.status = TaskStatus.COMPLETED
+
+            fail_handle = TaskHandle(
+                task_id="fail-1",
+                subagent_name="worker",
+                description="failing task",
+                status="running",
+            )
+            slow_handle = TaskHandle(
+                task_id="slow-2",
+                subagent_name="worker",
+                description="slow task",
+                status="running",
+            )
+            tm.create_task("fail-1", failing_coro(), fail_handle)
+            tm.create_task("slow-2", slow_coro(), slow_handle)
+
+            result = await wait_tool.function(
+                ctx, ["fail-1", "slow-2"], 5.0, "any"
+            )
+
+            assert "mode=any" in result
+            assert "1/2 finished" in result
+            assert "FAILED" in result
+            assert "boom" in result
+
+            slow_task = tm.tasks.get("slow-2")
+            if slow_task is not None and not slow_task.done():
+                slow_task.cancel()
+
+    @pytest.mark.asyncio
+    async def test_wait_tasks_all_still_waits_for_everything(self):
+        """Regression: default `mode="all"` still waits for every task."""
+        config = SubAgentConfig(
+            name="worker",
+            description="Worker",
+            instructions="Work",
+        )
+
+        mock_agent = FakeAgent(result=MockResult("done"))
+
+        mock_compiled = CompiledSubAgent(
+            name=config["name"],
+            description=config["description"],
+            config=config,
+            agent=mock_agent,
+        )
+
+        with patch(
+            "subagents_pydantic_ai.toolset._compile_subagent",
+            return_value=mock_compiled,
+        ):
+            toolset = create_subagent_toolset(
+                subagents=[config],
+                include_general_purpose=False,
+            )
+
+            task_tool = toolset.tools["task"]
+            wait_tool = toolset.tools["wait_tasks"]
+
+            ctx = MockRunContext(deps=MockDeps())
+
+            r1 = await task_tool.function(ctx, "task one", "worker", "async")
+            tid1 = r1.split("Task ID: ")[1].split("\n")[0]
+            r2 = await task_tool.function(ctx, "task two", "worker", "async")
+            tid2 = r2.split("Task ID: ")[1].split("\n")[0]
+
+            # Default mode (no explicit arg) should be "all" and wait for both.
+            result = await wait_tool.function(ctx, [tid1, tid2], 5.0)
+
+            assert "mode=all" in result
+            assert "2/2 finished" in result
+            # No "still running" segment when everything is done
+            assert "still running" not in result
+            assert result.count("COMPLETED") == 2
 
     @pytest.mark.asyncio
     async def test_soft_cancel_task_success(self):


### PR DESCRIPTION
Closes #29

## Summary

`wait_tasks` previously always blocked until every task in `task_ids` finished, which meant orchestrators with several parallel subagents stalled on the slowest one even when an earlier finisher had a result ready to act on.

This PR adds a `mode: Literal["all", "any"] = "all"` parameter:

- `mode="all"` (default): unchanged — backward compatible.
- `mode="any"`: returns as soon as one task reaches a terminal state (completed, failed, or cancelled), implemented via `asyncio.wait(aws, timeout=timeout, return_when=asyncio.FIRST_COMPLETED)`.

The output now includes a header like `Task results (mode=any, 1/3 finished, 2 still running):` so the orchestrator can see exactly what finished vs. what's still in flight and decide whether to keep waiting or do other work. Cancelled tasks are now also explicitly labelled `CANCELLED` in the per-task output.

## Files changed

- `src/subagents_pydantic_ai/toolset.py` — new `mode` param + branched wait logic + new header format.
- `src/subagents_pydantic_ai/prompts.py` — rewrote `WAIT_TASKS_DESCRIPTION` to teach the model when to use each mode.
- `tests/test_toolset.py` — 3 new tests (any-mode first-completion, any-mode first-failure, all-mode regression) + updated `test_wait_tasks_timeout` header assertion.
- `docs/concepts/toolset.md` — new `wait_tasks` subsection covering both modes with a reactive `mode="any"` loop example.

## Test plan

- [x] All 291 existing tests still pass (`uv run pytest`).
- [x] New `mode="any"` test returns in ~10ms when a sibling task sleeps for 100s, proving early-return works.
- [x] New `mode="any"` failure test confirms early-return triggers on FAILED too.
- [x] Default `mode="all"` regression test confirms unchanged behavior.

## Non-goals (kept API minimal)

- No `min_completed` / first-N support.
- No new tool — same `wait_tasks`, new optional parameter, backward-compatible default.
