### PR TITLE
chore: release 0.2.5 — consolidated CI action bumps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,10 @@ jobs:
       matrix:
         python-version: ["3.10", "3.13"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v8.1.0
 
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
@@ -40,10 +40,10 @@ jobs:
     name: Type Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v8.1.0
 
       - name: Set up Python
         run: uv python install 3.12
@@ -65,10 +65,10 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v8.1.0
 
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,12 +13,12 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.14"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,8 +11,8 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v4
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v8.1.0
       - run: uv sync --all-extras
       - run: uv run python -m build
       - uses: pypa/gh-action-pypi-publish@release/v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.5] - 2026-05-24
+
+### Infrastructure
+
+Pure CI / dependency-bot housekeeping — no source-code changes, no behaviour change since 0.2.4. Consolidates the two open Renovate auto-PRs plus the preemptive `setup-uv` / `setup-python` major bumps (same set Renovate has been gradually surfacing across the sibling repos) into a single release so downstream consumers see one bump instead of four.
+
+- **CI: bump `actions/checkout` to `v6`** across `ci.yml` (×3), `docs.yml`, `publish.yml` ([#34](https://github.com/vstorm-co/subagents-pydantic-ai/pull/34), Renovate auto-PR — folded in here).
+- **CI: bump `docs.yml` Python to `3.14`** ([#33](https://github.com/vstorm-co/subagents-pydantic-ai/pull/33), Renovate auto-PR — folded in here).
+- **CI: bump `astral-sh/setup-uv` to `v8.1.0`** across `ci.yml` (×3) and `publish.yml`. Pinned to the specific patch because `astral-sh/setup-uv` does not maintain a rolling `v8` tag (only `v8.0.0` / `v8.1.0`; `v7` and earlier do have rolling majors).
+- **CI: bump `actions/setup-python` to `v6`** in `docs.yml` — `v6` has a rolling tag so plain `@v6` is used.
+
+The `ci.yml` test matrix is unchanged.
+
 ## [0.2.4] - 2026-05-24
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "subagents-pydantic-ai"
-version = "0.2.4"
+version = "0.2.5"
 description = "Subagent toolset for pydantic-ai with dual-mode execution and dynamic agent creation"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
Folds **#33** + **#34** plus preemptive `setup-uv` / `setup-python` major bumps (same set Renovate has been gradually surfacing across the sibling repos) into **one** release so downstream consumers see a single bump instead of four.

## Bumps

| Action | From | To | Files | Source |
|---|---|---|---|---|
| `actions/checkout` | `v4` | `v6` | `ci.yml` (×3), `docs.yml`, `publish.yml` | #34 |
| Python in `docs.yml` | `3.12` | `3.14` | `docs.yml` | #33 |
| `astral-sh/setup-uv` | `v4` | `v8.1.0` | `ci.yml` (×3), `publish.yml` | preemptive |
| `actions/setup-python` | `v5` | `v6` | `docs.yml` | preemptive |

`setup-uv` is pinned to the specific patch — the repo does **not** maintain a rolling `v8` tag (only `v8.0.0` / `v8.1.0` exist; `v7` and earlier do have rolling majors). Same lesson learned in summarization-pydantic-ai#23, pydantic-ai-backend#43, pydantic-ai-todo#25.

The `ci.yml` test matrix is unchanged. Pure CI — no library code touched.

## Closing

Closes #33
Closes #34

## Gate

- `make test` — passed, 100% coverage
- `ruff format --check` + `ruff check` — clean
- `pyright` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)