### PR TITLE
fix: wait_tasks no longer cascades cancellation to its workers + bump 0.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.4] - 2026-05-24
+
+### Added
+
+- **`wait_tasks(mode="any")` for reactive orchestration** ([#29](https://github.com/vstorm-co/subagents-pydantic-ai/issues/29), [#30](https://github.com/vstorm-co/subagents-pydantic-ai/pull/30) by [@Gby56](https://github.com/Gby56)) — new `mode: Literal["all", "any"] = "all"` parameter on `wait_tasks`. `mode="any"` returns as soon as the first task reaches a terminal state (completed/failed/cancelled), so an orchestrator can act on the first finisher instead of stalling on the slowest. Default `mode="all"` is backward-compatible. Output now includes a header (`Task results (mode=any, X/Y finished, Z still running):`) and explicitly labels `CANCELLED` tasks.
+
+### Fixed
+
+- **`wait_tasks` no longer cascades cancellation to its workers.** Previously the default (`mode="all"`) path used `asyncio.wait_for(asyncio.gather(...))`, both of which propagate cancellation to their constituent tasks. When pydantic-ai's `_call_tools` sibling-cancel hit the `wait_tasks` tool call (e.g. another tool raised during a parallel turn), or any outer cancel reached the orchestrator, the cascade silently killed every in-flight subagent — they surfaced as `TaskStatus.CANCELLED` with an empty `error` string even though the parent never requested it. Both modes now use `asyncio.wait(..., return_when=...)`, which does not cancel its awaitees on timeout or caller cancellation. Workers keep owning their own lifecycle. Diagnosed by [@Gby56](https://github.com/Gby56).
+
 ## [0.2.3] - 2026-05-17
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "subagents-pydantic-ai"
-version = "0.2.3"
+version = "0.2.4"
 description = "Subagent toolset for pydantic-ai with dual-mode execution and dynamic agent creation"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/subagents_pydantic_ai/toolset.py
+++ b/src/subagents_pydantic_ai/toolset.py
@@ -514,22 +514,15 @@ def create_subagent_toolset(  # noqa: C901
 
         if tasks_to_await:
             aws = [t for _, t in tasks_to_await]
-            if mode == "any":
-                # asyncio.wait with FIRST_COMPLETED naturally returns on the
-                # first finish (success or exception) and never raises on
-                # timeout — both pending and timed-out cases fall through to
-                # the result collection below.
-                await asyncio.wait(
-                    aws, timeout=timeout, return_when=asyncio.FIRST_COMPLETED
-                )
-            else:
-                try:
-                    await asyncio.wait_for(
-                        asyncio.gather(*aws, return_exceptions=True),
-                        timeout=timeout,
-                    )
-                except asyncio.TimeoutError:
-                    pass  # Report what we have so far
+            # Both modes route through ``asyncio.wait``. Unlike
+            # ``asyncio.wait_for(asyncio.gather(...))``, ``asyncio.wait`` does
+            # *not* cascade cancellation to its constituent tasks — neither on
+            # timeout nor when its caller is cancelled (e.g. pydantic-ai's
+            # ``_call_tools`` sibling-cancel hitting this tool call). Workers
+            # keep owning their lifecycle, which is what an orchestrator
+            # expects.
+            return_when = asyncio.FIRST_COMPLETED if mode == "any" else asyncio.ALL_COMPLETED
+            await asyncio.wait(aws, timeout=timeout, return_when=return_when)
 
         # Collect results
         lines: list[str] = []

--- a/tests/test_toolset.py
+++ b/tests/test_toolset.py
@@ -2102,9 +2102,7 @@ class TestToolsetFunctionsCoverage:
 
             # Generous timeout — should return as soon as fast finishes,
             # not wait for the 100s slow_coro.
-            result = await wait_tool.function(
-                ctx, ["fast-1", "slow-1"], 5.0, "any"
-            )
+            result = await wait_tool.function(ctx, ["fast-1", "slow-1"], 5.0, "any")
 
             assert "mode=any" in result
             assert "1/2 finished" in result
@@ -2177,9 +2175,7 @@ class TestToolsetFunctionsCoverage:
             tm.create_task("fail-1", failing_coro(), fail_handle)
             tm.create_task("slow-2", slow_coro(), slow_handle)
 
-            result = await wait_tool.function(
-                ctx, ["fail-1", "slow-2"], 5.0, "any"
-            )
+            result = await wait_tool.function(ctx, ["fail-1", "slow-2"], 5.0, "any")
 
             assert "mode=any" in result
             assert "1/2 finished" in result
@@ -2235,6 +2231,88 @@ class TestToolsetFunctionsCoverage:
             # No "still running" segment when everything is done
             assert "still running" not in result
             assert result.count("COMPLETED") == 2
+
+    @pytest.mark.asyncio
+    async def test_wait_tasks_does_not_cascade_cancel_to_workers(self):
+        """Cancelling wait_tasks must NOT cancel the workers it is waiting on.
+
+        Regression for the silent-CANCELLED bug: the previous
+        ``asyncio.wait_for(asyncio.gather(...))`` propagated cancellation
+        through ``wait_for`` → ``gather`` → child tasks, so a sibling-cancel
+        from pydantic-ai's ``_call_tools`` (or any other outer cancel) would
+        silently kill all in-flight subagents.
+        """
+        config = SubAgentConfig(name="worker", description="Worker", instructions="Work")
+        mock_agent = FakeAgent(result=MockResult("done"), delay=0.1)
+        mock_compiled = CompiledSubAgent(
+            name=config["name"],
+            description=config["description"],
+            config=config,
+            agent=mock_agent,
+        )
+
+        with patch(
+            "subagents_pydantic_ai.toolset._compile_subagent",
+            return_value=mock_compiled,
+        ):
+            toolset = create_subagent_toolset(subagents=[config], include_general_purpose=False)
+            task_tool = toolset.tools["task"]
+            wait_tool = toolset.tools["wait_tasks"]
+            ctx = MockRunContext(deps=MockDeps())
+
+            r = await task_tool.function(ctx, "slow work", "worker", "async")
+            tid = r.split("Task ID: ")[1].split("\n")[0]
+
+            worker_task = toolset.task_manager.tasks[tid]  # type: ignore[attr-defined]
+
+            # Schedule wait_tasks as its own task so we can cancel it from
+            # outside (mimicking pydantic-ai sibling-cancel of the tool call).
+            waiter = asyncio.create_task(wait_tool.function(ctx, [tid], 5.0))
+            await asyncio.sleep(0)  # let waiter start
+            waiter.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await waiter
+
+            # Worker MUST still be alive and own its own lifecycle.
+            assert not worker_task.done()
+
+            # And it must finish normally — proves no cascade kill happened.
+            await asyncio.wait_for(worker_task, timeout=2.0)
+            handle = toolset.task_manager.get_handle(tid)  # type: ignore[attr-defined]
+            assert handle is not None
+            assert handle.status == TaskStatus.COMPLETED
+
+    @pytest.mark.asyncio
+    async def test_wait_tasks_reports_cancelled_status(self):
+        """wait_tasks output labels CANCELLED tasks explicitly."""
+        config = SubAgentConfig(name="worker", description="Worker", instructions="Work")
+        mock_agent = FakeAgent(delay=10.0)
+        mock_compiled = CompiledSubAgent(
+            name=config["name"],
+            description=config["description"],
+            config=config,
+            agent=mock_agent,
+        )
+
+        with patch(
+            "subagents_pydantic_ai.toolset._compile_subagent",
+            return_value=mock_compiled,
+        ):
+            toolset = create_subagent_toolset(subagents=[config], include_general_purpose=False)
+            task_tool = toolset.tools["task"]
+            wait_tool = toolset.tools["wait_tasks"]
+            hard_cancel_tool = toolset.tools["hard_cancel_task"]
+            ctx = MockRunContext(deps=MockDeps())
+
+            r = await task_tool.function(ctx, "long work", "worker", "async")
+            tid = r.split("Task ID: ")[1].split("\n")[0]
+
+            await hard_cancel_tool.function(ctx, tid)
+            await asyncio.sleep(0.05)  # let cancellation settle
+
+            result = await wait_tool.function(ctx, [tid], 1.0)
+            assert "CANCELLED" in result
+            assert "1/1 finished" in result
 
     @pytest.mark.asyncio
     async def test_soft_cancel_task_success(self):


### PR DESCRIPTION
## Summary

Follow-up to #30 that closes the cancellation-cascade bug Gabriel ([@Gby56](https://github.com/Gby56)) diagnosed separately and bumps the release to **0.2.4** (0.2.3 is already on PyPI).

### The bug

`wait_tasks`'s default `mode="all"` used `asyncio.wait_for(asyncio.gather(*aws, return_exceptions=True), timeout=timeout)`. Both layers propagate cancellation to their awaitees:

- `asyncio.gather(...)` cancels its child tasks when the gather future is cancelled (`return_exceptions=True` only changes how completed-with-error results are reported, not cancellation propagation).
- `asyncio.wait_for(...)` cancels its inner awaitable on timeout *and* when its caller cancels it.

So when pydantic-ai's `_call_tools` sibling-cancelled the `wait_tasks` tool call (or any outer cancel hit the orchestrator), the cascade silently killed every in-flight subagent — they surfaced as `TaskStatus.CANCELLED` with an empty `error` string even though the parent LLM never requested cancellation.

### The fix

Both modes now route through `asyncio.wait(aws, timeout=timeout, return_when=...)` with `FIRST_COMPLETED` for `mode="any"` and `ALL_COMPLETED` for `mode="all"`. `asyncio.wait` does **not** cancel its awaitees on timeout or caller cancellation — workers keep owning their own lifecycle. Also removes the `try/except TimeoutError` since `asyncio.wait` doesn't raise on timeout.

#30 already used `asyncio.wait` for `mode="any"` (incidentally getting the safe behaviour), so this just extends the same primitive to the default path and removes the duplication.

### Test plan

- [x] **`test_wait_tasks_does_not_cascade_cancel_to_workers`** — the critical regression: schedules `wait_tasks`, cancels it externally, asserts the worker task is still alive and eventually completes normally (`TaskStatus.COMPLETED`).
- [x] **`test_wait_tasks_reports_cancelled_status`** — also covers the `elif status == "cancelled"` output branch added in #30 (it was left untested there; that was the 99.73% coverage gap on main).
- [x] Existing `wait_tasks` tests still pass (any-mode early-return, all-mode regression, timeout, not-found, failure, completion).
- [x] 293 passed, **100% coverage**, ruff + pyright clean.

### CHANGELOG

New `[0.2.4]` section: **Added** `wait_tasks(mode="any")` (#30 by @Gby56), **Fixed** the cancellation cascade described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)