### PR TITLE
feat: parent->child steering via send_message_to_subagent (#28)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-06-04
+
+### Added
+
+- **Unprompted parent -> child steering via `send_message_to_subagent`** ([#28](https://github.com/vstorm-co/subagents-pydantic-ai/issues/28)). A parent agent can now steer a running **async** subagent mid-flight without cancelling it — e.g. "narrow the search to `packages/sparta/`, it isn't in `core/`" — so the subagent adapts on its next step while keeping all partial progress, instead of the lossy cancel-and-respawn pattern. The new `send_message_to_subagent(task_id, message)` tool enqueues a `TASK_UPDATE` on the message bus for `subagent-{task_id}`; the run loop drains it at the next model-request boundary (`_drive_run` gained an `inject_messages` hook alongside the existing `cancel_check`) and folds each message into that request as an extra `UserPromptPart`. Injecting only at model-request boundaries guarantees a steering part is never spliced into a tool-call/tool-return pair. This is distinct from `answer_subagent`, which only replies to a question the subagent already asked via `ask_parent`. Sending to a finished or unknown task returns a clear error. Honoured on the retry-driven run path (`max_retries > 0`, the default); the legacy `agent.run()` fast path (`max_retries == 0`) does not expose node boundaries, so steering messages stay queued there.
+
 ## [0.2.6] - 2026-06-01
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.3.0] - 2026-06-04
+## [0.2.7] - 2026-06-04
 
 ### Added
 

--- a/docs/concepts/toolset.md
+++ b/docs/concepts/toolset.md
@@ -129,6 +129,40 @@ Answer a question from a blocked subagent.
 answer_subagent(task_id="abc123", answer="Use PostgreSQL for this project")
 ```
 
+### send_message_to_subagent
+
+Steer a running **async** subagent mid-flight, without cancelling it. Use this
+when you learn something new while a long task is in progress and want to
+redirect or narrow it — the subagent keeps all its partial progress.
+
+```python
+# The agent calls:
+send_message_to_subagent(
+    task_id="abc123",
+    message="narrow the search to packages/sparta/ — it isn't in core/",
+)
+```
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `task_id` | `str` | Task ID of the running async subagent |
+| `message` | `str` | Steering instruction to deliver |
+
+The message is folded into the subagent's **next model request** as an extra
+user instruction, so it adapts on its next step. This is unprompted parent ->
+child steering, distinct from `answer_subagent` (which only replies to a
+question the subagent already asked via `ask_parent`). It applies to async
+tasks that are still running; messages to a finished or unknown task return an
+error.
+
+!!! note
+    Steering is delivered at model-request boundaries on the retry-driven run
+    path, which is the default (`max_retries > 0`). If you explicitly set
+    `max_retries=0` on a subagent, it runs via the legacy single-shot path and
+    steering messages stay queued instead of being applied.
+
 ### list_active_tasks
 
 List all running background tasks.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "subagents-pydantic-ai"
-version = "0.2.6"
+version = "0.3.0"
 description = "Subagent toolset for pydantic-ai with dual-mode execution and dynamic agent creation"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "subagents-pydantic-ai"
-version = "0.3.0"
+version = "0.2.7"
 description = "Subagent toolset for pydantic-ai with dual-mode execution and dynamic agent creation"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/subagents_pydantic_ai/prompts.py
+++ b/src/subagents_pydantic_ai/prompts.py
@@ -141,6 +141,20 @@ showing `mode`, `<finished>/<total> finished`, and how many are still \
 running. Unfinished tasks remain in the background — you can keep working \
 or wait on them again later."""
 
+SEND_MESSAGE_TO_SUBAGENT_DESCRIPTION = """\
+Send a steering message to a running background (async) subagent without \
+cancelling it.
+
+Use this to redirect or refine a long-running task mid-flight when you learn \
+something new — e.g. "narrow the search to packages/sparta/, it isn't in \
+core/" or "stop after the first 5 matches". The subagent receives your message \
+as an extra user instruction on its next step and adapts, keeping all partial \
+progress (unlike cancel-and-respawn).
+
+This is unprompted parent -> child steering — distinct from `answer_subagent`, \
+which only replies to a question the subagent already asked. It applies to \
+async tasks only; the target must still be running."""
+
 SOFT_CANCEL_TASK_DESCRIPTION = """\
 Request cooperative cancellation of a background task. The subagent will be \
 notified and can clean up before stopping. Use this for graceful cancellation."""

--- a/src/subagents_pydantic_ai/retry.py
+++ b/src/subagents_pydantic_ai/retry.py
@@ -221,12 +221,9 @@ async def _drive_run(
         # A capability's wrap_run short-circuit can publish the result early.
         if run.result is not None:
             break
-        # Unprompted parent -> child steering: fold any pending messages into
-        # the upcoming model request so the subagent reads them on its next
-        # turn. Only at a model-request boundary, so a UserPromptPart is never
-        # inserted between a tool call and its return. An isinstance check
-        # (rather than agent.is_model_request_node) keeps this independent of
-        # the agent object — it inspects the graph node directly.
+        # Fold pending parent -> child steering into the upcoming request. Only
+        # at a model-request boundary, so a UserPromptPart is never spliced
+        # between a tool call and its return.
         if inject_messages is not None and isinstance(node, _agent_graph.ModelRequestNode):
             steering = await inject_messages()
             if steering:

--- a/src/subagents_pydantic_ai/retry.py
+++ b/src/subagents_pydantic_ai/retry.py
@@ -35,6 +35,7 @@ from typing import Any
 
 from pydantic_ai import _agent_graph
 from pydantic_ai.exceptions import ModelAPIError, ModelHTTPError
+from pydantic_ai.messages import UserPromptPart
 from pydantic_graph import End
 
 from subagents_pydantic_ai.types import SubAgentConfig
@@ -163,6 +164,7 @@ async def _drive_run(
     run: Any,
     event_stream_handler: Any,
     cancel_check: Callable[[], bool] | None = None,
+    inject_messages: Callable[[], Awaitable[list[str]]] | None = None,
 ) -> None:
     """Advance *run* to completion, firing the same hooks as :meth:`Agent.run`.
 
@@ -181,6 +183,14 @@ async def _drive_run(
     preserved on the accumulated history. Because `CancelledError` is a
     `BaseException` it is not caught by the retry loop and propagates to the
     caller's cancellation handling unchanged.
+
+    `inject_messages` enables unprompted parent -> child steering: it is
+    awaited just before each model-request node and returns any pending
+    steering messages, which are appended as :class:`UserPromptPart`s to that
+    request. The subagent therefore sees them as extra user instructions on
+    its very next model turn, keeping all partial progress. Injecting only at
+    model-request boundaries (not before tool execution) guarantees the parts
+    are never spliced into a tool-call/tool-return pair.
     """
 
     _stream_step: Any = None
@@ -211,6 +221,19 @@ async def _drive_run(
         # A capability's wrap_run short-circuit can publish the result early.
         if run.result is not None:
             break
+        # Unprompted parent -> child steering: fold any pending messages into
+        # the upcoming model request so the subagent reads them on its next
+        # turn. Only at a model-request boundary, so a UserPromptPart is never
+        # inserted between a tool call and its return. An isinstance check
+        # (rather than agent.is_model_request_node) keeps this independent of
+        # the agent object — it inspects the graph node directly.
+        if inject_messages is not None and isinstance(node, _agent_graph.ModelRequestNode):
+            steering = await inject_messages()
+            if steering:
+                node.request.parts = [
+                    *node.request.parts,
+                    *(UserPromptPart(content=text) for text in steering),
+                ]
         if _stream_step is not None:
             node = await run._run_node_with_hooks(node, _stream_step)
         else:
@@ -227,6 +250,7 @@ async def run_with_retry(
     sleep: Callable[[float], Awaitable[None]] = asyncio.sleep,
     event_stream_handler: Any | None = None,
     cancel_check: Callable[[], bool] | None = None,
+    inject_messages: Callable[[], Awaitable[list[str]]] | None = None,
 ) -> Any:
     """Run *agent* with auto-retry on transient errors.
 
@@ -261,6 +285,12 @@ async def run_with_retry(
             (`max_retries > 0`); the legacy `agent.run()` fast path
             (`max_retries <= 0`) does not expose node boundaries, so soft
             cancel is best-effort there.
+        inject_messages: Optional async callable awaited before each model
+            request; its returned strings are appended to that request as
+            user instructions (unprompted parent -> child steering). Like
+            `cancel_check`, only honoured on the retry-driven path
+            (`max_retries > 0`); the legacy `agent.run()` fast path does not
+            expose node boundaries, so steering messages stay queued there.
 
     Returns:
         The `AgentRunResult` of the first successful attempt.
@@ -289,7 +319,7 @@ async def run_with_retry(
         run = None
         try:
             async with agent.iter(prompt, message_history=message_history, **run_kwargs) as run:
-                await _drive_run(agent, run, handler, cancel_check)
+                await _drive_run(agent, run, handler, cancel_check, inject_messages)
             return run.result
         except Exception as exc:
             if attempt >= retry.max_retries or not retry.should_retry(exc):

--- a/src/subagents_pydantic_ai/toolset.py
+++ b/src/subagents_pydantic_ai/toolset.py
@@ -23,6 +23,7 @@ from subagents_pydantic_ai.prompts import (
     DEFAULT_GENERAL_PURPOSE_DESCRIPTION,
     HARD_CANCEL_TASK_DESCRIPTION,
     LIST_ACTIVE_TASKS_DESCRIPTION,
+    SEND_MESSAGE_TO_SUBAGENT_DESCRIPTION,
     SOFT_CANCEL_TASK_DESCRIPTION,
     SUBAGENT_SYSTEM_PROMPT,
     TASK_TOOL_DESCRIPTION,
@@ -32,9 +33,11 @@ from subagents_pydantic_ai.prompts import (
 from subagents_pydantic_ai.protocols import SubAgentDepsProtocol
 from subagents_pydantic_ai.retry import RetryConfig, run_with_retry
 from subagents_pydantic_ai.types import (
+    AgentMessage,
     AskUserCallback,
     CompiledSubAgent,
     ExecutionMode,
+    MessageType,
     SubAgentConfig,
     TaskCharacteristics,
     TaskHandle,
@@ -61,6 +64,34 @@ def _serialize_output(output: Any) -> str:
 
         return json.dumps(dataclasses.asdict(output), default=str)
     return str(output)
+
+
+async def _drain_steering_messages(message_bus: InMemoryMessageBus, agent_id: str) -> list[str]:
+    """Drain pending parent -> child steering messages for a running subagent.
+
+    Pulls everything currently queued for ``agent_id`` and returns the text of
+    each ``TASK_UPDATE`` (the message type emitted by ``send_message_to_subagent``).
+    Other message types on the queue (e.g. an unused ``CANCEL_REQUEST`` — soft
+    cancel runs off the cancel event, not the bus) are ignored, as are empty
+    payloads.
+
+    Args:
+        message_bus: The bus the running subagent is registered on.
+        agent_id: The subagent's bus id (``subagent-{task_id}``).
+
+    Returns:
+        Steering instructions in delivery order (may be empty).
+    """
+    pending = await message_bus.get_messages(agent_id, timeout=0)
+    steering: list[str] = []
+    for msg in pending:
+        if msg.type != MessageType.TASK_UPDATE:
+            continue
+        payload = msg.payload
+        text = payload.get("message") if isinstance(payload, dict) else payload
+        if text:
+            steering.append(str(text))
+    return steering
 
 
 def _create_general_purpose_config() -> SubAgentConfig:
@@ -468,6 +499,50 @@ def create_subagent_toolset(  # noqa: C901
 
         return "Error: Could not send answer - subagent is no longer waiting"
 
+    @toolset.tool(
+        description=_descs.get("send_message_to_subagent", SEND_MESSAGE_TO_SUBAGENT_DESCRIPTION)
+    )
+    async def send_message_to_subagent(
+        ctx: RunContext[SubAgentDepsProtocol],
+        task_id: str,
+        message: str,
+    ) -> str:
+        """Steer a running async subagent with an unprompted message.
+
+        The message is queued for the subagent and folded into its next model
+        request as an extra user instruction, so it adapts without losing
+        partial progress. Works only while the task is still running.
+
+        Args:
+            ctx: The run context.
+            task_id: The task ID of the running async subagent.
+            message: The steering instruction to deliver.
+        """
+        agent_id = f"subagent-{task_id}"
+        if not message_bus.is_registered(agent_id):
+            handle = task_manager.get_handle(task_id)
+            if handle is None:
+                return f"Error: Task '{task_id}' not found"
+            return (
+                f"Error: Task '{task_id}' is not accepting messages "
+                f"(status: {handle.status}). Steering only works for running "
+                "async tasks."
+            )
+
+        await message_bus.send(
+            AgentMessage(
+                type=MessageType.TASK_UPDATE,
+                sender="parent",
+                receiver=agent_id,
+                payload={"message": message},
+                task_id=task_id,
+            )
+        )
+        return (
+            f"Message delivered to task '{task_id}'; "
+            "it will be applied on the subagent's next step."
+        )
+
     @toolset.tool(description=_descs.get("list_active_tasks", LIST_ACTIVE_TASKS_DESCRIPTION))
     async def list_active_tasks(
         ctx: RunContext[SubAgentDepsProtocol],
@@ -759,6 +834,9 @@ async def _run_async(
             cancel_event = task_manager.get_cancel_event(task_id)
             return cancel_event is not None and cancel_event.is_set()
 
+        async def _pending_steering() -> list[str]:
+            return await _drain_steering_messages(message_bus, agent_id)
+
         try:
             result = await run_with_retry(
                 agent,
@@ -767,6 +845,7 @@ async def _run_async(
                 retry=RetryConfig.from_config(config),
                 on_retry=_on_retry,
                 cancel_check=_cancel_requested,
+                inject_messages=_pending_steering,
             )
             handle.result = _serialize_output(result.output)
             handle.error = None

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -785,3 +785,144 @@ async def test_streaming_drive_breaks_on_wrap_run_short_circuit() -> None:
 
     assert result is short_circuit
     assert events == []
+
+
+# --------------------------------------------------------------------------- #
+# run_with_retry - unprompted parent -> child steering (inject_messages)
+# --------------------------------------------------------------------------- #
+
+
+def _make_tool_then_text_model(captured: dict[str, Any]) -> Any:
+    """FunctionModel: call tool `dig` on the first turn, then emit final text.
+
+    Records, on the second model request, every `UserPromptPart` content the
+    model can see — so a test can assert injected steering arrived.
+    """
+    from pydantic_ai.messages import (
+        ModelRequest,
+        ModelResponse,
+        TextPart,
+        ToolCallPart,
+        UserPromptPart,
+    )
+    from pydantic_ai.models.function import AgentInfo, FunctionModel
+
+    def model_fn(messages: list[Any], info: AgentInfo) -> Any:
+        n_responses = sum(1 for m in messages if isinstance(m, ModelResponse))
+        if n_responses == 0:
+            return ModelResponse(parts=[ToolCallPart(tool_name="dig", args={})])
+        captured["texts"] = [
+            p.content
+            for m in messages
+            if isinstance(m, ModelRequest)
+            for p in m.parts
+            if isinstance(p, UserPromptPart)
+        ]
+        return ModelResponse(parts=[TextPart(content="done")])
+
+    return FunctionModel(model_fn)
+
+
+async def test_inject_messages_folded_into_next_model_request() -> None:
+    """Pending steering is appended to the subagent's next model request."""
+    captured: dict[str, Any] = {}
+    agent = Agent(_make_tool_then_text_model(captured))
+
+    @agent.tool_plain
+    def dig() -> str:
+        return "dug"
+
+    calls = {"n": 0}
+
+    async def inject() -> list[str]:
+        calls["n"] += 1
+        # Nothing before the first request; steering arrives before the second.
+        return ["narrow to packages/sparta/"] if calls["n"] == 2 else []
+
+    result = await run_with_retry(
+        agent,
+        "search the repo",
+        run_kwargs={},
+        retry=RetryConfig(max_retries=3, jitter=False),
+        inject_messages=inject,
+    )
+
+    assert result.output == "done"
+    assert "narrow to packages/sparta/" in captured["texts"]
+    # Polled once per model-request node (before request 1 and request 2),
+    # never around the intervening tool-call node.
+    assert calls["n"] == 2
+
+
+async def test_run_async_steering_message_reaches_subagent() -> None:
+    """End-to-end: a steering message sent mid-run is seen on the next request."""
+    from pydantic_ai.messages import (
+        ModelRequest,
+        ModelResponse,
+        TextPart,
+        ToolCallPart,
+        UserPromptPart,
+    )
+    from pydantic_ai.models.function import AgentInfo, FunctionModel
+
+    from subagents_pydantic_ai.types import AgentMessage, MessageType
+
+    captured: dict[str, Any] = {}
+    parked = asyncio.Event()
+    release = asyncio.Event()
+
+    def model_fn(messages: list[Any], info: AgentInfo) -> Any:
+        n_responses = sum(1 for m in messages if isinstance(m, ModelResponse))
+        if n_responses == 0:
+            return ModelResponse(parts=[ToolCallPart(tool_name="hold", args={})])
+        captured["texts"] = [
+            p.content
+            for m in messages
+            if isinstance(m, ModelRequest)
+            for p in m.parts
+            if isinstance(p, UserPromptPart)
+        ]
+        return ModelResponse(parts=[TextPart(content="done")])
+
+    agent = Agent(FunctionModel(model_fn))
+
+    @agent.tool_plain
+    async def hold() -> str:
+        # Park the subagent between request 1 and request 2 so the test can
+        # deliver a steering message at a deterministic point.
+        parked.set()
+        await release.wait()
+        return "held"
+
+    config = SubAgentConfig(name="t", description="d", instructions="i")
+    bus = InMemoryMessageBus()
+    tm = TaskManager(message_bus=bus)
+
+    await _run_async(
+        agent=agent,
+        config=config,
+        description="go",
+        deps=FakeDeps(),
+        task_id="steer-1",
+        task_manager=tm,
+        message_bus=bus,
+    )
+    bg_task = tm.tasks["steer-1"]
+
+    await asyncio.wait_for(parked.wait(), timeout=2.0)
+    await bus.send(
+        AgentMessage(
+            type=MessageType.TASK_UPDATE,
+            sender="parent",
+            receiver="subagent-steer-1",
+            payload={"message": "STEER NOW"},
+            task_id="steer-1",
+        )
+    )
+    release.set()
+    await asyncio.wait_for(bg_task, timeout=2.0)
+
+    assert "STEER NOW" in captured["texts"]
+    handle = tm.get_handle("steer-1")
+    assert handle is not None
+    assert handle.status == TaskStatus.COMPLETED

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -15,6 +15,14 @@ import pytest
 from pydantic_ai import Agent
 from pydantic_ai.capabilities import AbstractCapability, ProcessEventStream
 from pydantic_ai.exceptions import ModelAPIError, ModelHTTPError
+from pydantic_ai.messages import (
+    ModelRequest,
+    ModelResponse,
+    TextPart,
+    ToolCallPart,
+    UserPromptPart,
+)
+from pydantic_ai.models.function import AgentInfo, FunctionModel
 from pydantic_ai.models.test import TestModel
 from pydantic_ai.run import AgentRunResult
 from pydantic_graph import End
@@ -29,7 +37,7 @@ from subagents_pydantic_ai import (
     run_with_retry,
 )
 from subagents_pydantic_ai.toolset import _run_async
-from subagents_pydantic_ai.types import SubAgentConfig
+from subagents_pydantic_ai.types import AgentMessage, MessageType, SubAgentConfig
 
 pytestmark = pytest.mark.asyncio
 
@@ -787,25 +795,12 @@ async def test_streaming_drive_breaks_on_wrap_run_short_circuit() -> None:
     assert events == []
 
 
-# --------------------------------------------------------------------------- #
-# run_with_retry - unprompted parent -> child steering (inject_messages)
-# --------------------------------------------------------------------------- #
-
-
 def _make_tool_then_text_model(captured: dict[str, Any]) -> Any:
     """FunctionModel: call tool `dig` on the first turn, then emit final text.
 
     Records, on the second model request, every `UserPromptPart` content the
     model can see — so a test can assert injected steering arrived.
     """
-    from pydantic_ai.messages import (
-        ModelRequest,
-        ModelResponse,
-        TextPart,
-        ToolCallPart,
-        UserPromptPart,
-    )
-    from pydantic_ai.models.function import AgentInfo, FunctionModel
 
     def model_fn(messages: list[Any], info: AgentInfo) -> Any:
         n_responses = sum(1 for m in messages if isinstance(m, ModelResponse))
@@ -856,17 +851,6 @@ async def test_inject_messages_folded_into_next_model_request() -> None:
 
 async def test_run_async_steering_message_reaches_subagent() -> None:
     """End-to-end: a steering message sent mid-run is seen on the next request."""
-    from pydantic_ai.messages import (
-        ModelRequest,
-        ModelResponse,
-        TextPart,
-        ToolCallPart,
-        UserPromptPart,
-    )
-    from pydantic_ai.models.function import AgentInfo, FunctionModel
-
-    from subagents_pydantic_ai.types import AgentMessage, MessageType
-
     captured: dict[str, Any] = {}
     parked = asyncio.Event()
     release = asyncio.Event()

--- a/tests/test_toolset.py
+++ b/tests/test_toolset.py
@@ -3083,7 +3083,7 @@ class TestDrainSteeringMessages:
             )
 
         assert await _drain_steering_messages(bus, "subagent-x") == ["first", "second"]
-        # Queue is drained.
+        # A second drain returns nothing — the queue was consumed.
         assert await _drain_steering_messages(bus, "subagent-x") == []
 
     @pytest.mark.asyncio

--- a/tests/test_toolset.py
+++ b/tests/test_toolset.py
@@ -3058,3 +3058,147 @@ class TestUsageTracking:
         assert handle.status == TaskStatus.COMPLETED
         assert handle.result == "bare output"
         assert handle.usage is None
+
+
+class TestDrainSteeringMessages:
+    """Unit tests for `_drain_steering_messages` (parent -> child steering)."""
+
+    @pytest.mark.asyncio
+    async def test_returns_task_update_text_in_order(self):
+        from subagents_pydantic_ai.message_bus import InMemoryMessageBus
+        from subagents_pydantic_ai.toolset import _drain_steering_messages
+        from subagents_pydantic_ai.types import AgentMessage, MessageType
+
+        bus = InMemoryMessageBus()
+        bus.register_agent("subagent-x")
+        for text in ("first", "second"):
+            await bus.send(
+                AgentMessage(
+                    type=MessageType.TASK_UPDATE,
+                    sender="parent",
+                    receiver="subagent-x",
+                    payload={"message": text},
+                    task_id="x",
+                )
+            )
+
+        assert await _drain_steering_messages(bus, "subagent-x") == ["first", "second"]
+        # Queue is drained.
+        assert await _drain_steering_messages(bus, "subagent-x") == []
+
+    @pytest.mark.asyncio
+    async def test_non_dict_payload_is_stringified(self):
+        from subagents_pydantic_ai.message_bus import InMemoryMessageBus
+        from subagents_pydantic_ai.toolset import _drain_steering_messages
+        from subagents_pydantic_ai.types import AgentMessage, MessageType
+
+        bus = InMemoryMessageBus()
+        bus.register_agent("subagent-x")
+        await bus.send(
+            AgentMessage(
+                type=MessageType.TASK_UPDATE,
+                sender="parent",
+                receiver="subagent-x",
+                payload="bare text",
+                task_id="x",
+            )
+        )
+
+        assert await _drain_steering_messages(bus, "subagent-x") == ["bare text"]
+
+    @pytest.mark.asyncio
+    async def test_ignores_other_types_and_empty_payloads(self):
+        from subagents_pydantic_ai.message_bus import InMemoryMessageBus
+        from subagents_pydantic_ai.toolset import _drain_steering_messages
+        from subagents_pydantic_ai.types import AgentMessage, MessageType
+
+        bus = InMemoryMessageBus()
+        bus.register_agent("subagent-x")
+        # A non-steering message type — ignored.
+        await bus.send(
+            AgentMessage(
+                type=MessageType.CANCEL_REQUEST,
+                sender="task_manager",
+                receiver="subagent-x",
+                payload={"reason": "soft_cancel"},
+                task_id="x",
+            )
+        )
+        # A steering message with an empty body — skipped.
+        await bus.send(
+            AgentMessage(
+                type=MessageType.TASK_UPDATE,
+                sender="parent",
+                receiver="subagent-x",
+                payload={"message": ""},
+                task_id="x",
+            )
+        )
+
+        assert await _drain_steering_messages(bus, "subagent-x") == []
+
+
+class TestSendMessageToSubagent:
+    """Tests for the `send_message_to_subagent` parent-facing tool."""
+
+    def _make_toolset(self):
+        config = SubAgentConfig(name="helper", description="Helps", instructions="Help")
+        with patch(
+            "subagents_pydantic_ai.toolset._compile_subagent",
+            return_value=_make_mock_compiled_subagent(config),
+        ):
+            return create_subagent_toolset(subagents=[config], include_general_purpose=False)
+
+    @pytest.mark.asyncio
+    async def test_registered_in_toolset(self):
+        toolset = self._make_toolset()
+        assert "send_message_to_subagent" in toolset.tools
+
+    @pytest.mark.asyncio
+    async def test_task_not_found(self):
+        toolset = self._make_toolset()
+        tool = toolset.tools["send_message_to_subagent"]
+        ctx = MockRunContext(deps=MockDeps())
+
+        result = await tool.function(ctx, "nope", "do this")
+        assert "Error" in result
+        assert "not found" in result
+
+    @pytest.mark.asyncio
+    async def test_task_not_running(self):
+        from subagents_pydantic_ai.types import TaskHandle
+
+        toolset = self._make_toolset()
+        tm = toolset.task_manager
+        # A finished task: a handle exists, but the subagent is not registered
+        # on the bus (it unregisters when done).
+        tm.handles["done-1"] = TaskHandle(
+            task_id="done-1",
+            subagent_name="helper",
+            description="d",
+            status=TaskStatus.COMPLETED,
+        )
+        tool = toolset.tools["send_message_to_subagent"]
+        ctx = MockRunContext(deps=MockDeps())
+
+        result = await tool.function(ctx, "done-1", "too late")
+        assert "Error" in result
+        assert "not accepting messages" in result
+
+    @pytest.mark.asyncio
+    async def test_delivers_to_running_subagent(self):
+        from subagents_pydantic_ai.types import MessageType
+
+        toolset = self._make_toolset()
+        bus = toolset.task_manager.message_bus
+        bus.register_agent("subagent-run-1")
+        tool = toolset.tools["send_message_to_subagent"]
+        ctx = MockRunContext(deps=MockDeps())
+
+        result = await tool.function(ctx, "run-1", "narrow the scope")
+        assert "delivered" in result
+
+        msgs = await bus.get_messages("subagent-run-1")
+        assert len(msgs) == 1
+        assert msgs[0].type == MessageType.TASK_UPDATE
+        assert msgs[0].payload == {"message": "narrow the scope"}

--- a/uv.lock
+++ b/uv.lock
@@ -1304,7 +1304,7 @@ wheels = [
 
 [[package]]
 name = "subagents-pydantic-ai"
-version = "0.2.6"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -1304,7 +1304,7 @@ wheels = [
 
 [[package]]
 name = "subagents-pydantic-ai"
-version = "0.3.0"
+version = "0.2.7"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary

Closes #28.

Adds **unprompted parent -> child steering** for running **async** subagents. When a parent agent learns something new while a long-running task is in progress, it can now redirect or narrow that task mid-flight — without cancelling it. The subagent adapts on its next step and keeps all partial progress, instead of the lossy cancel-and-respawn pattern that was the only option before.

```python
handle = await task(description="search repo for FProgram refs", subagent_type="general", mode="async")
# ... parent learns the area from other context ...
await send_message_to_subagent(
    task_id=handle.task_id,
    message="narrow the search to packages/sparta/ — I just confirmed it isn't in core/",
)
result = await wait_tasks([handle.task_id])
```

## How it works

- **New tool `send_message_to_subagent(task_id, message)`** (parent-facing): enqueues a `TASK_UPDATE` on the message bus for `subagent-{task_id}`. Sending to a finished or unknown task returns a clear error.
- **Run-loop delivery:** `_drive_run` gains an `inject_messages` hook (mirroring the existing `cancel_check`). Between graph nodes, at each **model-request boundary**, it drains pending steering and folds each message into that request as an extra `UserPromptPart`. The subagent therefore reads it as a normal user instruction on its very next model turn.
- **Safety:** injecting only at model-request boundaries guarantees a steering part is never spliced between a tool call and its return. The boundary check uses `isinstance(node, ModelRequestNode)` so it's independent of the agent object.
- **Distinct from `answer_subagent`**, which only replies to a question the subagent already asked via `ask_parent`. This is the inverse, unprompted direction.

The plumbing the issue identified (`InMemoryMessageBus`, `MessageType.TASK_UPDATE`, per-task `subagent-{task_id}` registration) was already present; this PR wires the missing pieces — draining the subagent's queue in the run loop and injecting into the next request.

## Scope / limitations

Honoured on the retry-driven run path (`max_retries > 0`, the **default**). The legacy `agent.run()` fast path (`max_retries == 0`) does not expose node boundaries, so steering messages stay queued there — documented in the tool description, `run_with_retry` docstring, changelog, and docs.

## Tests

- `test_retry.py`: injection mechanism with a real `FunctionModel` (tool-call then text; asserts steering lands in the **next** model request and is polled once per model-request node), plus a deterministic end-to-end `_run_async` test that parks the subagent in a tool, sends a steering message, and asserts it's seen on resume.
- `test_toolset.py`: `_drain_steering_messages` unit tests (TASK_UPDATE ordering, non-dict payload, ignored types / empty payloads) and `send_message_to_subagent` tool tests (not found, not running, delivered).

## Checks

- `make test` — **311 passed, 100% coverage**
- `pyright` — 0 errors · `mypy src` — clean
- `ruff check` / `ruff format --check` — clean
- `mkdocs build` — clean

Version bumped `0.2.6 -> 0.3.0` (new feature); changelog + `docs/concepts/toolset.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)