### PR TITLE
feat: add configurable delegation modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `"persisted_and_oneshot"`: `create_agent` + `task` + `delegate`
   - `"oneshot_only"`: `delegate` only
   The ephemeral `delegate` path bypasses the registry, while `create_agent` stores reusable specialists for later `task` calls. Shared dynamic-agent validation and construction logic lives in `dynamic_agent.py`.
-- **`"oneshot_only"` rejects a non-empty `subagents` list at construction time.** Without `task` there is no way to reach a configured subagent, so combining the two would compile agents the model can never call. `create_subagent_toolset` (and `SubAgentCapability`) now raise `ValueError` instead of silently dropping the configuration.
+- **A delegation mode rejects configuration it cannot reach.** Hiding a tool also hides everything that only that tool consults, so `create_subagent_toolset` (and `SubAgentCapability`) now raise `ValueError` at construction rather than dropping the configuration in silence: `"oneshot_only"` rejects `subagents` and `registry` (both reachable only through `task`), and `"default"` rejects `allowed_models`, `capabilities_map`, and `default_agent_factory` (consulted only by `create_agent` and `delegate`).
+- **`AgentFactory` type alias** for `default_agent_factory`, replacing `Any` on `create_subagent_toolset`, `create_agent_factory_toolset`, and `SubAgentCapability`. `registry` is likewise typed `DynamicAgentRegistry | None` now that the toolset depends on that interface directly.
 
 ### Fixed
 
 - **Registry-backed agents now receive `ask_parent` at run time.** Dynamic agents created via the registry previously lacked the `ask_parent` toolset that statically compiled subagents get, so `can_ask_questions` was effectively a no-op for them. The toolset now injects `ask_parent` when executing registry-backed (and one-shot) agents. Custom `default_agent_factory` implementations should not attach their own `ask_parent` toolset, or the tool name will be duplicated at run time.
+- **One-shot `delegate` no longer reports or stores a chat trace.** A `Chat Trace ID` is only redeemable if `task` can resolve the subagent it belongs to, and a one-shot specialist is never registered — so the id it handed back could not be used from any mode, while its saved history still consumed a slot in the `max_chat_traces` LRU and evicted conversations that *were* continuable. One-shot runs now leave `handle.chat_trace_id` unset, omit the id from `delegate` / `check_task` / `wait_tasks` output, and never write to the history store.
+- **Documented pairing of `create_subagent_toolset` with `create_agent_factory_toolset`.** The previous recipe in `docs/advanced/dynamic-agents.md` combined `"persisted"` with the factory toolset, which pydantic-ai rejects at run time because both define a `create_agent` tool, and let `create_agent_factory_toolset` silently overwrite the registry's `max_agents`. The documented setup now keeps the subagent toolset task-only and passes the limit to the toolset that owns creation.
 
 ## [0.2.10] - 2026-07-24
 
@@ -56,6 +59,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **Require `pydantic-ai-slim>=2.0`** (was `>=1.74.0`): the package now targets the 2.0 API (`result.usage` property; context-less tools registered via `tool_plain`, which 2.0 made a hard requirement rather than a deprecation).
+
+## [0.2.7] - 2026-06-04
+
+### Added
+
+- **Unprompted parent -> child steering via `send_message_to_subagent`** ([#28](https://github.com/vstorm-co/subagents-pydantic-ai/issues/28)). A parent agent can now steer a running **async** subagent mid-flight without cancelling it — e.g. "narrow the search to `packages/sparta/`, it isn't in `core/`" — so the subagent adapts on its next step while keeping all partial progress, instead of the lossy cancel-and-respawn pattern. The new `send_message_to_subagent(task_id, message)` tool enqueues a `TASK_UPDATE` on the message bus for `subagent-{task_id}`; the run loop drains it at the next model-request boundary (`_drive_run` gained an `inject_messages` hook alongside the existing `cancel_check`) and folds each message into that request as an extra `UserPromptPart`. Injecting only at model-request boundaries guarantees a steering part is never spliced into a tool-call/tool-return pair. This is distinct from `answer_subagent`, which only replies to a question the subagent already asked via `ask_parent`. Sending to a finished or unknown task returns a clear error. Honoured on the retry-driven run path (`max_retries > 0`, the default); the legacy `agent.run()` fast path (`max_retries == 0`) does not expose node boundaries, so steering messages stay queued there.
+
 ## [0.2.6] - 2026-06-01
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `"persisted_and_oneshot"`: `create_agent` + `task` + `delegate`
   - `"oneshot_only"`: `delegate` only
   The ephemeral `delegate` path bypasses the registry, while `create_agent` stores reusable specialists for later `task` calls. Shared dynamic-agent validation and construction logic lives in `dynamic_agent.py`.
+- **`"oneshot_only"` rejects a non-empty `subagents` list at construction time.** Without `task` there is no way to reach a configured subagent, so combining the two would compile agents the model can never call. `create_subagent_toolset` (and `SubAgentCapability`) now raise `ValueError` instead of silently dropping the configuration.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **One-shot delegation via `delegate` tool.** Opt in with `oneshot_delegation=True` on `create_subagent_toolset` or `SubAgentCapability`. The new `delegate` tool creates an ephemeral specialist and runs its task in one call, bypassing the dynamic agent registry. Shared dynamic-agent validation and construction logic was extracted into `dynamic_agent.py` and reused by `create_agent_factory_toolset`.
+- **Configurable persistent and one-shot delegation.** `delegation_configuration` on `create_subagent_toolset` and `SubAgentCapability` selects `"default"` (`create_agent` + `task`), `"persisted_and_oneshot"` (also `delegate`), or `"oneshot_only"` (`delegate` only). The ephemeral `delegate` path bypasses the registry, while `create_agent` stores reusable specialists for later `task` calls. Shared dynamic-agent validation and construction logic lives in `dynamic_agent.py`.
 
 ## [0.2.8] - 2026-06-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Configurable persistent and one-shot delegation.** `delegation_configuration` on `create_subagent_toolset` and `SubAgentCapability` selects `"default"` (`create_agent` + `task`), `"persisted_and_oneshot"` (also `delegate`), or `"oneshot_only"` (`delegate` only). The ephemeral `delegate` path bypasses the registry, while `create_agent` stores reusable specialists for later `task` calls. Shared dynamic-agent validation and construction logic lives in `dynamic_agent.py`.
+- **Configurable persistent and one-shot delegation.** `delegation_configuration` on `create_subagent_toolset` and `SubAgentCapability` selects:
+  - `"default"`: `task` only (backward-compatible)
+  - `"persisted"`: `create_agent` + `task`
+  - `"persisted_and_oneshot"`: `create_agent` + `task` + `delegate`
+  - `"oneshot_only"`: `delegate` only
+  The ephemeral `delegate` path bypasses the registry, while `create_agent` stores reusable specialists for later `task` calls. Shared dynamic-agent validation and construction logic lives in `dynamic_agent.py`.
+
+### Fixed
+
+- **Registry-backed agents now receive `ask_parent` at run time.** Dynamic agents created via the registry previously lacked the `ask_parent` toolset that statically compiled subagents get, so `can_ask_questions` was effectively a no-op for them. The toolset now injects `ask_parent` when executing registry-backed (and one-shot) agents. Custom `default_agent_factory` implementations should not attach their own `ask_parent` toolset, or the tool name will be duplicated at run time.
 
 ## [0.2.8] - 2026-06-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **One-shot delegation via `delegate` tool.** Opt in with `oneshot_delegation=True` on `create_subagent_toolset` or `SubAgentCapability`. The new `delegate` tool creates an ephemeral specialist and runs its task in one call, bypassing the dynamic agent registry. Shared dynamic-agent validation and construction logic was extracted into `dynamic_agent.py` and reused by `create_agent_factory_toolset`.
+
 ## [0.2.8] - 2026-06-26
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -200,6 +200,31 @@ agent = Agent(
 # 2. task(description="...", subagent_type="analyst") — delegates to it
 ```
 
+### One-Shot Delegation
+
+For one-off specialists, enable `oneshot_delegation=True` to expose a `delegate` tool that creates an ephemeral agent and runs its task in a single call. The specialist is **not** registered and cannot be reused by name:
+
+```python
+from subagents_pydantic_ai import create_subagent_toolset
+
+toolset = create_subagent_toolset(
+    oneshot_delegation=True,
+    allowed_models=["openai:gpt-4o", "openai:gpt-4o-mini"],
+    capabilities_map={
+        "filesystem": lambda deps: [create_fs_toolset(deps.backend)],
+    },
+)
+
+# Parent agent calls:
+# delegate(
+#     description="Analyze this CSV and summarize trends",
+#     instructions="You are a data analyst. Return concise findings.",
+#     mode="sync",
+# )
+```
+
+Use `create_agent` + `task` when you need a reusable specialist. Use `delegate` for ephemeral one-off work.
+
 ## Subagent Questions
 
 Enable subagents to ask the parent for clarification:
@@ -221,6 +246,7 @@ The parent agent can then respond using `answer_subagent(task_id, answer)`.
 | Tool | Description |
 |------|-------------|
 | `task` | Delegate a task to a subagent (sync, async, or auto) |
+| `delegate` | Create and run an ephemeral specialist in one call (when `oneshot_delegation=True`) |
 | `check_task` | Check status and get result of a background task |
 | `answer_subagent` | Answer a question from a blocked subagent |
 | `list_active_tasks` | List all running background tasks |

--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ agent = Agent(
     deps_type=Deps,
     toolsets=[create_subagent_toolset(
         registry=registry,
+        delegation_configuration="persisted",
         allowed_models=["openai:gpt-4o", "openai:gpt-4o-mini"],
     )],
 )
@@ -200,7 +201,8 @@ Choose which delegation entry points are exposed:
 
 | Mode | Entry-point tools |
 |------|-------------------|
-| `"default"` | `create_agent`, `task` |
+| `"default"` | `task` (backward-compatible) |
+| `"persisted"` | `create_agent`, `task` |
 | `"persisted_and_oneshot"` | `create_agent`, `task`, `delegate` |
 | `"oneshot_only"` | `delegate` |
 
@@ -225,7 +227,7 @@ toolset = create_subagent_toolset(
 # )
 ```
 
-Use `create_agent` + `task` when you need a reusable specialist. Use `delegate` for ephemeral one-off work.
+Use `"persisted"` or `"default"` with `create_agent` / `task` when you need reusable specialists. Use `delegate` for ephemeral one-off work.
 
 ## Subagent Questions
 
@@ -247,7 +249,7 @@ The parent agent can then respond using `answer_subagent(task_id, answer)`.
 
 | Tool | Description |
 |------|-------------|
-| `create_agent` | Create a reusable registry-backed specialist |
+| `create_agent` | Create a reusable registry-backed specialist (opt-in modes) |
 | `task` | Delegate a task to a subagent (sync, async, or auto) |
 | `delegate` | Create and run an ephemeral specialist in one call |
 | `check_task` | Check status and get result of a background task |

--- a/README.md
+++ b/README.md
@@ -175,7 +175,6 @@ Create agents on-the-fly and delegate to them seamlessly:
 ```python
 from subagents_pydantic_ai import (
     create_subagent_toolset,
-    create_agent_factory_toolset,
     DynamicAgentRegistry,
 )
 
@@ -184,15 +183,10 @@ registry = DynamicAgentRegistry()
 agent = Agent(
     "openai:gpt-4o",
     deps_type=Deps,
-    toolsets=[
-        # Pass registry so task() can resolve dynamically created agents
-        create_subagent_toolset(registry=registry),
-        create_agent_factory_toolset(
-            registry=registry,
-            allowed_models=["openai:gpt-4o", "openai:gpt-4o-mini"],
-            max_agents=5,
-        ),
-    ],
+    toolsets=[create_subagent_toolset(
+        registry=registry,
+        allowed_models=["openai:gpt-4o", "openai:gpt-4o-mini"],
+    )],
 )
 
 # Now the agent can:
@@ -200,15 +194,23 @@ agent = Agent(
 # 2. task(description="...", subagent_type="analyst") — delegates to it
 ```
 
-### One-Shot Delegation
+### Delegation Configuration
 
-For one-off specialists, enable `oneshot_delegation=True` to expose a `delegate` tool that creates an ephemeral agent and runs its task in a single call. The specialist is **not** registered and cannot be reused by name:
+Choose which delegation entry points are exposed:
+
+| Mode | Entry-point tools |
+|------|-------------------|
+| `"default"` | `create_agent`, `task` |
+| `"persisted_and_oneshot"` | `create_agent`, `task`, `delegate` |
+| `"oneshot_only"` | `delegate` |
+
+Async task lifecycle tools remain available in every mode. One-shot specialists are **not** registered and cannot be reused by name.
 
 ```python
 from subagents_pydantic_ai import create_subagent_toolset
 
 toolset = create_subagent_toolset(
-    oneshot_delegation=True,
+    delegation_configuration="persisted_and_oneshot",
     allowed_models=["openai:gpt-4o", "openai:gpt-4o-mini"],
     capabilities_map={
         "filesystem": lambda deps: [create_fs_toolset(deps.backend)],
@@ -245,8 +247,9 @@ The parent agent can then respond using `answer_subagent(task_id, answer)`.
 
 | Tool | Description |
 |------|-------------|
+| `create_agent` | Create a reusable registry-backed specialist |
 | `task` | Delegate a task to a subagent (sync, async, or auto) |
-| `delegate` | Create and run an ephemeral specialist in one call (when `oneshot_delegation=True`) |
+| `delegate` | Create and run an ephemeral specialist in one call |
 | `check_task` | Check status and get result of a background task |
 | `answer_subagent` | Answer a question from a blocked subagent |
 | `list_active_tasks` | List all running background tasks |

--- a/docs/advanced/dynamic-agents.md
+++ b/docs/advanced/dynamic-agents.md
@@ -1,6 +1,6 @@
 # Dynamic Agent Creation
 
-Create specialized agents at runtime using the agent factory toolset.
+Create reusable or ephemeral specialized agents at runtime.
 
 ## Overview
 
@@ -10,14 +10,13 @@ While pre-configured subagents cover most use cases, sometimes you need to creat
 - Task requires a unique combination of capabilities
 - Experimentation with different agent configurations
 
-## Agent Factory Toolset
+## Delegation Toolset
 
-Add dynamic creation capabilities:
+`create_subagent_toolset` exposes persistent creation and task delegation by default:
 
 ```python
 from subagents_pydantic_ai import (
     create_subagent_toolset,
-    create_agent_factory_toolset,
     DynamicAgentRegistry,
 )
 
@@ -26,14 +25,11 @@ registry = DynamicAgentRegistry()
 agent = Agent(
     "openai:gpt-4o",
     deps_type=Deps,
-    toolsets=[
-        create_subagent_toolset(subagents=base_subagents),
-        create_agent_factory_toolset(
-            registry=registry,
-            allowed_models=["openai:gpt-4o", "openai:gpt-4o-mini"],
-            max_agents=5,
-        ),
-    ],
+    toolsets=[create_subagent_toolset(
+        subagents=base_subagents,
+        registry=registry,
+        allowed_models=["openai:gpt-4o", "openai:gpt-4o-mini"],
+    )],
 )
 ```
 
@@ -41,16 +37,16 @@ agent = Agent(
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `registry` | `DynamicAgentRegistry` | Required | Registry for created agents |
+| `registry` | `DynamicAgentRegistry \| None` | `None` | Registry for created agents; an internal registry is created when omitted |
 | `allowed_models` | `list[str] \| None` | `None` (all allowed) | Models agents can use |
 | `default_model` | `str \| Model` | `"openai:gpt-4.1"` | Default model for new agents when none is given |
 | `max_agents` | `int` | `10` | Maximum dynamic agents |
 | `toolsets_factory` | `ToolsetFactory \| None` | `None` | Factory that builds toolsets for every new agent. Takes priority over `capabilities_map` when both are set |
 | `capabilities_map` | `dict[str, CapabilityFactory] \| None` | `None` | Maps capability names to factory functions, e.g. `{"filesystem": ..., "todo": ...}`. Used when `capabilities` are passed to `create_agent` |
-| `id` | `str \| None` | `None` (-> `"agent_factory"`) | Optional toolset ID |
+| `delegation_configuration` | `DelegationConfiguration` | `"default"` | Select persistent, combined, or one-shot-only entry points |
 | `default_agent_factory` | `Callable \| None` | `None` | Factory used to build every dynamic agent |
 
-See [`create_agent_factory_toolset`][subagents_pydantic_ai.factory.create_agent_factory_toolset]
+See [`create_subagent_toolset`][subagents_pydantic_ai.toolset.create_subagent_toolset]
 for the full signature.
 
 ## DynamicAgentRegistry
@@ -314,26 +310,33 @@ create_agent_factory_toolset(
 
 ### Agent Limits
 
-Prevent unlimited agent creation:
+Prevent unlimited agent creation when the toolset creates its internal registry:
 
 ```python
-create_agent_factory_toolset(
-    registry=registry,
+create_subagent_toolset(
     max_agents=3,  # Maximum 3 dynamic agents
 )
 ```
 
 After reaching the limit, creating new agents will fail until existing ones are removed.
 
-## One-Shot Delegation
+## Delegation Modes
 
-For one-off specialists, enable `oneshot_delegation=True` on the subagent toolset (or `SubAgentCapability`). This exposes a `delegate` tool that combines agent creation and task execution in a single call.
+`delegation_configuration` controls the primary tools exposed to the parent:
+
+| Mode | Entry-point tools | Use case |
+|------|-------------------|----------|
+| `"default"` | `create_agent`, `task` | Reusable specialists |
+| `"persisted_and_oneshot"` | `create_agent`, `task`, `delegate` | Reusable and ad-hoc specialists |
+| `"oneshot_only"` | `delegate` | Minimal one-shot delegation |
+
+Async lifecycle tools such as `check_task` remain available in every mode.
 
 ```python
 from subagents_pydantic_ai import create_subagent_toolset
 
 toolset = create_subagent_toolset(
-    oneshot_delegation=True,
+    delegation_configuration="persisted_and_oneshot",
     allowed_models=["openai:gpt-4o", "openai:gpt-4o-mini"],
     capabilities_map={
         "filesystem": lambda deps: [create_fs_toolset(deps.backend)],

--- a/docs/advanced/dynamic-agents.md
+++ b/docs/advanced/dynamic-agents.md
@@ -316,31 +316,56 @@ Prevent unlimited agent creation when the toolset creates its internal registry:
 
 ```python
 create_subagent_toolset(
+    delegation_configuration="persisted",
     max_agents=3,  # Maximum 3 dynamic agents
 )
 ```
 
 After reaching the limit, creating new agents will fail until existing ones are removed.
 
-`create_subagent_toolset` exposes no `remove_agent` tool, so a parent using
-`"persisted"` or `"persisted_and_oneshot"` cannot free a slot on its own once
-`max_agents` is hit. Pair it with `create_agent_factory_toolset` over a shared
-registry when the parent should manage its own agents:
+`max_agents` only applies to the registry `create_subagent_toolset` builds for
+itself. Pass your own `registry` and it keeps its own cap instead.
+
+#### Letting the parent free a slot
+
+`create_subagent_toolset` exposes no `remove_agent` tool, so a parent in
+`"persisted"` or `"persisted_and_oneshot"` cannot free a slot once `max_agents`
+is hit — it is told to remove an agent with no tool to do it. Give it the
+management tools from `create_agent_factory_toolset` over a shared registry, and
+leave the subagent toolset on `"default"`:
 
 ```python
-registry = DynamicAgentRegistry(max_agents=3)
+registry = DynamicAgentRegistry()
 
 agent = Agent(
     "openai:gpt-4o",
     toolsets=[
-        create_subagent_toolset(
-            registry=registry,
-            delegation_configuration="persisted",
-        ),
-        create_agent_factory_toolset(registry=registry),
+        # Task-only. Creating, listing and removing agents lives in the factory
+        # toolset, the only one that exposes `remove_agent`.
+        create_subagent_toolset(registry=registry),
+        create_agent_factory_toolset(registry=registry, max_agents=3),
     ],
 )
 ```
+
+Agents the parent creates are immediately reachable through `task`, because both
+toolsets share one registry.
+
+!!! warning "One owner for `create_agent`"
+
+    Do not combine `"persisted"` or `"persisted_and_oneshot"` with
+    `create_agent_factory_toolset`. Both define a tool named `create_agent`, and
+    pydantic-ai rejects duplicate tool names across toolsets at run time:
+
+    ```
+    UserError: FunctionToolset 'agent_factory' defines a tool whose name conflicts
+    with existing tool from FunctionToolset 'subagents': 'create_agent'.
+    ```
+
+    Pick one owner for agent creation: `"persisted"` for creation without
+    management, or `"default"` plus the factory toolset for both. Note that
+    `create_agent_factory_toolset` writes its `max_agents` onto the registry, so
+    pass the limit there rather than to `DynamicAgentRegistry(...)`.
 
 ## Delegation Modes
 
@@ -354,8 +379,15 @@ agent = Agent(
 | `"oneshot_only"` | `delegate` | Minimal one-shot delegation |
 
 Async lifecycle tools such as `check_task` remain available in every mode.
-`"oneshot_only"` rejects a non-empty `subagents` list at construction time,
-because those agents would be unreachable without `task`.
+
+A mode that hides a tool also hides that tool's configuration, so passing
+configuration the mode can never consult raises `ValueError` at construction
+instead of being dropped in silence:
+
+| Mode | Rejects | Because |
+|------|---------|---------|
+| `"oneshot_only"` | `subagents`, `registry` | Only `task` can reach either |
+| `"default"` | `allowed_models`, `capabilities_map`, `default_agent_factory` | Only `create_agent` / `delegate` consult them |
 
 Custom `default_agent_factory` implementations should not attach an
 `ask_parent` toolset; the toolset injects it at run time for registry-backed
@@ -392,6 +424,11 @@ One-shot specialists are **ephemeral**:
 - They do **not** count toward `max_agents`
 - They cannot be reused via `task(subagent_type=...)`
 - An internal name like `oneshot-{task_id}` is generated for logging and async task handles
+- They report **no chat trace**. A `Chat Trace ID` is only useful if `task` can
+  resolve the subagent it belongs to, which is never true for a one-shot, so
+  `delegate` results omit it and one-shot runs never occupy a slot in the
+  `max_chat_traces` LRU that a continuable conversation could use. Use
+  `create_agent` + `task` when you want a resumable conversation.
 
 Use `delegate` for ad-hoc specialists. Use `create_agent` + `task` when you need a reusable agent that persists in the registry.
 

--- a/docs/advanced/dynamic-agents.md
+++ b/docs/advanced/dynamic-agents.md
@@ -322,6 +322,26 @@ create_subagent_toolset(
 
 After reaching the limit, creating new agents will fail until existing ones are removed.
 
+`create_subagent_toolset` exposes no `remove_agent` tool, so a parent using
+`"persisted"` or `"persisted_and_oneshot"` cannot free a slot on its own once
+`max_agents` is hit. Pair it with `create_agent_factory_toolset` over a shared
+registry when the parent should manage its own agents:
+
+```python
+registry = DynamicAgentRegistry(max_agents=3)
+
+agent = Agent(
+    "openai:gpt-4o",
+    toolsets=[
+        create_subagent_toolset(
+            registry=registry,
+            delegation_configuration="persisted",
+        ),
+        create_agent_factory_toolset(registry=registry),
+    ],
+)
+```
+
 ## Delegation Modes
 
 `delegation_configuration` controls the primary tools exposed to the parent:

--- a/docs/advanced/dynamic-agents.md
+++ b/docs/advanced/dynamic-agents.md
@@ -12,7 +12,8 @@ While pre-configured subagents cover most use cases, sometimes you need to creat
 
 ## Delegation Toolset
 
-`create_subagent_toolset` exposes persistent creation and task delegation by default:
+`create_subagent_toolset` exposes `task` by default. Opt into persistent
+creation with `delegation_configuration="persisted"`:
 
 ```python
 from subagents_pydantic_ai import (
@@ -28,6 +29,7 @@ agent = Agent(
     toolsets=[create_subagent_toolset(
         subagents=base_subagents,
         registry=registry,
+        delegation_configuration="persisted",
         allowed_models=["openai:gpt-4o", "openai:gpt-4o-mini"],
     )],
 )
@@ -43,7 +45,7 @@ agent = Agent(
 | `max_agents` | `int` | `10` | Maximum dynamic agents |
 | `toolsets_factory` | `ToolsetFactory \| None` | `None` | Factory that builds toolsets for every new agent. Takes priority over `capabilities_map` when both are set |
 | `capabilities_map` | `dict[str, CapabilityFactory] \| None` | `None` | Maps capability names to factory functions, e.g. `{"filesystem": ..., "todo": ...}`. Used when `capabilities` are passed to `create_agent` |
-| `delegation_configuration` | `DelegationConfiguration` | `"default"` | Select persistent, combined, or one-shot-only entry points |
+| `delegation_configuration` | `DelegationConfiguration` | `"default"` | Select default, persisted, combined, or one-shot-only entry points |
 | `default_agent_factory` | `Callable \| None` | `None` | Factory used to build every dynamic agent |
 
 See [`create_subagent_toolset`][subagents_pydantic_ai.toolset.create_subagent_toolset]
@@ -326,11 +328,18 @@ After reaching the limit, creating new agents will fail until existing ones are 
 
 | Mode | Entry-point tools | Use case |
 |------|-------------------|----------|
-| `"default"` | `create_agent`, `task` | Reusable specialists |
+| `"default"` | `task` | Backward-compatible configured/registry delegation |
+| `"persisted"` | `create_agent`, `task` | Reusable specialists |
 | `"persisted_and_oneshot"` | `create_agent`, `task`, `delegate` | Reusable and ad-hoc specialists |
 | `"oneshot_only"` | `delegate` | Minimal one-shot delegation |
 
 Async lifecycle tools such as `check_task` remain available in every mode.
+`"oneshot_only"` rejects a non-empty `subagents` list at construction time,
+because those agents would be unreachable without `task`.
+
+Custom `default_agent_factory` implementations should not attach an
+`ask_parent` toolset; the toolset injects it at run time for registry-backed
+and one-shot agents.
 
 ```python
 from subagents_pydantic_ai import create_subagent_toolset

--- a/docs/advanced/dynamic-agents.md
+++ b/docs/advanced/dynamic-agents.md
@@ -325,6 +325,44 @@ create_agent_factory_toolset(
 
 After reaching the limit, creating new agents will fail until existing ones are removed.
 
+## One-Shot Delegation
+
+For one-off specialists, enable `oneshot_delegation=True` on the subagent toolset (or `SubAgentCapability`). This exposes a `delegate` tool that combines agent creation and task execution in a single call.
+
+```python
+from subagents_pydantic_ai import create_subagent_toolset
+
+toolset = create_subagent_toolset(
+    oneshot_delegation=True,
+    allowed_models=["openai:gpt-4o", "openai:gpt-4o-mini"],
+    capabilities_map={
+        "filesystem": lambda deps: [create_fs_toolset(deps.backend)],
+    },
+)
+```
+
+### `delegate` Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `description` | `str` | Task prompt for the specialist |
+| `instructions` | `str` | Specialist system prompt |
+| `model` | `str \| None` | Optional model override |
+| `capabilities` | `list[str] \| None` | Optional capability names |
+| `can_ask_questions` | `bool` | Whether the specialist can ask the parent (default: `True`) |
+| `mode` | `str` | `"sync"`, `"async"`, or `"auto"` (default: `"sync"`) |
+
+### Registry Semantics
+
+One-shot specialists are **ephemeral**:
+
+- They are **not** registered in `DynamicAgentRegistry`
+- They do **not** count toward `max_agents`
+- They cannot be reused via `task(subagent_type=...)`
+- An internal name like `oneshot-{task_id}` is generated for logging and async task handles
+
+Use `delegate` for ad-hoc specialists. Use `create_agent` + `task` when you need a reusable agent that persists in the registry.
+
 ### Naming Conflicts
 
 Dynamic agents cannot override pre-configured agents:

--- a/docs/concepts/capability.md
+++ b/docs/concepts/capability.md
@@ -50,8 +50,26 @@ SubAgentCapability(
     usage_limits=UsageLimits(           # Static limits, or a factory (see below)
         request_limit=10,
     ),
+    oneshot_delegation=False,           # Expose delegate for ephemeral create-and-run
+    allowed_models=None,                # Model allow-list for one-shot specialists
+    capabilities_map=None,              # Capability factories for one-shot specialists
+    default_agent_factory=None,         # Custom agent factory for one-shot specialists
 )
 ```
+
+### One-shot delegation
+
+Set `oneshot_delegation=True` to expose a `delegate` tool that creates an ephemeral specialist and runs its task in one call. The specialist is not registered in the dynamic agent registry.
+
+```python
+SubAgentCapability(
+    oneshot_delegation=True,
+    allowed_models=["openai:gpt-4.1"],
+    capabilities_map={"filesystem": lambda deps: [create_fs_toolset(deps.backend)]},
+)
+```
+
+Use `delegate` for one-off specialists. Use `task` with pre-configured or registry-backed agents for reusable delegation.
 
 ### Usage limits
 
@@ -82,8 +100,8 @@ cap = SubAgentCapability(subagents=[...], usage_limits=limits_for)
 When you pass `SubAgentCapability` to an agent, pydantic-ai calls:
 
 1. **`get_toolset()`** — returns the `FunctionToolset` containing delegation tools
-   (`task`, `check_task`, `answer_subagent`, `list_active_tasks`, `wait_tasks`,
-   `soft_cancel_task`, `hard_cancel_task`)
+   (`task`, `delegate` when `oneshot_delegation=True`, `check_task`, `answer_subagent`,
+   `list_active_tasks`, `wait_tasks`, `soft_cancel_task`, `hard_cancel_task`)
 
 2. **`get_instructions()`** — returns a callable that generates the system prompt
    listing available subagents with their descriptions (via

--- a/docs/concepts/capability.md
+++ b/docs/concepts/capability.md
@@ -50,20 +50,30 @@ SubAgentCapability(
     usage_limits=UsageLimits(           # Static limits, or a factory (see below)
         request_limit=10,
     ),
-    oneshot_delegation=False,           # Expose delegate for ephemeral create-and-run
-    allowed_models=None,                # Model allow-list for one-shot specialists
-    capabilities_map=None,              # Capability factories for one-shot specialists
-    default_agent_factory=None,         # Custom agent factory for one-shot specialists
+    delegation_configuration="default", # Persistent, combined, or one-shot only
+    allowed_models=None,                # Model allow-list for dynamic specialists
+    capabilities_map=None,              # Capability factories for dynamic specialists
+    default_agent_factory=None,         # Custom agent factory for dynamic specialists
+    max_agents=10,                      # Persistent-agent limit
 )
 ```
 
-### One-shot delegation
+### Delegation configuration
 
-Set `oneshot_delegation=True` to expose a `delegate` tool that creates an ephemeral specialist and runs its task in one call. The specialist is not registered in the dynamic agent registry.
+Choose which delegation entry points the capability exposes:
+
+| Mode | Entry-point tools |
+|------|-------------------|
+| `"default"` | `create_agent`, `task` |
+| `"persisted_and_oneshot"` | `create_agent`, `task`, `delegate` |
+| `"oneshot_only"` | `delegate` |
+
+The one-shot `delegate` tool creates an ephemeral specialist and runs its task
+in one call. The specialist is not registered in the dynamic agent registry.
 
 ```python
 SubAgentCapability(
-    oneshot_delegation=True,
+    delegation_configuration="persisted_and_oneshot",
     allowed_models=["openai:gpt-4.1"],
     capabilities_map={"filesystem": lambda deps: [create_fs_toolset(deps.backend)]},
 )
@@ -99,9 +109,9 @@ cap = SubAgentCapability(subagents=[...], usage_limits=limits_for)
 
 When you pass `SubAgentCapability` to an agent, pydantic-ai calls:
 
-1. **`get_toolset()`** — returns the `FunctionToolset` containing delegation tools
-   (`task`, `delegate` when `oneshot_delegation=True`, `check_task`, `answer_subagent`,
-   `list_active_tasks`, `wait_tasks`, `soft_cancel_task`, `hard_cancel_task`)
+1. **`get_toolset()`** — returns the configured delegation entry points plus
+   task lifecycle tools (`check_task`, `answer_subagent`, `list_active_tasks`,
+   `wait_tasks`, `soft_cancel_task`, `hard_cancel_task`)
 
 2. **`get_instructions()`** — returns a callable that generates the system prompt
    listing available subagents with their descriptions (via

--- a/docs/concepts/capability.md
+++ b/docs/concepts/capability.md
@@ -50,7 +50,7 @@ SubAgentCapability(
     usage_limits=UsageLimits(           # Static limits, or a factory (see below)
         request_limit=10,
     ),
-    delegation_configuration="default", # Persistent, combined, or one-shot only
+    delegation_configuration="default", # Task-only, persisted, combined, or oneshot
     allowed_models=None,                # Model allow-list for dynamic specialists
     capabilities_map=None,              # Capability factories for dynamic specialists
     default_agent_factory=None,         # Custom agent factory for dynamic specialists
@@ -64,7 +64,8 @@ Choose which delegation entry points the capability exposes:
 
 | Mode | Entry-point tools |
 |------|-------------------|
-| `"default"` | `create_agent`, `task` |
+| `"default"` | `task` |
+| `"persisted"` | `create_agent`, `task` |
 | `"persisted_and_oneshot"` | `create_agent`, `task`, `delegate` |
 | `"oneshot_only"` | `delegate` |
 

--- a/docs/concepts/toolset.md
+++ b/docs/concepts/toolset.md
@@ -29,7 +29,7 @@ toolset = create_subagent_toolset(subagents=subagents)
 | `max_nesting_depth` | `int` | `0` | Maximum subagent nesting depth |
 | `registry` | `DynamicAgentRegistry \| None` | `None` | Registry for dynamically created agents |
 | `descriptions` | `dict[str, str] \| None` | `None` | Override default tool descriptions by tool name |
-| `delegation_configuration` | `DelegationConfiguration` | `"default"` | Controls whether persistent, one-shot, or both entry points are exposed |
+| `delegation_configuration` | `DelegationConfiguration` | `"default"` | Controls whether task-only, persisted, one-shot, or combined entry points are exposed |
 | `allowed_models` | `list[str] \| None` | `None` | Model allow-list for dynamic specialists |
 | `capabilities_map` | `dict[str, Callable] \| None` | `None` | Capability factories for dynamic specialists |
 | `default_agent_factory` | `Callable \| None` | `None` | Custom agent factory for dynamic specialists |
@@ -98,7 +98,8 @@ The toolset provides these tools to your agent:
 
 | Mode | Entry-point tools |
 |------|-------------------|
-| `"default"` | `create_agent`, `task` |
+| `"default"` | `task` |
+| `"persisted"` | `create_agent`, `task` |
 | `"persisted_and_oneshot"` | `create_agent`, `task`, `delegate` |
 | `"oneshot_only"` | `delegate` |
 

--- a/docs/concepts/toolset.md
+++ b/docs/concepts/toolset.md
@@ -138,10 +138,13 @@ task(
 
 #### Stateful conversations (`chat_trace_id`)
 
-Every successful task result ends with a `Chat Trace ID: <id>` line. Passing
+Every successful `task()` result ends with a `Chat Trace ID: <id>` line. Passing
 that ID back to `task()` resumes the same subagent conversation: the subagent
 sees the full message history of its previous run and continues from there.
 Omit `chat_trace_id` to start a fresh conversation.
+
+`delegate()` results carry no trace ID, because a one-shot specialist is never
+registered and so cannot be named in a follow-up `task()` call.
 
 ```python
 # First task — a new conversation is created automatically:
@@ -167,7 +170,8 @@ Rules and limits:
   first run failed) returns an error instead of silently starting over.
 - Only the `max_chat_traces` most recently used conversations are kept
   (default 100, configurable on `create_subagent_toolset`); older ones are
-  evicted to bound memory in long-lived sessions.
+  evicted to bound memory in long-lived sessions. One-shot `delegate` runs are
+  not stored, so they never evict a conversation you can still continue.
 - History grows with every continuation — the full prior conversation is
   replayed on each resumed run, so long traces cost more tokens per call.
 

--- a/docs/concepts/toolset.md
+++ b/docs/concepts/toolset.md
@@ -29,10 +29,11 @@ toolset = create_subagent_toolset(subagents=subagents)
 | `max_nesting_depth` | `int` | `0` | Maximum subagent nesting depth |
 | `registry` | `DynamicAgentRegistry \| None` | `None` | Registry for dynamically created agents |
 | `descriptions` | `dict[str, str] \| None` | `None` | Override default tool descriptions by tool name |
-| `oneshot_delegation` | `bool` | `False` | Expose `delegate` for ephemeral create-and-run |
-| `allowed_models` | `list[str] \| None` | `None` | Model allow-list for one-shot specialists |
-| `capabilities_map` | `dict[str, Callable] \| None` | `None` | Capability factories for one-shot specialists |
-| `default_agent_factory` | `Callable \| None` | `None` | Custom agent factory for one-shot specialists |
+| `delegation_configuration` | `DelegationConfiguration` | `"default"` | Controls whether persistent, one-shot, or both entry points are exposed |
+| `allowed_models` | `list[str] \| None` | `None` | Model allow-list for dynamic specialists |
+| `capabilities_map` | `dict[str, Callable] \| None` | `None` | Capability factories for dynamic specialists |
+| `default_agent_factory` | `Callable \| None` | `None` | Custom agent factory for dynamic specialists |
+| `max_agents` | `int` | `10` | Maximum persistent agents in an internally created registry |
 
 ## Adding to an Agent
 
@@ -93,6 +94,22 @@ See [SubAgentConfig](types.md#subagentconfig) for full documentation of the `age
 
 The toolset provides these tools to your agent:
 
+### Delegation modes
+
+| Mode | Entry-point tools |
+|------|-------------------|
+| `"default"` | `create_agent`, `task` |
+| `"persisted_and_oneshot"` | `create_agent`, `task`, `delegate` |
+| `"oneshot_only"` | `delegate` |
+
+Task lifecycle tools remain available in every mode so async work can be checked,
+steered, awaited, answered, or cancelled.
+
+### create_agent
+
+Create and register a reusable specialist. The resulting name can be passed to
+`task` multiple times.
+
 ### task
 
 Delegate a task to a subagent.
@@ -116,7 +133,8 @@ task(
 
 ### delegate
 
-Create an ephemeral specialist and delegate a task in one call. Available when `oneshot_delegation=True`.
+Create an ephemeral specialist and delegate a task in one call. Available in
+`"persisted_and_oneshot"` and `"oneshot_only"` modes.
 
 ```python
 # The agent calls:

--- a/docs/concepts/toolset.md
+++ b/docs/concepts/toolset.md
@@ -25,9 +25,14 @@ toolset = create_subagent_toolset(subagents=subagents)
 | `subagents` | `list[SubAgentConfig]` | `[]` | List of subagent configurations |
 | `default_model` | `str \| None` | `None` | Default model for subagents |
 | `toolsets_factory` | `Callable` | `None` | Factory to create toolsets for subagents |
-| `max_nesting_depth` | `int` | `2` | Maximum subagent nesting depth |
-| `general_purpose_config` | `SubAgentConfig \| None` | Auto | Config for the "general" subagent |
+| `include_general_purpose` | `bool` | `True` | Include the general-purpose subagent |
+| `max_nesting_depth` | `int` | `0` | Maximum subagent nesting depth |
+| `registry` | `DynamicAgentRegistry \| None` | `None` | Registry for dynamically created agents |
 | `descriptions` | `dict[str, str] \| None` | `None` | Override default tool descriptions by tool name |
+| `oneshot_delegation` | `bool` | `False` | Expose `delegate` for ephemeral create-and-run |
+| `allowed_models` | `list[str] \| None` | `None` | Model allow-list for one-shot specialists |
+| `capabilities_map` | `dict[str, Callable] \| None` | `None` | Capability factories for one-shot specialists |
+| `default_agent_factory` | `Callable \| None` | `None` | Custom agent factory for one-shot specialists |
 
 ## Adding to an Agent
 
@@ -108,6 +113,32 @@ task(
 | `description` | `str` | What the subagent should do |
 | `subagent_type` | `str` | Name of the subagent to use |
 | `mode` | `str` | `"sync"`, `"async"`, or `"auto"` |
+
+### delegate
+
+Create an ephemeral specialist and delegate a task in one call. Available when `oneshot_delegation=True`.
+
+```python
+# The agent calls:
+delegate(
+    description="Analyze this dataset and summarize key trends",
+    instructions="You are a data analyst. Return concise findings.",
+    mode="sync",
+)
+```
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `description` | `str` | Task prompt for the specialist |
+| `instructions` | `str` | Specialist system prompt |
+| `model` | `str \| None` | Optional model override |
+| `capabilities` | `list[str] \| None` | Optional capability names |
+| `can_ask_questions` | `bool` | Whether the specialist can ask the parent |
+| `mode` | `str` | `"sync"`, `"async"`, or `"auto"` |
+
+The specialist is not registered and cannot be reused by name.
 
 ### check_task
 

--- a/docs/concepts/types.md
+++ b/docs/concepts/types.md
@@ -110,6 +110,7 @@ from subagents_pydantic_ai import DelegationConfiguration
 
 DelegationConfiguration = Literal[
     "default",
+    "persisted",
     "persisted_and_oneshot",
     "oneshot_only",
 ]
@@ -117,7 +118,8 @@ DelegationConfiguration = Literal[
 
 | Mode | Entry-point tools |
 |------|-------------------|
-| `default` | `create_agent`, `task` |
+| `default` | `task` |
+| `persisted` | `create_agent`, `task` |
 | `persisted_and_oneshot` | `create_agent`, `task`, `delegate` |
 | `oneshot_only` | `delegate` |
 

--- a/docs/concepts/types.md
+++ b/docs/concepts/types.md
@@ -100,6 +100,27 @@ ExecutionMode = Literal["sync", "async", "auto"]
 | `async` | Run in background |
 | `auto` | Automatically decide |
 
+### DelegationConfiguration
+
+Controls the delegation entry-point tools exposed by `create_subagent_toolset`
+and `SubAgentCapability`.
+
+```python
+from subagents_pydantic_ai import DelegationConfiguration
+
+DelegationConfiguration = Literal[
+    "default",
+    "persisted_and_oneshot",
+    "oneshot_only",
+]
+```
+
+| Mode | Entry-point tools |
+|------|-------------------|
+| `default` | `create_agent`, `task` |
+| `persisted_and_oneshot` | `create_agent`, `task`, `delegate` |
+| `oneshot_only` | `delegate` |
+
 ### TaskStatus
 
 Status of a background task.

--- a/src/subagents_pydantic_ai/__init__.py
+++ b/src/subagents_pydantic_ai/__init__.py
@@ -55,6 +55,9 @@ from subagents_pydantic_ai.prompts import (
     DEFAULT_GENERAL_PURPOSE_DESCRIPTION as DEFAULT_GENERAL_PURPOSE_DESCRIPTION,
 )
 from subagents_pydantic_ai.prompts import (
+    DELEGATE_TOOL_DESCRIPTION as DELEGATE_TOOL_DESCRIPTION,
+)
+from subagents_pydantic_ai.prompts import (
     DUAL_MODE_SYSTEM_PROMPT as DUAL_MODE_SYSTEM_PROMPT,
 )
 from subagents_pydantic_ai.prompts import (
@@ -195,6 +198,7 @@ __all__ = [
     "SUBAGENT_SYSTEM_PROMPT",
     "DUAL_MODE_SYSTEM_PROMPT",
     "DEFAULT_GENERAL_PURPOSE_DESCRIPTION",
+    "DELEGATE_TOOL_DESCRIPTION",
     "TASK_TOOL_DESCRIPTION",
     "CHECK_TASK_DESCRIPTION",
     "ANSWER_SUBAGENT_DESCRIPTION",

--- a/src/subagents_pydantic_ai/__init__.py
+++ b/src/subagents_pydantic_ai/__init__.py
@@ -124,6 +124,9 @@ from subagents_pydantic_ai.types import (
     CompiledSubAgent as CompiledSubAgent,
 )
 from subagents_pydantic_ai.types import (
+    DelegationConfiguration as DelegationConfiguration,
+)
+from subagents_pydantic_ai.types import (
     ExecutionMode as ExecutionMode,
 )
 from subagents_pydantic_ai.types import (
@@ -170,6 +173,7 @@ __all__ = [
     "TaskPriority",
     "TaskCharacteristics",
     "ExecutionMode",
+    "DelegationConfiguration",
     "ToolsetFactory",
     "UsageLimitsFactory",
     "AskUserCallback",

--- a/src/subagents_pydantic_ai/capability.py
+++ b/src/subagents_pydantic_ai/capability.py
@@ -32,8 +32,9 @@ from pydantic_ai import RunContext, UsageLimits
 from pydantic_ai.capabilities import AbstractCapability
 from pydantic_ai.toolsets import AbstractToolset
 
-from subagents_pydantic_ai.dynamic_agent import CapabilityFactory
+from subagents_pydantic_ai.dynamic_agent import AgentFactory, CapabilityFactory
 from subagents_pydantic_ai.prompts import get_subagent_system_prompt
+from subagents_pydantic_ai.registry import DynamicAgentRegistry
 from subagents_pydantic_ai.toolset import create_subagent_toolset
 from subagents_pydantic_ai.types import (
     DelegationConfiguration,
@@ -78,17 +79,27 @@ class SubAgentCapability(AbstractCapability[Any]):
         usage_limits: Optional static or per-task usage limits for delegated
             subagent runs.
         delegation_configuration: Select default, persisted, combined, or
-            one-shot-only delegation entry points.
+            one-shot-only delegation entry points. A mode that hides a tool
+            rejects that tool's configuration rather than ignoring it — see
+            `Raises`.
         allowed_models: Optional model allow-list for dynamic specialists.
         capabilities_map: Optional capability factories for dynamic specialists.
         default_agent_factory: Optional custom agent factory for dynamic specialists.
             Do not attach an `ask_parent` toolset in the factory; the toolset
             injects it at run time when needed.
-        max_agents: Maximum number of persistent dynamic agents.
+        max_agents: Maximum number of persistent dynamic agents, applied to the
+            registry the toolset creates for `create_agent`. Ignored when
+            `registry` is set — that registry keeps its own `max_agents`.
         max_result_chars: Character budget for a completed task's result in the
             `wait_tasks` listing. Truncated results carry an explicit marker
             pointing at `check_task`, which always returns the full text. Pass
             `None` to never truncate.
+
+    Raises:
+        ValueError: From `create_subagent_toolset` when the configuration is
+            self-contradictory — an invalid `delegation_configuration`, or one
+            whose hidden tools make `subagents`, `registry`, `allowed_models`,
+            `capabilities_map`, or `default_agent_factory` unreachable.
     """
 
     subagents: list[SubAgentConfig] | None = None
@@ -96,13 +107,13 @@ class SubAgentCapability(AbstractCapability[Any]):
     include_general_purpose: bool = True
     max_nesting_depth: int = 0
     toolsets_factory: ToolsetFactory | None = None
-    registry: Any = None
+    registry: DynamicAgentRegistry | None = None
     descriptions: dict[str, str] | None = None
     usage_limits: UsageLimits | UsageLimitsFactory | None = None
     delegation_configuration: DelegationConfiguration = "default"
     allowed_models: list[str] | None = None
     capabilities_map: dict[str, CapabilityFactory] | None = None
-    default_agent_factory: Any | None = None
+    default_agent_factory: AgentFactory | None = None
     max_agents: int = 10
     max_result_chars: int | None = 2000
     _toolset: AbstractToolset[Any] | None = field(default=None, init=False, repr=False)

--- a/src/subagents_pydantic_ai/capability.py
+++ b/src/subagents_pydantic_ai/capability.py
@@ -71,6 +71,12 @@ class SubAgentCapability(AbstractCapability[Any]):
         descriptions: Custom tool descriptions override.
         usage_limits: Optional static or per-task usage limits for delegated
             subagent runs.
+        oneshot_delegation: When True, expose a `delegate` tool for ephemeral
+            create-and-run delegation.
+        allowed_models: Optional model allow-list for one-shot specialists.
+        capabilities_map: Optional capability factories for one-shot specialists.
+        default_agent_factory: Optional custom agent factory for one-shot
+            specialists.
     """
 
     subagents: list[SubAgentConfig] | None = None
@@ -81,6 +87,10 @@ class SubAgentCapability(AbstractCapability[Any]):
     registry: Any = None
     descriptions: dict[str, str] | None = None
     usage_limits: UsageLimits | UsageLimitsFactory | None = None
+    oneshot_delegation: bool = False
+    allowed_models: list[str] | None = None
+    capabilities_map: dict[str, Any] | None = None
+    default_agent_factory: Any | None = None
     _toolset: AbstractToolset[Any] | None = field(default=None, init=False, repr=False)
 
     def __post_init__(self) -> None:
@@ -95,6 +105,10 @@ class SubAgentCapability(AbstractCapability[Any]):
             registry=self.registry,
             descriptions=self.descriptions,
             usage_limits=self.usage_limits,
+            oneshot_delegation=self.oneshot_delegation,
+            allowed_models=self.allowed_models,
+            capabilities_map=self.capabilities_map,
+            default_agent_factory=self.default_agent_factory,
         )
 
     @classmethod

--- a/src/subagents_pydantic_ai/capability.py
+++ b/src/subagents_pydantic_ai/capability.py
@@ -34,7 +34,12 @@ from pydantic_ai.toolsets import AbstractToolset
 
 from subagents_pydantic_ai.prompts import get_subagent_system_prompt
 from subagents_pydantic_ai.toolset import create_subagent_toolset
-from subagents_pydantic_ai.types import SubAgentConfig, ToolsetFactory, UsageLimitsFactory
+from subagents_pydantic_ai.types import (
+    DelegationConfiguration,
+    SubAgentConfig,
+    ToolsetFactory,
+    UsageLimitsFactory,
+)
 
 
 @dataclass
@@ -71,12 +76,12 @@ class SubAgentCapability(AbstractCapability[Any]):
         descriptions: Custom tool descriptions override.
         usage_limits: Optional static or per-task usage limits for delegated
             subagent runs.
-        oneshot_delegation: When True, expose a `delegate` tool for ephemeral
-            create-and-run delegation.
-        allowed_models: Optional model allow-list for one-shot specialists.
-        capabilities_map: Optional capability factories for one-shot specialists.
-        default_agent_factory: Optional custom agent factory for one-shot
-            specialists.
+        delegation_configuration: Select persisted, combined, or one-shot-only
+            delegation entry points.
+        allowed_models: Optional model allow-list for dynamic specialists.
+        capabilities_map: Optional capability factories for dynamic specialists.
+        default_agent_factory: Optional custom agent factory for dynamic specialists.
+        max_agents: Maximum number of persistent dynamic agents.
     """
 
     subagents: list[SubAgentConfig] | None = None
@@ -87,10 +92,11 @@ class SubAgentCapability(AbstractCapability[Any]):
     registry: Any = None
     descriptions: dict[str, str] | None = None
     usage_limits: UsageLimits | UsageLimitsFactory | None = None
-    oneshot_delegation: bool = False
+    delegation_configuration: DelegationConfiguration = "default"
     allowed_models: list[str] | None = None
     capabilities_map: dict[str, Any] | None = None
     default_agent_factory: Any | None = None
+    max_agents: int = 10
     _toolset: AbstractToolset[Any] | None = field(default=None, init=False, repr=False)
 
     def __post_init__(self) -> None:
@@ -105,10 +111,11 @@ class SubAgentCapability(AbstractCapability[Any]):
             registry=self.registry,
             descriptions=self.descriptions,
             usage_limits=self.usage_limits,
-            oneshot_delegation=self.oneshot_delegation,
+            delegation_configuration=self.delegation_configuration,
             allowed_models=self.allowed_models,
             capabilities_map=self.capabilities_map,
             default_agent_factory=self.default_agent_factory,
+            max_agents=self.max_agents,
         )
 
     @classmethod
@@ -130,6 +137,12 @@ class SubAgentCapability(AbstractCapability[Any]):
         configs = list(self.subagents) if self.subagents else []
 
         def _instructions(ctx: RunContext[Any]) -> str:
+            if self.delegation_configuration == "oneshot_only":
+                return (
+                    "## One-Shot Delegation\n\n"
+                    "Use the `delegate` tool to create an ephemeral specialist "
+                    "and run a task in one call."
+                )
             return get_subagent_system_prompt(configs)
 
         return _instructions

--- a/src/subagents_pydantic_ai/capability.py
+++ b/src/subagents_pydantic_ai/capability.py
@@ -32,6 +32,7 @@ from pydantic_ai import RunContext, UsageLimits
 from pydantic_ai.capabilities import AbstractCapability
 from pydantic_ai.toolsets import AbstractToolset
 
+from subagents_pydantic_ai.dynamic_agent import CapabilityFactory
 from subagents_pydantic_ai.prompts import get_subagent_system_prompt
 from subagents_pydantic_ai.toolset import create_subagent_toolset
 from subagents_pydantic_ai.types import (
@@ -76,11 +77,13 @@ class SubAgentCapability(AbstractCapability[Any]):
         descriptions: Custom tool descriptions override.
         usage_limits: Optional static or per-task usage limits for delegated
             subagent runs.
-        delegation_configuration: Select persisted, combined, or one-shot-only
-            delegation entry points.
+        delegation_configuration: Select default, persisted, combined, or
+            one-shot-only delegation entry points.
         allowed_models: Optional model allow-list for dynamic specialists.
         capabilities_map: Optional capability factories for dynamic specialists.
         default_agent_factory: Optional custom agent factory for dynamic specialists.
+            Do not attach an `ask_parent` toolset in the factory; the toolset
+            injects it at run time when needed.
         max_agents: Maximum number of persistent dynamic agents.
     """
 
@@ -94,7 +97,7 @@ class SubAgentCapability(AbstractCapability[Any]):
     usage_limits: UsageLimits | UsageLimitsFactory | None = None
     delegation_configuration: DelegationConfiguration = "default"
     allowed_models: list[str] | None = None
-    capabilities_map: dict[str, Any] | None = None
+    capabilities_map: dict[str, CapabilityFactory] | None = None
     default_agent_factory: Any | None = None
     max_agents: int = 10
     _toolset: AbstractToolset[Any] | None = field(default=None, init=False, repr=False)

--- a/src/subagents_pydantic_ai/dynamic_agent.py
+++ b/src/subagents_pydantic_ai/dynamic_agent.py
@@ -1,0 +1,189 @@
+"""Shared helpers for building dynamic subagents at runtime."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic_ai import Agent, RunContext
+from pydantic_ai.models import Model
+
+from subagents_pydantic_ai.protocols import SubAgentDepsProtocol
+from subagents_pydantic_ai.types import SubAgentConfig, ToolsetFactory
+
+CapabilityFactory = ToolsetFactory
+
+
+def validate_agent_name(name: str) -> str | None:
+    """Return an error message when the agent name is invalid."""
+    if not name or not all(c.isalnum() or c == "-" for c in name):
+        return "Error: Name must contain only letters, numbers, and hyphens"
+    return None
+
+
+def validate_model(
+    model: str | Model,
+    allowed_models: list[str] | None,
+) -> str | None:
+    """Return an error message when the model is not allowed."""
+    if allowed_models and model not in allowed_models:
+        allowed = ", ".join(allowed_models)
+        return f"Error: Model '{model}' is not allowed. Use one of: {allowed}"
+    return None
+
+
+def validate_capabilities(
+    capabilities: list[str] | None,
+    capabilities_map: dict[str, CapabilityFactory] | None,
+) -> str | None:
+    """Return an error message when capabilities are unknown."""
+    if capabilities and capabilities_map:
+        invalid_caps = [cap for cap in capabilities if cap not in capabilities_map]
+        if invalid_caps:
+            available = ", ".join(capabilities_map.keys())
+            invalid = ", ".join(invalid_caps)
+            return f"Error: Unknown capabilities: {invalid}. Available: {available}"
+    return None
+
+
+def validate_capabilities_with_factory(
+    capabilities: list[str] | None,
+    default_agent_factory: Any | None,
+) -> str | None:
+    """Return an error when capabilities cannot be injected with a custom factory."""
+    if default_agent_factory is not None and capabilities:
+        return (
+            "Error: capabilities are not supported when a custom "
+            "default_agent_factory is configured. The factory builds the "
+            "agent itself; create the agent without capabilities or "
+            "configure the factory to attach the required toolsets."
+        )
+    return None
+
+
+def build_subagent_config(
+    *,
+    name: str,
+    description: str,
+    instructions: str,
+    model: str | Model,
+    can_ask_questions: bool = True,
+) -> SubAgentConfig:
+    """Build a runtime subagent configuration."""
+    return SubAgentConfig(
+        name=name,
+        description=description,
+        instructions=instructions,
+        model=model,
+        can_ask_questions=can_ask_questions,
+    )
+
+
+def collect_agent_toolsets(
+    ctx: RunContext[SubAgentDepsProtocol],
+    capabilities: list[str] | None,
+    *,
+    toolsets_factory: ToolsetFactory | None,
+    capabilities_map: dict[str, CapabilityFactory] | None,
+) -> list[Any]:
+    """Collect toolsets to attach to a dynamically built agent."""
+    agent_toolsets: list[Any] = []
+    if toolsets_factory:
+        agent_toolsets.extend(toolsets_factory(ctx.deps))
+    elif capabilities and capabilities_map:
+        for cap_name in capabilities:
+            cap_factory = capabilities_map[cap_name]
+            agent_toolsets.extend(cap_factory(ctx.deps))
+    return agent_toolsets
+
+
+def build_agent_instance(
+    ctx: RunContext[SubAgentDepsProtocol],
+    config: SubAgentConfig,
+    *,
+    model: str | Model,
+    capabilities: list[str] | None,
+    toolsets_factory: ToolsetFactory | None,
+    capabilities_map: dict[str, CapabilityFactory] | None,
+    default_agent_factory: Any | None,
+) -> Any:
+    """Build a pydantic-ai Agent instance for a dynamic subagent."""
+    if default_agent_factory is not None:
+        return default_agent_factory(config)
+
+    agent_toolsets = collect_agent_toolsets(
+        ctx,
+        capabilities,
+        toolsets_factory=toolsets_factory,
+        capabilities_map=capabilities_map,
+    )
+    return Agent(
+        model,
+        system_prompt=config["instructions"],
+        toolsets=agent_toolsets or None,
+    )
+
+
+def build_dynamic_agent(
+    ctx: RunContext[SubAgentDepsProtocol],
+    *,
+    name: str,
+    description: str,
+    instructions: str,
+    model: str | Model,
+    can_ask_questions: bool = True,
+    capabilities: list[str] | None = None,
+    allowed_models: list[str] | None = None,
+    toolsets_factory: ToolsetFactory | None = None,
+    capabilities_map: dict[str, CapabilityFactory] | None = None,
+    default_agent_factory: Any | None = None,
+) -> tuple[Any | None, SubAgentConfig | None, str | None]:
+    """Validate inputs and build a dynamic agent.
+
+    Returns:
+        A tuple of ``(agent, config, error_message)``. On success,
+        ``error_message`` is ``None``. On failure, ``agent`` and ``config``
+        are ``None``.
+    """
+    name_error = validate_agent_name(name)
+    if name_error is not None:
+        return None, None, name_error
+
+    model_error = validate_model(model, allowed_models)
+    if model_error is not None:
+        return None, None, model_error
+
+    caps_error = validate_capabilities(capabilities, capabilities_map)
+    if caps_error is not None:
+        return None, None, caps_error
+
+    factory_caps_error = validate_capabilities_with_factory(
+        capabilities,
+        default_agent_factory,
+    )
+    if factory_caps_error is not None:
+        return None, None, factory_caps_error
+
+    config = build_subagent_config(
+        name=name,
+        description=description,
+        instructions=instructions,
+        model=model,
+        can_ask_questions=can_ask_questions,
+    )
+
+    try:
+        agent = build_agent_instance(
+            ctx,
+            config,
+            model=model,
+            capabilities=capabilities,
+            toolsets_factory=toolsets_factory,
+            capabilities_map=capabilities_map,
+            default_agent_factory=default_agent_factory,
+        )
+    except ValueError as exc:
+        return None, None, f"Error: {exc}"
+    except Exception as exc:
+        return None, None, f"Error creating agent: {exc}"
+
+    return agent, config, None

--- a/src/subagents_pydantic_ai/dynamic_agent.py
+++ b/src/subagents_pydantic_ai/dynamic_agent.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import Any
 
 from pydantic_ai import Agent, RunContext
@@ -11,6 +12,18 @@ from subagents_pydantic_ai.protocols import SubAgentDepsProtocol
 from subagents_pydantic_ai.types import SubAgentConfig, ToolsetFactory
 
 CapabilityFactory = ToolsetFactory
+
+AgentFactory = Callable[[SubAgentConfig], Any]
+"""Builds the agent instance for a dynamically created subagent.
+
+Receives the freshly built `SubAgentConfig` and returns an agent instance. The
+return type is `Any` because the agent need not be a `pydantic_ai.Agent` —
+consumers such as pydantic-deep return their own agent objects.
+
+A factory must not attach an `ask_parent` toolset; the subagent toolset injects
+one at run time for registry-backed and one-shot agents, and a second copy would
+collide on the tool name.
+"""
 
 
 def validate_agent_name(name: str) -> str | None:
@@ -47,7 +60,7 @@ def validate_capabilities(
 
 def validate_capabilities_with_factory(
     capabilities: list[str] | None,
-    default_agent_factory: Any | None,
+    default_agent_factory: AgentFactory | None,
 ) -> str | None:
     """Return an error when capabilities cannot be injected with a custom factory."""
     if default_agent_factory is not None and capabilities:
@@ -104,7 +117,7 @@ def build_agent_instance(
     capabilities: list[str] | None,
     toolsets_factory: ToolsetFactory | None,
     capabilities_map: dict[str, CapabilityFactory] | None,
-    default_agent_factory: Any | None,
+    default_agent_factory: AgentFactory | None,
 ) -> Any:
     """Build a pydantic-ai Agent instance for a dynamic subagent."""
     if default_agent_factory is not None:
@@ -135,7 +148,7 @@ def build_dynamic_agent(
     allowed_models: list[str] | None = None,
     toolsets_factory: ToolsetFactory | None = None,
     capabilities_map: dict[str, CapabilityFactory] | None = None,
-    default_agent_factory: Any | None = None,
+    default_agent_factory: AgentFactory | None = None,
 ) -> str | tuple[Any, SubAgentConfig]:
     """Validate inputs and build a dynamic agent.
 

--- a/src/subagents_pydantic_ai/dynamic_agent.py
+++ b/src/subagents_pydantic_ai/dynamic_agent.py
@@ -136,32 +136,30 @@ def build_dynamic_agent(
     toolsets_factory: ToolsetFactory | None = None,
     capabilities_map: dict[str, CapabilityFactory] | None = None,
     default_agent_factory: Any | None = None,
-) -> tuple[Any | None, SubAgentConfig | None, str | None]:
+) -> str | tuple[Any, SubAgentConfig]:
     """Validate inputs and build a dynamic agent.
 
     Returns:
-        A tuple of ``(agent, config, error_message)``. On success,
-        ``error_message`` is ``None``. On failure, ``agent`` and ``config``
-        are ``None``.
+        An error string on failure, or ``(agent, config)`` on success.
     """
     name_error = validate_agent_name(name)
     if name_error is not None:
-        return None, None, name_error
+        return name_error
 
     model_error = validate_model(model, allowed_models)
     if model_error is not None:
-        return None, None, model_error
+        return model_error
 
     caps_error = validate_capabilities(capabilities, capabilities_map)
     if caps_error is not None:
-        return None, None, caps_error
+        return caps_error
 
     factory_caps_error = validate_capabilities_with_factory(
         capabilities,
         default_agent_factory,
     )
     if factory_caps_error is not None:
-        return None, None, factory_caps_error
+        return factory_caps_error
 
     config = build_subagent_config(
         name=name,
@@ -182,8 +180,8 @@ def build_dynamic_agent(
             default_agent_factory=default_agent_factory,
         )
     except ValueError as exc:
-        return None, None, f"Error: {exc}"
+        return f"Error: {exc}"
     except Exception as exc:
-        return None, None, f"Error creating agent: {exc}"
+        return f"Error creating agent: {exc}"
 
-    return agent, config, None
+    return agent, config

--- a/src/subagents_pydantic_ai/factory.py
+++ b/src/subagents_pydantic_ai/factory.py
@@ -138,7 +138,7 @@ def create_agent_factory_toolset(
             return f"Error: Agent '{name}' already exists"
 
         actual_model = model or default_model
-        agent, config, error = build_dynamic_agent(
+        result = build_dynamic_agent(
             ctx,
             name=name,
             description=description,
@@ -151,26 +151,22 @@ def create_agent_factory_toolset(
             capabilities_map=capabilities_map,
             default_agent_factory=default_agent_factory,
         )
-        if error is not None:
-            return error
-        if config is None or agent is None:
-            return "Error creating agent"
+        if isinstance(result, str):
+            return result
+        agent, config = result
 
         try:
             registry.register(config, agent)
-
-            caps_info = f"\nCapabilities: {', '.join(capabilities)}" if capabilities else ""
-            return (
-                f"Agent '{name}' created successfully.\n"
-                f"Model: {actual_model}\n"
-                f"Description: {description}{caps_info}\n"
-                f"Use task(description, '{name}') to delegate tasks."
-            )
-
         except ValueError as e:
             return f"Error: {e}"
-        except Exception as e:
-            return f"Error creating agent: {e}"
+
+        caps_info = f"\nCapabilities: {', '.join(capabilities)}" if capabilities else ""
+        return (
+            f"Agent '{name}' created successfully.\n"
+            f"Model: {actual_model}\n"
+            f"Description: {description}{caps_info}\n"
+            f"Use task(description, '{name}') to delegate tasks."
+        )
 
     @toolset.tool
     async def list_agents(

--- a/src/subagents_pydantic_ai/factory.py
+++ b/src/subagents_pydantic_ai/factory.py
@@ -13,6 +13,7 @@ from pydantic_ai.models import Model
 from pydantic_ai.toolsets import FunctionToolset
 
 from subagents_pydantic_ai.dynamic_agent import (
+    AgentFactory,
     CapabilityFactory,
     build_dynamic_agent,
 )
@@ -29,7 +30,7 @@ def create_agent_factory_toolset(
     toolsets_factory: ToolsetFactory | None = None,
     capabilities_map: dict[str, CapabilityFactory] | None = None,
     id: str | None = None,
-    default_agent_factory: Any | None = None,
+    default_agent_factory: AgentFactory | None = None,
 ) -> FunctionToolset[Any]:
     """Create a toolset for dynamic agent creation.
 
@@ -42,13 +43,19 @@ def create_agent_factory_toolset(
         allowed_models: List of allowed model names. If None, any model
             is allowed.
         default_model: Default model to use when not specified.
-        max_agents: Maximum number of dynamic agents allowed.
+        max_agents: Maximum number of dynamic agents allowed. This is written
+            onto `registry.max_agents`, so it wins over whatever cap the
+            registry was constructed with — pass it explicitly when the limit
+            matters.
         toolsets_factory: Factory to create toolsets for new agents.
             Takes priority over capabilities if both are provided.
         capabilities_map: Mapping of capability names to factory functions.
             E.g., {"filesystem": create_fs_toolset, "todo": create_todo_toolset}.
             Used when capabilities are specified in create_agent.
         id: Optional toolset ID. Defaults to "agent_factory".
+        default_agent_factory: Optional builder for created agents, replacing the
+            default plain `pydantic_ai.Agent`. When set, `create_agent` rejects
+            requested `capabilities`, since the factory owns the agent's toolsets.
 
     Returns:
         FunctionToolset with agent management tools.

--- a/src/subagents_pydantic_ai/factory.py
+++ b/src/subagents_pydantic_ai/factory.py
@@ -8,16 +8,17 @@ from __future__ import annotations
 
 from typing import Any
 
-from pydantic_ai import Agent, RunContext
+from pydantic_ai import RunContext
 from pydantic_ai.models import Model
 from pydantic_ai.toolsets import FunctionToolset
 
+from subagents_pydantic_ai.dynamic_agent import (
+    CapabilityFactory,
+    build_dynamic_agent,
+)
 from subagents_pydantic_ai.protocols import SubAgentDepsProtocol
 from subagents_pydantic_ai.registry import DynamicAgentRegistry
-from subagents_pydantic_ai.types import SubAgentConfig, ToolsetFactory
-
-# Type alias for capability factory functions
-CapabilityFactory = ToolsetFactory
+from subagents_pydantic_ai.types import ToolsetFactory
 
 
 def create_agent_factory_toolset(
@@ -133,69 +134,29 @@ def create_agent_factory_toolset(
         Returns:
             Confirmation message or error.
         """
-        # Validate name
-        if not name or not all(c.isalnum() or c == "-" for c in name):
-            return "Error: Name must contain only letters, numbers, and hyphens"
-
         if registry.exists(name):
             return f"Error: Agent '{name}' already exists"
 
-        # Validate model
         actual_model = model or default_model
-        if allowed_models and actual_model not in allowed_models:
-            allowed = ", ".join(allowed_models)
-            return f"Error: Model '{actual_model}' is not allowed. Use one of: {allowed}"
-
-        # Validate capabilities
-        if capabilities and capabilities_map:
-            invalid_caps = [c for c in capabilities if c not in capabilities_map]
-            if invalid_caps:
-                available = ", ".join(capabilities_map.keys())
-                invalid = ", ".join(invalid_caps)
-                return f"Error: Unknown capabilities: {invalid}. Available: {available}"
-
-        # Create config
-        config = SubAgentConfig(
+        agent, config, error = build_dynamic_agent(
+            ctx,
             name=name,
             description=description,
             instructions=instructions,
             model=actual_model,
             can_ask_questions=can_ask_questions,
+            capabilities=capabilities,
+            allowed_models=allowed_models,
+            toolsets_factory=toolsets_factory,
+            capabilities_map=capabilities_map,
+            default_agent_factory=default_agent_factory,
         )
+        if error is not None:
+            return error
+        if config is None or agent is None:
+            return "Error creating agent"
 
-        # A custom default_agent_factory owns the whole agent build and only
-        # receives `config`, so any toolsets/capabilities collected here
-        # cannot be injected. Rather than silently dropping them while the
-        # success message still reports them as enabled, reject the request so
-        # the caller knows capabilities are unsupported with a custom factory.
-        if default_agent_factory is not None and capabilities:
-            return (
-                "Error: capabilities are not supported when a custom "
-                "default_agent_factory is configured. The factory builds the "
-                "agent itself; create the agent without capabilities or "
-                "configure the factory to attach the required toolsets."
-            )
-
-        # Collect toolsets
-        agent_toolsets: list[Any] = []
-        if toolsets_factory:
-            agent_toolsets.extend(toolsets_factory(ctx.deps))
-        elif capabilities and capabilities_map:
-            for cap_name in capabilities:
-                cap_factory = capabilities_map[cap_name]
-                agent_toolsets.extend(cap_factory(ctx.deps))
-
-        # Create agent
         try:
-            if default_agent_factory is not None:
-                agent: Any = default_agent_factory(config)
-            else:
-                agent = Agent(
-                    actual_model,
-                    system_prompt=instructions,
-                    toolsets=agent_toolsets or None,
-                )
-
             registry.register(config, agent)
 
             caps_info = f"\nCapabilities: {', '.join(capabilities)}" if capabilities else ""

--- a/src/subagents_pydantic_ai/prompts.py
+++ b/src/subagents_pydantic_ai/prompts.py
@@ -50,6 +50,34 @@ DEFAULT_GENERAL_PURPOSE_DESCRIPTION = """A general-purpose agent for a wide vari
 Use this when no specialized subagent matches the task requirements.
 Capable of research, analysis, writing, and problem-solving."""
 
+DELEGATE_TOOL_DESCRIPTION = """\
+Create an ephemeral specialist and delegate a task to it in a single call.
+
+Use this instead of `create_agent` + `task` when you need a one-off specialist \
+for a single job. The specialist is not registered and cannot be reused by name.
+
+## When to use
+- One-off tasks that need custom instructions or capabilities
+- Ad-hoc specialists you will not delegate to again
+- Quick delegation without polluting the agent registry
+
+## When NOT to use
+- Reusable specialists you will delegate to multiple times — use `task` with a \
+configured subagent or create a persistent agent first
+- Trivial tasks you can do faster yourself
+
+## Parameters
+- **description**: The task prompt for the specialist to execute
+- **instructions**: The specialist's system prompt / role definition
+- **model**: Optional model override
+- **capabilities**: Optional capability names to attach to the specialist
+- **mode**: `"sync"` (default), `"async"`, or `"auto"`
+
+Returns:
+- In sync mode: The specialist's response as a string.
+- In async mode: A task handle with task_id for status checking.
+"""
+
 TASK_TOOL_DESCRIPTION = """\
 Delegate a task to a specialized subagent. The subagent runs independently \
 with its own context and tools, and returns a result when done.

--- a/src/subagents_pydantic_ai/toolset.py
+++ b/src/subagents_pydantic_ai/toolset.py
@@ -338,9 +338,9 @@ def create_subagent_toolset(  # noqa: C901
 
     This is the main entry point for using the subagent system. It creates
     a toolset with tools for:
-    - `create_agent`: Create a reusable, registry-backed specialist
+    - `create_agent`: Create a reusable, registry-backed specialist (opt-in modes)
     - `task`: Delegate a task to a configured or registry-backed specialist
-    - `delegate`: Create and run an ephemeral specialist in one call
+    - `delegate`: Create and run an ephemeral specialist in one call (opt-in modes)
     - `check_task`: Check status of an async task
     - `answer_subagent`: Answer a question from a subagent
     - `list_active_tasks`: List all running background tasks
@@ -375,15 +375,20 @@ def create_subagent_toolset(  # noqa: C901
             to run that task without explicit limits. Limits are honoured on
             every retry attempt as well.
         delegation_configuration: Controls the delegation entry points:
-            `"default"` exposes `create_agent` and `task`;
+            `"default"` exposes `task` only (backward-compatible);
+            `"persisted"` exposes `create_agent` and `task`;
             `"persisted_and_oneshot"` also exposes `delegate`;
             `"oneshot_only"` exposes only `delegate`.
             Async task lifecycle tools remain available in every mode.
+            Custom factories that already attach `ask_parent` should not do so;
+            the toolset injects it at run time for registry-backed agents.
         allowed_models: Optional model allow-list for dynamically created specialists.
         capabilities_map: Optional capability factories for dynamically created
             specialists.
         default_agent_factory: Optional custom agent factory for dynamically
             created specialists. When set, requested `capabilities` are rejected.
+            Do not attach an `ask_parent` toolset in the factory; the toolset
+            injects it at run time when needed.
         max_agents: Maximum number of persistent dynamic agents.
 
     Returns:
@@ -410,12 +415,24 @@ def create_subagent_toolset(  # noqa: C901
         agent = Agent("openai:gpt-4.1", toolsets=[toolset])
         ```
     """
-    valid_configurations = {"default", "persisted_and_oneshot", "oneshot_only"}
+    valid_configurations = {
+        "default",
+        "persisted",
+        "persisted_and_oneshot",
+        "oneshot_only",
+    }
     if delegation_configuration not in valid_configurations:
         valid = ", ".join(sorted(valid_configurations))
         raise ValueError(
             f"Invalid delegation_configuration '{delegation_configuration}'. "
             f"Expected one of: {valid}"
+        )
+
+    if delegation_configuration == "oneshot_only" and subagents:
+        raise ValueError(
+            "delegation_configuration='oneshot_only' cannot be combined with "
+            "non-empty subagents; configured subagents would be unreachable. "
+            "Omit subagents, or use a mode that exposes the task tool."
         )
 
     _descs = descriptions or {}
@@ -425,7 +442,7 @@ def create_subagent_toolset(  # noqa: C901
 
     # Build subagent configs
     configs: list[SubAgentConfig] = list(subagents) if subagents else []
-    if include_general_purpose:
+    if include_general_purpose and delegation_configuration != "oneshot_only":
         configs.append(_create_general_purpose_config())
 
     # Compile subagents
@@ -455,7 +472,17 @@ def create_subagent_toolset(  # noqa: C901
         else "No predefined capabilities available"
     )
 
-    if delegation_configuration != "oneshot_only":
+    expose_create_agent = delegation_configuration in {
+        "persisted",
+        "persisted_and_oneshot",
+    }
+    expose_task = delegation_configuration != "oneshot_only"
+    expose_delegate = delegation_configuration in {
+        "persisted_and_oneshot",
+        "oneshot_only",
+    }
+
+    if expose_create_agent:
         create_agent_description = _descs.get(
             "create_agent",
             "Create a reusable specialized agent at runtime. The agent is stored "
@@ -479,7 +506,7 @@ def create_subagent_toolset(  # noqa: C901
                 return f"Error: Agent '{name}' already exists"
 
             actual_model = model or default_model
-            agent, config, error = build_dynamic_agent(
+            result = build_dynamic_agent(
                 ctx,
                 name=name,
                 description=description,
@@ -492,17 +519,14 @@ def create_subagent_toolset(  # noqa: C901
                 capabilities_map=capabilities_map,
                 default_agent_factory=default_agent_factory,
             )
-            if error is not None:
-                return error
-            if config is None or agent is None:
-                return "Error creating agent"
+            if isinstance(result, str):
+                return result
+            agent, config = result
 
             try:
                 active_registry.register(config, agent)
             except ValueError as exc:
                 return f"Error: {exc}"
-            except Exception as exc:
-                return f"Error creating agent: {exc}"
 
             caps_info = f"\nCapabilities: {', '.join(capabilities)}" if capabilities else ""
             return (
@@ -512,67 +536,63 @@ def create_subagent_toolset(  # noqa: C901
                 f"Use task(description, '{name}') to delegate tasks."
             )
 
-    @toolset.tool(description=task_description)
-    async def task(
-        ctx: RunContext[SubAgentDepsProtocol],
-        description: str,
-        subagent_type: str,
-        mode: ExecutionMode = "sync",
-        priority: TaskPriority = TaskPriority.NORMAL,
-        complexity: Literal["simple", "moderate", "complex"] | None = None,
-        requires_user_context: bool = False,
-        may_need_clarification: bool = False,
-    ) -> str:
-        """Delegate a task to a specialized subagent.
+    if expose_task:
 
-        Args:
-            ctx: The run context with dependencies.
-            description: Detailed description of the task to perform.
-            subagent_type: Name of the subagent to use.
-            mode: Execution mode - "sync" (blocking), "async" (background), or "auto".
-            priority: Task priority level (for async tasks).
-            complexity: Override complexity estimate ("simple", "moderate", "complex").
-            requires_user_context: Whether task needs ongoing user interaction.
-            may_need_clarification: Whether task might need clarifying questions.
-        """
-        # Validate subagent_type — check static compiled dict first, then dynamic registry
-        if subagent_type in compiled:
-            subagent = compiled[subagent_type]
-            inject_ask_parent = False
-        elif (
-            active_registry is not None
-            and hasattr(active_registry, "get_compiled")
-            and active_registry.get_compiled(subagent_type)
-        ):
-            subagent = active_registry.get_compiled(subagent_type)
-            inject_ask_parent = True
-        else:
-            # Build available list from both sources
-            available_names = list(compiled.keys())
-            if active_registry is not None and hasattr(active_registry, "list_agents"):
+        @toolset.tool(description=task_description)
+        async def task(
+            ctx: RunContext[SubAgentDepsProtocol],
+            description: str,
+            subagent_type: str,
+            mode: ExecutionMode = "sync",
+            priority: TaskPriority = TaskPriority.NORMAL,
+            complexity: Literal["simple", "moderate", "complex"] | None = None,
+            requires_user_context: bool = False,
+            may_need_clarification: bool = False,
+        ) -> str:
+            """Delegate a task to a specialized subagent.
+
+            Args:
+                ctx: The run context with dependencies.
+                description: Detailed description of the task to perform.
+                subagent_type: Name of the subagent to use.
+                mode: Execution mode - "sync" (blocking), "async" (background), or "auto".
+                priority: Task priority level (for async tasks).
+                complexity: Override complexity estimate ("simple", "moderate", "complex").
+                requires_user_context: Whether task needs ongoing user interaction.
+                may_need_clarification: Whether task might need clarifying questions.
+            """
+            # Validate subagent_type — check static compiled dict first, then dynamic registry
+            if subagent_type in compiled:
+                subagent = compiled[subagent_type]
+                inject_ask_parent = False
+            elif active_registry.get_compiled(subagent_type):
+                subagent = active_registry.get_compiled(subagent_type)
+                inject_ask_parent = True
+            else:
+                available_names = list(compiled.keys())
                 available_names.extend(active_registry.list_agents())
-            available = ", ".join(available_names)
-            return f"Error: Unknown subagent '{subagent_type}'. Available: {available}"
+                available = ", ".join(available_names)
+                return f"Error: Unknown subagent '{subagent_type}'. Available: {available}"
 
-        return await _execute_compiled_subagent(
-            ctx,
-            subagent,
-            description,
-            mode=mode,
-            priority=priority,
-            complexity=complexity,
-            requires_user_context=requires_user_context,
-            may_need_clarification=may_need_clarification,
-            max_nesting_depth=max_nesting_depth,
-            toolsets_factory=toolsets_factory,
-            ask_user=ask_user,
-            usage_limits=usage_limits,
-            task_manager=task_manager,
-            message_bus=message_bus,
-            inject_ask_parent=inject_ask_parent,
-        )
+            return await _execute_compiled_subagent(
+                ctx,
+                subagent,
+                description,
+                mode=mode,
+                priority=priority,
+                complexity=complexity,
+                requires_user_context=requires_user_context,
+                may_need_clarification=may_need_clarification,
+                max_nesting_depth=max_nesting_depth,
+                toolsets_factory=toolsets_factory,
+                ask_user=ask_user,
+                usage_limits=usage_limits,
+                task_manager=task_manager,
+                message_bus=message_bus,
+                inject_ask_parent=inject_ask_parent,
+            )
 
-    if delegation_configuration != "default":
+    if expose_delegate:
         delegate_description = _descs.get(
             "delegate",
             DELEGATE_TOOL_DESCRIPTION.rstrip()
@@ -600,7 +620,7 @@ def create_subagent_toolset(  # noqa: C901
             agent_description = description[:120] or "Ephemeral specialist"
             actual_model = model or default_model
 
-            agent, config, error = build_dynamic_agent(
+            result = build_dynamic_agent(
                 ctx,
                 name=agent_name,
                 description=agent_description,
@@ -613,10 +633,9 @@ def create_subagent_toolset(  # noqa: C901
                 capabilities_map=capabilities_map,
                 default_agent_factory=default_agent_factory,
             )
-            if error is not None:
-                return error
-            if config is None or agent is None:
-                return "Error creating agent"
+            if isinstance(result, str):
+                return result
+            agent, config = result
 
             subagent = CompiledSubAgent(
                 name=agent_name,
@@ -898,9 +917,6 @@ def create_subagent_toolset(  # noqa: C901
         return totals
 
     toolset.get_total_usage = get_total_usage  # type: ignore[attr-defined]
-
-    if delegation_configuration == "oneshot_only":
-        toolset.tools.pop("task")
 
     return toolset
 

--- a/src/subagents_pydantic_ai/toolset.py
+++ b/src/subagents_pydantic_ai/toolset.py
@@ -33,11 +33,13 @@ from subagents_pydantic_ai.prompts import (
     get_task_instructions_prompt,
 )
 from subagents_pydantic_ai.protocols import SubAgentDepsProtocol
+from subagents_pydantic_ai.registry import DynamicAgentRegistry
 from subagents_pydantic_ai.retry import RetryConfig, run_with_retry
 from subagents_pydantic_ai.types import (
     AgentMessage,
     AskUserCallback,
     CompiledSubAgent,
+    DelegationConfiguration,
     ExecutionMode,
     MessageType,
     SubAgentConfig,
@@ -326,18 +328,19 @@ def create_subagent_toolset(  # noqa: C901
     descriptions: dict[str, str] | None = None,
     ask_user: AskUserCallback | None = None,
     usage_limits: UsageLimits | UsageLimitsFactory | None = None,
-    oneshot_delegation: bool = False,
+    delegation_configuration: DelegationConfiguration = "default",
     allowed_models: list[str] | None = None,
     capabilities_map: dict[str, CapabilityFactory] | None = None,
     default_agent_factory: Any | None = None,
+    max_agents: int = 10,
 ) -> FunctionToolset[Any]:
     """Create a toolset for delegating tasks to subagents.
 
     This is the main entry point for using the subagent system. It creates
     a toolset with tools for:
-    - `task`: Delegate a task to a subagent (sync or async)
-    - `delegate`: Create and run an ephemeral specialist in one call (when
-      `oneshot_delegation=True`)
+    - `create_agent`: Create a reusable, registry-backed specialist
+    - `task`: Delegate a task to a configured or registry-backed specialist
+    - `delegate`: Create and run an ephemeral specialist in one call
     - `check_task`: Check status of an async task
     - `answer_subagent`: Answer a question from a subagent
     - `list_active_tasks`: List all running background tasks
@@ -371,13 +374,17 @@ def create_subagent_toolset(  # noqa: C901
             context and selected subagent config. A factory may return `None`
             to run that task without explicit limits. Limits are honoured on
             every retry attempt as well.
-        oneshot_delegation: When True, expose a `delegate` tool that creates an
-            ephemeral specialist and runs its task in one call. The specialist
-            is not registered in the dynamic agent registry.
-        allowed_models: Optional model allow-list for one-shot specialists.
-        capabilities_map: Optional capability factories for one-shot specialists.
-        default_agent_factory: Optional custom agent factory for one-shot
-            specialists. When set, `capabilities` on `delegate` are rejected.
+        delegation_configuration: Controls the delegation entry points:
+            `"default"` exposes `create_agent` and `task`;
+            `"persisted_and_oneshot"` also exposes `delegate`;
+            `"oneshot_only"` exposes only `delegate`.
+            Async task lifecycle tools remain available in every mode.
+        allowed_models: Optional model allow-list for dynamically created specialists.
+        capabilities_map: Optional capability factories for dynamically created
+            specialists.
+        default_agent_factory: Optional custom agent factory for dynamically
+            created specialists. When set, requested `capabilities` are rejected.
+        max_agents: Maximum number of persistent dynamic agents.
 
     Returns:
         FunctionToolset configured with subagent management tools.
@@ -403,7 +410,18 @@ def create_subagent_toolset(  # noqa: C901
         agent = Agent("openai:gpt-4.1", toolsets=[toolset])
         ```
     """
+    valid_configurations = {"default", "persisted_and_oneshot", "oneshot_only"}
+    if delegation_configuration not in valid_configurations:
+        valid = ", ".join(sorted(valid_configurations))
+        raise ValueError(
+            f"Invalid delegation_configuration '{delegation_configuration}'. "
+            f"Expected one of: {valid}"
+        )
+
     _descs = descriptions or {}
+    active_registry: Any = (
+        registry if registry is not None else DynamicAgentRegistry(max_agents=max_agents)
+    )
 
     # Build subagent configs
     configs: list[SubAgentConfig] = list(subagents) if subagents else []
@@ -427,6 +445,72 @@ def create_subagent_toolset(  # noqa: C901
     )
 
     toolset: FunctionToolset[Any] = FunctionToolset(id=id or "subagents")
+
+    models_desc = (
+        f"Allowed models: {', '.join(allowed_models)}" if allowed_models else "Any model is allowed"
+    )
+    caps_desc = (
+        f"Available capabilities: {', '.join(capabilities_map.keys())}"
+        if capabilities_map
+        else "No predefined capabilities available"
+    )
+
+    if delegation_configuration != "oneshot_only":
+        create_agent_description = _descs.get(
+            "create_agent",
+            "Create a reusable specialized agent at runtime. The agent is stored "
+            "in the registry and can be used repeatedly with the task tool.\n\n"
+            f"{models_desc}\n{caps_desc}\n\n"
+            f"Default model when none is given: {default_model}.",
+        )
+
+        @toolset.tool(description=create_agent_description)
+        async def create_agent(
+            ctx: RunContext[SubAgentDepsProtocol],
+            name: str,
+            description: str,
+            instructions: str,
+            model: str | None = None,
+            capabilities: list[str] | None = None,
+            can_ask_questions: bool = True,
+        ) -> str:
+            """Create and register a reusable specialized agent."""
+            if active_registry.exists(name):
+                return f"Error: Agent '{name}' already exists"
+
+            actual_model = model or default_model
+            agent, config, error = build_dynamic_agent(
+                ctx,
+                name=name,
+                description=description,
+                instructions=instructions,
+                model=actual_model,
+                can_ask_questions=can_ask_questions,
+                capabilities=capabilities,
+                allowed_models=allowed_models,
+                toolsets_factory=None,
+                capabilities_map=capabilities_map,
+                default_agent_factory=default_agent_factory,
+            )
+            if error is not None:
+                return error
+            if config is None or agent is None:
+                return "Error creating agent"
+
+            try:
+                active_registry.register(config, agent)
+            except ValueError as exc:
+                return f"Error: {exc}"
+            except Exception as exc:
+                return f"Error creating agent: {exc}"
+
+            caps_info = f"\nCapabilities: {', '.join(capabilities)}" if capabilities else ""
+            return (
+                f"Agent '{name}' created successfully.\n"
+                f"Model: {actual_model}\n"
+                f"Description: {description}{caps_info}\n"
+                f"Use task(description, '{name}') to delegate tasks."
+            )
 
     @toolset.tool(description=task_description)
     async def task(
@@ -456,17 +540,17 @@ def create_subagent_toolset(  # noqa: C901
             subagent = compiled[subagent_type]
             inject_ask_parent = False
         elif (
-            registry is not None
-            and hasattr(registry, "get_compiled")
-            and registry.get_compiled(subagent_type)
+            active_registry is not None
+            and hasattr(active_registry, "get_compiled")
+            and active_registry.get_compiled(subagent_type)
         ):
-            subagent = registry.get_compiled(subagent_type)
+            subagent = active_registry.get_compiled(subagent_type)
             inject_ask_parent = True
         else:
             # Build available list from both sources
             available_names = list(compiled.keys())
-            if registry is not None and hasattr(registry, "list_agents"):
-                available_names.extend(registry.list_agents())
+            if active_registry is not None and hasattr(active_registry, "list_agents"):
+                available_names.extend(active_registry.list_agents())
             available = ", ".join(available_names)
             return f"Error: Unknown subagent '{subagent_type}'. Available: {available}"
 
@@ -488,17 +572,7 @@ def create_subagent_toolset(  # noqa: C901
             inject_ask_parent=inject_ask_parent,
         )
 
-    if oneshot_delegation:
-        models_desc = (
-            f"Allowed models: {', '.join(allowed_models)}"
-            if allowed_models
-            else "Any model is allowed"
-        )
-        caps_desc = (
-            f"Available capabilities: {', '.join(capabilities_map.keys())}"
-            if capabilities_map
-            else "No predefined capabilities available"
-        )
+    if delegation_configuration != "default":
         delegate_description = _descs.get(
             "delegate",
             DELEGATE_TOOL_DESCRIPTION.rstrip()
@@ -824,6 +898,9 @@ def create_subagent_toolset(  # noqa: C901
         return totals
 
     toolset.get_total_usage = get_total_usage  # type: ignore[attr-defined]
+
+    if delegation_configuration == "oneshot_only":
+        toolset.tools.pop("task")
 
     return toolset
 

--- a/src/subagents_pydantic_ai/toolset.py
+++ b/src/subagents_pydantic_ai/toolset.py
@@ -16,11 +16,13 @@ from pydantic_ai import Agent, RunContext, UsageLimits
 from pydantic_ai.models import Model
 from pydantic_ai.toolsets import FunctionToolset
 
+from subagents_pydantic_ai.dynamic_agent import CapabilityFactory, build_dynamic_agent
 from subagents_pydantic_ai.message_bus import InMemoryMessageBus, TaskManager
 from subagents_pydantic_ai.prompts import (
     ANSWER_SUBAGENT_DESCRIPTION,
     CHECK_TASK_DESCRIPTION,
     DEFAULT_GENERAL_PURPOSE_DESCRIPTION,
+    DELEGATE_TOOL_DESCRIPTION,
     HARD_CANCEL_TASK_DESCRIPTION,
     LIST_ACTIVE_TASKS_DESCRIPTION,
     SEND_MESSAGE_TO_SUBAGENT_DESCRIPTION,
@@ -235,6 +237,84 @@ def _create_ask_parent_toolset() -> FunctionToolset[Any]:
     return toolset
 
 
+async def _execute_compiled_subagent(
+    ctx: RunContext[SubAgentDepsProtocol],
+    subagent: CompiledSubAgent,
+    description: str,
+    *,
+    mode: ExecutionMode,
+    priority: TaskPriority,
+    complexity: Literal["simple", "moderate", "complex"] | None,
+    requires_user_context: bool,
+    may_need_clarification: bool,
+    max_nesting_depth: int,
+    toolsets_factory: ToolsetFactory | None,
+    ask_user: AskUserCallback | None,
+    usage_limits: UsageLimits | UsageLimitsFactory | None,
+    task_manager: TaskManager,
+    message_bus: InMemoryMessageBus,
+    inject_ask_parent: bool = False,
+    task_id: str | None = None,
+) -> str:
+    """Run a compiled subagent synchronously or asynchronously."""
+    config = subagent.config
+    agent = subagent.agent
+
+    if agent is None:
+        return f"Error: Subagent '{subagent.name}' is not properly initialized"
+
+    resolved_usage_limits = usage_limits(ctx, config) if callable(usage_limits) else usage_limits
+
+    parent_deps = ctx.deps
+    subagent_deps = parent_deps.clone_for_subagent(max_nesting_depth - 1)
+
+    runtime_toolsets: list[Any] | None = None
+    if toolsets_factory or inject_ask_parent:
+        runtime_toolsets = []
+        if inject_ask_parent and config.get("can_ask_questions", True):
+            runtime_toolsets.append(_create_ask_parent_toolset())
+        if toolsets_factory:
+            runtime_toolsets.extend(toolsets_factory(subagent_deps))
+
+    actual_task_id = task_id or str(uuid.uuid4())[:8]
+
+    if mode == "auto":
+        characteristics = TaskCharacteristics(
+            estimated_complexity=complexity or config.get("typical_complexity", "moderate"),
+            requires_user_context=requires_user_context
+            or config.get("typically_needs_context", False),
+            may_need_clarification=may_need_clarification,
+        )
+        resolved_mode = decide_execution_mode(characteristics, config)
+    else:
+        resolved_mode = mode
+
+    if resolved_mode == "sync":
+        return await _run_sync(
+            agent=agent,
+            config=config,
+            description=description,
+            deps=subagent_deps,
+            task_id=actual_task_id,
+            extra_toolsets=runtime_toolsets,
+            ask_user=ask_user,
+            usage_limits=resolved_usage_limits,
+        )
+
+    return await _run_async(
+        agent=agent,
+        config=config,
+        description=description,
+        deps=subagent_deps,
+        task_id=actual_task_id,
+        task_manager=task_manager,
+        message_bus=message_bus,
+        extra_toolsets=runtime_toolsets,
+        priority=priority,
+        usage_limits=resolved_usage_limits,
+    )
+
+
 def create_subagent_toolset(  # noqa: C901
     subagents: list[SubAgentConfig] | None = None,
     default_model: str | Model = "openai:gpt-4.1",
@@ -246,12 +326,18 @@ def create_subagent_toolset(  # noqa: C901
     descriptions: dict[str, str] | None = None,
     ask_user: AskUserCallback | None = None,
     usage_limits: UsageLimits | UsageLimitsFactory | None = None,
+    oneshot_delegation: bool = False,
+    allowed_models: list[str] | None = None,
+    capabilities_map: dict[str, CapabilityFactory] | None = None,
+    default_agent_factory: Any | None = None,
 ) -> FunctionToolset[Any]:
     """Create a toolset for delegating tasks to subagents.
 
     This is the main entry point for using the subagent system. It creates
     a toolset with tools for:
     - `task`: Delegate a task to a subagent (sync or async)
+    - `delegate`: Create and run an ephemeral specialist in one call (when
+      `oneshot_delegation=True`)
     - `check_task`: Check status of an async task
     - `answer_subagent`: Answer a question from a subagent
     - `list_active_tasks`: List all running background tasks
@@ -285,6 +371,13 @@ def create_subagent_toolset(  # noqa: C901
             context and selected subagent config. A factory may return `None`
             to run that task without explicit limits. Limits are honoured on
             every retry attempt as well.
+        oneshot_delegation: When True, expose a `delegate` tool that creates an
+            ephemeral specialist and runs its task in one call. The specialist
+            is not registered in the dynamic agent registry.
+        allowed_models: Optional model allow-list for one-shot specialists.
+        capabilities_map: Optional capability factories for one-shot specialists.
+        default_agent_factory: Optional custom agent factory for one-shot
+            specialists. When set, `capabilities` on `delegate` are rejected.
 
     Returns:
         FunctionToolset configured with subagent management tools.
@@ -361,12 +454,14 @@ def create_subagent_toolset(  # noqa: C901
         # Validate subagent_type — check static compiled dict first, then dynamic registry
         if subagent_type in compiled:
             subagent = compiled[subagent_type]
+            inject_ask_parent = False
         elif (
             registry is not None
             and hasattr(registry, "get_compiled")
             and registry.get_compiled(subagent_type)
         ):
             subagent = registry.get_compiled(subagent_type)
+            inject_ask_parent = True
         else:
             # Build available list from both sources
             available_names = list(compiled.keys())
@@ -375,61 +470,104 @@ def create_subagent_toolset(  # noqa: C901
             available = ", ".join(available_names)
             return f"Error: Unknown subagent '{subagent_type}'. Available: {available}"
 
-        config = subagent.config
-        agent = subagent.agent
-
-        if agent is None:
-            return f"Error: Subagent '{subagent_type}' is not properly initialized"
-
-        resolved_usage_limits = (
-            usage_limits(ctx, config) if callable(usage_limits) else usage_limits
+        return await _execute_compiled_subagent(
+            ctx,
+            subagent,
+            description,
+            mode=mode,
+            priority=priority,
+            complexity=complexity,
+            requires_user_context=requires_user_context,
+            may_need_clarification=may_need_clarification,
+            max_nesting_depth=max_nesting_depth,
+            toolsets_factory=toolsets_factory,
+            ask_user=ask_user,
+            usage_limits=usage_limits,
+            task_manager=task_manager,
+            message_bus=message_bus,
+            inject_ask_parent=inject_ask_parent,
         )
 
-        # Create deps for subagent
-        parent_deps = ctx.deps
-        subagent_deps = parent_deps.clone_for_subagent(max_nesting_depth - 1)
+    if oneshot_delegation:
+        models_desc = (
+            f"Allowed models: {', '.join(allowed_models)}"
+            if allowed_models
+            else "Any model is allowed"
+        )
+        caps_desc = (
+            f"Available capabilities: {', '.join(capabilities_map.keys())}"
+            if capabilities_map
+            else "No predefined capabilities available"
+        )
+        delegate_description = _descs.get(
+            "delegate",
+            DELEGATE_TOOL_DESCRIPTION.rstrip()
+            + f"\n\n{models_desc}\n{caps_desc}\n\n"
+            + f"Default model when none is given: {default_model}.",
+        )
 
-        # Build runtime toolsets from factory if provided
-        runtime_toolsets = toolsets_factory(subagent_deps) if toolsets_factory else None
+        @toolset.tool(description=delegate_description)
+        async def delegate(
+            ctx: RunContext[SubAgentDepsProtocol],
+            description: str,
+            instructions: str,
+            model: str | None = None,
+            capabilities: list[str] | None = None,
+            can_ask_questions: bool = True,
+            mode: ExecutionMode = "sync",
+            priority: TaskPriority = TaskPriority.NORMAL,
+            complexity: Literal["simple", "moderate", "complex"] | None = None,
+            requires_user_context: bool = False,
+            may_need_clarification: bool = False,
+        ) -> str:
+            """Create an ephemeral specialist and delegate a task in one call."""
+            task_id = str(uuid.uuid4())[:8]
+            agent_name = f"oneshot-{task_id}"
+            agent_description = description[:120] or "Ephemeral specialist"
+            actual_model = model or default_model
 
-        # Generate task ID
-        task_id = str(uuid.uuid4())[:8]
+            agent, config, error = build_dynamic_agent(
+                ctx,
+                name=agent_name,
+                description=agent_description,
+                instructions=instructions,
+                model=actual_model,
+                can_ask_questions=can_ask_questions,
+                capabilities=capabilities,
+                allowed_models=allowed_models,
+                toolsets_factory=None,
+                capabilities_map=capabilities_map,
+                default_agent_factory=default_agent_factory,
+            )
+            if error is not None:
+                return error
+            if config is None or agent is None:
+                return "Error creating agent"
 
-        # Resolve mode if "auto"
-        if mode == "auto":
-            characteristics = TaskCharacteristics(
-                estimated_complexity=complexity or config.get("typical_complexity", "moderate"),
-                requires_user_context=requires_user_context
-                or config.get("typically_needs_context", False),
+            subagent = CompiledSubAgent(
+                name=agent_name,
+                description=agent_description,
+                agent=agent,
+                config=config,
+            )
+
+            return await _execute_compiled_subagent(
+                ctx,
+                subagent,
+                description,
+                mode=mode,
+                priority=priority,
+                complexity=complexity,
+                requires_user_context=requires_user_context,
                 may_need_clarification=may_need_clarification,
-            )
-            resolved_mode = decide_execution_mode(characteristics, config)
-        else:
-            resolved_mode = mode
-
-        if resolved_mode == "sync":
-            return await _run_sync(
-                agent=agent,
-                config=config,
-                description=description,
-                deps=subagent_deps,
-                task_id=task_id,
-                extra_toolsets=runtime_toolsets,
+                max_nesting_depth=max_nesting_depth,
+                toolsets_factory=toolsets_factory,
                 ask_user=ask_user,
-                usage_limits=resolved_usage_limits,
-            )
-        else:
-            return await _run_async(
-                agent=agent,
-                config=config,
-                description=description,
-                deps=subagent_deps,
-                task_id=task_id,
+                usage_limits=usage_limits,
                 task_manager=task_manager,
                 message_bus=message_bus,
-                extra_toolsets=runtime_toolsets,
-                priority=priority,
-                usage_limits=resolved_usage_limits,
+                inject_ask_parent=True,
+                task_id=task_id,
             )
 
     @toolset.tool(description=_descs.get("check_task", CHECK_TASK_DESCRIPTION))

--- a/src/subagents_pydantic_ai/toolset.py
+++ b/src/subagents_pydantic_ai/toolset.py
@@ -20,7 +20,11 @@ from pydantic_ai import Agent, RunContext, UsageLimits
 from pydantic_ai.models import Model
 from pydantic_ai.toolsets import FunctionToolset
 
-from subagents_pydantic_ai.dynamic_agent import CapabilityFactory, build_dynamic_agent
+from subagents_pydantic_ai.dynamic_agent import (
+    AgentFactory,
+    CapabilityFactory,
+    build_dynamic_agent,
+)
 from subagents_pydantic_ai.message_bus import InMemoryMessageBus, TaskManager
 from subagents_pydantic_ai.prompts import (
     ANSWER_SUBAGENT_DESCRIPTION,
@@ -395,14 +399,14 @@ def create_subagent_toolset(  # noqa: C901
     include_general_purpose: bool = True,
     max_nesting_depth: int = 0,
     id: str | None = None,
-    registry: Any | None = None,
+    registry: DynamicAgentRegistry | None = None,
     descriptions: dict[str, str] | None = None,
     ask_user: AskUserCallback | None = None,
     usage_limits: UsageLimits | UsageLimitsFactory | None = None,
     delegation_configuration: DelegationConfiguration = "default",
     allowed_models: list[str] | None = None,
     capabilities_map: dict[str, CapabilityFactory] | None = None,
-    default_agent_factory: Any | None = None,
+    default_agent_factory: AgentFactory | None = None,
     max_agents: int = 10,
     max_chat_traces: int = 100,
     max_task_handles: int = 500,
@@ -456,6 +460,13 @@ def create_subagent_toolset(  # noqa: C901
             Async task lifecycle tools remain available in every mode.
             Custom factories that already attach `ask_parent` should not do so;
             the toolset injects it at run time for registry-backed agents.
+            A mode that hides a tool rejects that tool's configuration rather
+            than ignoring it — see `Raises`.
+            `"persisted"` and `"persisted_and_oneshot"` expose a `create_agent`
+            tool of their own, so they cannot be combined with
+            `create_agent_factory_toolset` on one agent (pydantic-ai rejects the
+            duplicate tool name). Use `"default"` and let the factory toolset own
+            agent creation when you also want its `remove_agent`.
         allowed_models: Optional model allow-list for dynamically created specialists.
         capabilities_map: Optional capability factories for dynamically created
             specialists.
@@ -463,7 +474,9 @@ def create_subagent_toolset(  # noqa: C901
             created specialists. When set, requested `capabilities` are rejected.
             Do not attach an `ask_parent` toolset in the factory; the toolset
             injects it at run time when needed.
-        max_agents: Maximum number of persistent dynamic agents.
+        max_agents: Maximum number of persistent dynamic agents, applied to the
+            registry this toolset creates for `create_agent`. Ignored when
+            `registry` is passed — that registry keeps its own `max_agents`.
         max_chat_traces: Maximum number of chat traces (subagent conversations)
             whose message history is kept in memory for continuation via
             `chat_trace_id`. Least-recently-used traces are evicted past this
@@ -484,9 +497,13 @@ def create_subagent_toolset(  # noqa: C901
         FunctionToolset configured with subagent management tools.
 
     Raises:
-        ValueError: If `max_result_chars` is negative, or
-            `delegation_configuration` is invalid, or
-            `oneshot_only` is combined with non-empty `subagents`.
+        ValueError: If `max_result_chars` is negative; if
+            `delegation_configuration` is invalid; if `"oneshot_only"` is
+            combined with `subagents` or a `registry`, neither of which is
+            reachable without `task`; or if a mode exposing neither
+            `create_agent` nor `delegate` is given `allowed_models`,
+            `capabilities_map`, or `default_agent_factory`, which only those
+            tools consult.
 
     Example:
         ```python
@@ -522,24 +539,63 @@ def create_subagent_toolset(  # noqa: C901
             f"Expected one of: {valid}"
         )
 
-    if delegation_configuration == "oneshot_only" and subagents:
-        raise ValueError(
-            "delegation_configuration='oneshot_only' cannot be combined with "
-            "non-empty subagents; configured subagents would be unreachable. "
-            "Omit subagents, or use a mode that exposes the task tool."
-        )
+    expose_create_agent = delegation_configuration in {
+        "persisted",
+        "persisted_and_oneshot",
+    }
+    expose_task = delegation_configuration != "oneshot_only"
+    expose_delegate = delegation_configuration in {
+        "persisted_and_oneshot",
+        "oneshot_only",
+    }
+
+    # Hiding a tool also hides everything only that tool reads, so configuration
+    # for a hidden tool can never take effect. Rejecting it here surfaces the
+    # contradiction at construction, where the caller can still see their own
+    # arguments; dropping it silently only shows up as a subagent that ignores
+    # an allow-list, or a capability the model is never offered.
+    if not expose_task:
+        if subagents:
+            raise ValueError(
+                f"delegation_configuration={delegation_configuration!r} cannot be combined "
+                "with non-empty subagents; configured subagents would be unreachable "
+                "without the task tool. Omit subagents, or use a mode that exposes task."
+            )
+        if registry is not None:
+            raise ValueError(
+                f"delegation_configuration={delegation_configuration!r} cannot be combined "
+                "with a registry; registry-backed agents are only reachable through the "
+                "task tool. Omit registry, or use a mode that exposes task."
+            )
+
+    if not expose_create_agent and not expose_delegate:
+        unreachable = [
+            name
+            for name, value in (
+                ("allowed_models", allowed_models),
+                ("capabilities_map", capabilities_map),
+                ("default_agent_factory", default_agent_factory),
+            )
+            if value is not None
+        ]
+        if unreachable:
+            raise ValueError(
+                f"delegation_configuration={delegation_configuration!r} exposes no "
+                f"dynamic-agent tool, so {', '.join(unreachable)} would be ignored. "
+                "Use 'persisted', 'persisted_and_oneshot', or 'oneshot_only'."
+            )
 
     if max_result_chars is not None and max_result_chars < 0:
         raise ValueError(f"max_result_chars must be >= 0 or None, got {max_result_chars}")
 
     _descs = descriptions or {}
-    active_registry: Any = (
+    active_registry = (
         registry if registry is not None else DynamicAgentRegistry(max_agents=max_agents)
     )
 
     # Build subagent configs
     configs: list[SubAgentConfig] = list(subagents) if subagents else []
-    if include_general_purpose and delegation_configuration != "oneshot_only":
+    if include_general_purpose and expose_task:
         configs.append(_create_general_purpose_config())
 
     # Compile subagents
@@ -596,16 +652,6 @@ def create_subagent_toolset(  # noqa: C901
         else "No predefined capabilities available"
     )
 
-    expose_create_agent = delegation_configuration in {
-        "persisted",
-        "persisted_and_oneshot",
-    }
-    expose_task = delegation_configuration != "oneshot_only"
-    expose_delegate = delegation_configuration in {
-        "persisted_and_oneshot",
-        "oneshot_only",
-    }
-
     async def execute_compiled_subagent(
         ctx: RunContext[SubAgentDepsProtocol],
         subagent: CompiledSubAgent,
@@ -619,8 +665,16 @@ def create_subagent_toolset(  # noqa: C901
         inject_ask_parent: bool = False,
         task_id: str | None = None,
         chat_trace_id: str | None = None,
+        persist_chat_trace: bool = True,
     ) -> str:
-        """Run a compiled subagent with chat-trace and observability support."""
+        """Run a compiled subagent with chat-trace and observability support.
+
+        `persist_chat_trace` must be `False` for a subagent the orchestrator
+        cannot address by name later — a one-shot specialist. A chat trace is
+        only worth handing out if `task` can resolve the subagent it belongs to,
+        and storing one costs a slot in the `max_chat_traces` LRU that a
+        continuable conversation would otherwise keep.
+        """
         config = subagent.config
         agent = subagent.agent
 
@@ -668,6 +722,12 @@ def create_subagent_toolset(  # noqa: C901
             while len(message_history_store) > max_chat_traces:
                 message_history_store.popitem(last=False)
 
+        # A one-shot run exposes no chat trace, so it neither stores history nor
+        # reports an id: `handle.chat_trace_id` stays `None` and check_task /
+        # wait_tasks skip it for the same reason the returned text does.
+        on_history = save_message_history if persist_chat_trace else None
+        reported_chat_trace_id = effective_chat_trace_id if persist_chat_trace else None
+
         evict_finished_handles()
 
         if mode == "auto":
@@ -688,7 +748,7 @@ def create_subagent_toolset(  # noqa: C901
                 description=description,
                 status=TaskStatus.RUNNING,
                 priority=priority,
-                chat_trace_id=effective_chat_trace_id,
+                chat_trace_id=reported_chat_trace_id,
                 started_at=datetime.now(),
             )
             task_manager.handles[actual_task_id] = handle
@@ -705,11 +765,13 @@ def create_subagent_toolset(  # noqa: C901
                     usage_limits=resolved_usage_limits,
                     handle=handle,
                     message_history=message_history,
-                    on_message_history=save_message_history,
+                    on_message_history=on_history,
                 )
             finally:
                 active_chat_traces.discard(chat_trace_key)
-            if handle.status != TaskStatus.FAILED or chat_trace_key in message_history_store:
+            if persist_chat_trace and (
+                handle.status != TaskStatus.FAILED or chat_trace_key in message_history_store
+            ):
                 return _format_chat_trace_result(result, effective_chat_trace_id)
             return result
 
@@ -726,9 +788,9 @@ def create_subagent_toolset(  # noqa: C901
                 extra_toolsets=runtime_toolsets,
                 priority=priority,
                 usage_limits=resolved_usage_limits,
-                chat_trace_id=effective_chat_trace_id,
+                chat_trace_id=reported_chat_trace_id,
                 message_history=message_history,
-                on_message_history=save_message_history,
+                on_message_history=on_history,
                 on_run_finished=lambda: active_chat_traces.discard(chat_trace_key),
             )
         except BaseException:
@@ -821,8 +883,8 @@ def create_subagent_toolset(  # noqa: C901
             if subagent_type in compiled:
                 subagent = compiled[subagent_type]
                 inject_ask_parent = False
-            elif active_registry.get_compiled(subagent_type):
-                subagent = active_registry.get_compiled(subagent_type)
+            elif (registry_subagent := active_registry.get_compiled(subagent_type)) is not None:
+                subagent = registry_subagent
                 inject_ask_parent = True
             else:
                 available_names = list(compiled.keys())
@@ -906,6 +968,7 @@ def create_subagent_toolset(  # noqa: C901
                 may_need_clarification=may_need_clarification,
                 inject_ask_parent=True,
                 task_id=task_id,
+                persist_chat_trace=False,
             )
 
     @toolset.tool(description=_descs.get("check_task", CHECK_TASK_DESCRIPTION))

--- a/src/subagents_pydantic_ai/types.py
+++ b/src/subagents_pydantic_ai/types.py
@@ -80,10 +80,16 @@ ExecutionMode = Literal["sync", "async", "auto"]
 - auto: Automatically decide based on task characteristics
 """
 
-DelegationConfiguration = Literal["default", "persisted_and_oneshot", "oneshot_only"]
+DelegationConfiguration = Literal[
+    "default",
+    "persisted",
+    "persisted_and_oneshot",
+    "oneshot_only",
+]
 """Controls which delegation entry-point tools are exposed.
 
-- default: Expose ``create_agent`` and ``task``
+- default: Expose ``task`` only (backward-compatible with existing users)
+- persisted: Expose ``create_agent`` and ``task``
 - persisted_and_oneshot: Expose ``create_agent``, ``task``, and ``delegate``
 - oneshot_only: Expose only ``delegate`` as the delegation entry point
 """

--- a/src/subagents_pydantic_ai/types.py
+++ b/src/subagents_pydantic_ai/types.py
@@ -80,6 +80,14 @@ ExecutionMode = Literal["sync", "async", "auto"]
 - auto: Automatically decide based on task characteristics
 """
 
+DelegationConfiguration = Literal["default", "persisted_and_oneshot", "oneshot_only"]
+"""Controls which delegation entry-point tools are exposed.
+
+- default: Expose ``create_agent`` and ``task``
+- persisted_and_oneshot: Expose ``create_agent``, ``task``, and ``delegate``
+- oneshot_only: Expose only ``delegate`` as the delegation entry point
+"""
+
 
 class TaskPriority(str, Enum):
     """Priority levels for background tasks."""

--- a/tests/test_capability.py
+++ b/tests/test_capability.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass, field
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -11,6 +13,14 @@ from pydantic_ai.models.test import TestModel
 from subagents_pydantic_ai import SubAgentCapability, SubAgentConfig
 
 _MODEL = TestModel()
+
+
+@dataclass
+class MockDeps:
+    subagents: dict[str, Any] = field(default_factory=dict)
+
+    def clone_for_subagent(self, max_depth: int = 0) -> MockDeps:
+        return MockDeps(subagents={} if max_depth <= 0 else self.subagents.copy())
 
 
 def _cap(**kwargs):
@@ -105,22 +115,38 @@ class TestSubAgentCapability:
         assert cap.usage_limits is usage_limits
         assert create_toolset.call_args.kwargs["usage_limits"] is usage_limits
 
-    def test_oneshot_delegation_forwarded_to_toolset(self):
+    def test_delegation_configuration_forwarded_to_toolset(self):
         with patch("subagents_pydantic_ai.capability.create_subagent_toolset") as create_toolset:
             cap = _cap(
-                oneshot_delegation=True,
+                delegation_configuration="persisted_and_oneshot",
                 allowed_models=["openai:gpt-4.1"],
             )
 
-        assert cap.oneshot_delegation is True
-        assert create_toolset.call_args.kwargs["oneshot_delegation"] is True
+        assert cap.delegation_configuration == "persisted_and_oneshot"
+        assert (
+            create_toolset.call_args.kwargs["delegation_configuration"] == "persisted_and_oneshot"
+        )
         assert create_toolset.call_args.kwargs["allowed_models"] == ["openai:gpt-4.1"]
 
-    def test_delegate_tool_present_when_enabled(self):
-        cap = _cap(oneshot_delegation=True, include_general_purpose=False)
+    def test_delegate_tool_present_in_combined_mode(self):
+        cap = _cap(
+            delegation_configuration="persisted_and_oneshot",
+            include_general_purpose=False,
+        )
         toolset = cap.get_toolset()
         assert toolset is not None
         assert "delegate" in toolset.tools
+
+    def test_oneshot_only_instructions_reference_delegate(self):
+        cap = _cap(
+            delegation_configuration="oneshot_only",
+            include_general_purpose=False,
+        )
+        instructions_fn = cap.get_instructions()
+        ctx = type("FakeCtx", (), {"deps": None})()
+        result = instructions_fn(ctx)
+        assert "delegate" in result
+        assert "`task`" not in result
 
 
 class TestSubAgentCapabilityIntegration:
@@ -130,8 +156,8 @@ class TestSubAgentCapabilityIntegration:
     async def test_agent_with_capability(self):
         """Agent with SubAgentCapability can run successfully."""
         cap = _cap()
-        agent = Agent(_MODEL, capabilities=[cap])
-        result = await agent.run("Delegate a task")
+        agent = Agent(_MODEL, deps_type=MockDeps, capabilities=[cap])
+        result = await agent.run("Delegate a task", deps=MockDeps())
         assert result.output is not None
 
     @pytest.mark.anyio
@@ -145,8 +171,8 @@ class TestSubAgentCapabilityIntegration:
             ),
         ]
         cap = _cap(subagents=configs)
-        agent = Agent(_MODEL, capabilities=[cap])
-        result = await agent.run("Analyze something")
+        agent = Agent(_MODEL, deps_type=MockDeps, capabilities=[cap])
+        result = await agent.run("Analyze something", deps=MockDeps())
         assert result.output is not None
 
     @pytest.mark.anyio

--- a/tests/test_capability.py
+++ b/tests/test_capability.py
@@ -10,7 +10,7 @@ import pytest
 from pydantic_ai import Agent, UsageLimits
 from pydantic_ai.models.test import TestModel
 
-from subagents_pydantic_ai import SubAgentCapability, SubAgentConfig
+from subagents_pydantic_ai import DynamicAgentRegistry, SubAgentCapability, SubAgentConfig
 
 _MODEL = TestModel()
 
@@ -160,6 +160,18 @@ class TestSubAgentCapability:
                     )
                 ],
             )
+
+    def test_oneshot_only_rejects_registry(self):
+        with pytest.raises(ValueError, match="cannot be combined with a registry"):
+            _cap(
+                delegation_configuration="oneshot_only",
+                registry=DynamicAgentRegistry(),
+            )
+
+    def test_default_mode_rejects_dynamic_agent_config(self):
+        """The capability is the entry point most users configure, so it must reject too."""
+        with pytest.raises(ValueError, match="exposes no dynamic-agent tool"):
+            _cap(allowed_models=["openai:gpt-4.1"])
 
     def test_max_result_chars_defaults_to_2000(self):
         """The result preview budget defaults to 2000 characters."""

--- a/tests/test_capability.py
+++ b/tests/test_capability.py
@@ -148,6 +148,19 @@ class TestSubAgentCapability:
         assert "delegate" in result
         assert "`task`" not in result
 
+    def test_oneshot_only_rejects_configured_subagents(self):
+        with pytest.raises(ValueError, match="cannot be combined with"):
+            _cap(
+                delegation_configuration="oneshot_only",
+                subagents=[
+                    SubAgentConfig(
+                        name="researcher",
+                        description="Researches topics",
+                        instructions="Research.",
+                    )
+                ],
+            )
+
     def test_max_result_chars_defaults_to_2000(self):
         """The result preview budget defaults to 2000 characters."""
         with patch("subagents_pydantic_ai.capability.create_subagent_toolset") as create_toolset:

--- a/tests/test_capability.py
+++ b/tests/test_capability.py
@@ -105,6 +105,23 @@ class TestSubAgentCapability:
         assert cap.usage_limits is usage_limits
         assert create_toolset.call_args.kwargs["usage_limits"] is usage_limits
 
+    def test_oneshot_delegation_forwarded_to_toolset(self):
+        with patch("subagents_pydantic_ai.capability.create_subagent_toolset") as create_toolset:
+            cap = _cap(
+                oneshot_delegation=True,
+                allowed_models=["openai:gpt-4.1"],
+            )
+
+        assert cap.oneshot_delegation is True
+        assert create_toolset.call_args.kwargs["oneshot_delegation"] is True
+        assert create_toolset.call_args.kwargs["allowed_models"] == ["openai:gpt-4.1"]
+
+    def test_delegate_tool_present_when_enabled(self):
+        cap = _cap(oneshot_delegation=True, include_general_purpose=False)
+        toolset = cap.get_toolset()
+        assert toolset is not None
+        assert "delegate" in toolset.tools
+
 
 class TestSubAgentCapabilityIntegration:
     """Integration tests with real Agent."""

--- a/tests/test_dynamic_agent.py
+++ b/tests/test_dynamic_agent.py
@@ -42,7 +42,7 @@ class TestDynamicAgentValidation:
         assert validate_model("anthropic:claude", ["openai:gpt-4"]) is not None
 
     def test_validate_capabilities(self):
-        caps_map = {"filesystem": lambda deps: []}
+        caps_map: dict[str, Any] = {"filesystem": lambda deps: []}
         assert validate_capabilities(["filesystem"], caps_map) is None
         assert validate_capabilities(["missing"], caps_map) is not None
 
@@ -57,7 +57,7 @@ class TestBuildDynamicAgent:
         ctx = MockRunContext(deps=MockDeps())
         with patch("subagents_pydantic_ai.dynamic_agent.Agent") as mock_agent_class:
             mock_agent_class.return_value = MagicMock()
-            agent, config, error = build_dynamic_agent(
+            result = build_dynamic_agent(
                 ctx,
                 name="test-agent",
                 description="Test agent",
@@ -65,15 +65,15 @@ class TestBuildDynamicAgent:
                 model="openai:gpt-4.1",
             )
 
-        assert error is None
+        assert not isinstance(result, str)
+        agent, config = result
         assert agent is not None
-        assert config is not None
         assert config["name"] == "test-agent"
 
     @pytest.mark.asyncio
     async def test_build_disallowed_model(self):
         ctx = MockRunContext(deps=MockDeps())
-        agent, config, error = build_dynamic_agent(
+        result = build_dynamic_agent(
             ctx,
             name="test-agent",
             description="Test agent",
@@ -82,10 +82,8 @@ class TestBuildDynamicAgent:
             allowed_models=["openai:gpt-4.1"],
         )
 
-        assert agent is None
-        assert config is None
-        assert error is not None
-        assert "not allowed" in error
+        assert isinstance(result, str)
+        assert "not allowed" in result
 
     @pytest.mark.asyncio
     async def test_build_with_capabilities(self):
@@ -97,7 +95,7 @@ class TestBuildDynamicAgent:
 
         with patch("subagents_pydantic_ai.dynamic_agent.Agent") as mock_agent_class:
             mock_agent_class.return_value = MagicMock()
-            agent, config, error = build_dynamic_agent(
+            result = build_dynamic_agent(
                 ctx,
                 name="test-agent",
                 description="Test agent",
@@ -107,7 +105,8 @@ class TestBuildDynamicAgent:
                 capabilities_map={"filesystem": mock_capability_factory},
             )
 
-        assert error is None
+        assert not isinstance(result, str)
+        agent, _config = result
         assert agent is not None
         mock_agent_class.assert_called_once()
         assert mock_agent_class.call_args.kwargs.get("toolsets") is not None
@@ -117,7 +116,7 @@ class TestBuildDynamicAgent:
         ctx = MockRunContext(deps=MockDeps())
         factory = MagicMock(return_value=MagicMock())
 
-        agent, config, error = build_dynamic_agent(
+        result = build_dynamic_agent(
             ctx,
             name="test-agent",
             description="Test agent",
@@ -128,10 +127,8 @@ class TestBuildDynamicAgent:
             default_agent_factory=factory,
         )
 
-        assert agent is None
-        assert config is None
-        assert error is not None
-        assert "not supported" in error
+        assert isinstance(result, str)
+        assert "not supported" in result
         factory.assert_not_called()
 
     @pytest.mark.asyncio
@@ -139,7 +136,7 @@ class TestBuildDynamicAgent:
         ctx = MockRunContext(deps=MockDeps())
         with patch("subagents_pydantic_ai.dynamic_agent.Agent") as mock_agent_class:
             mock_agent_class.side_effect = ValueError("Invalid configuration")
-            agent, config, error = build_dynamic_agent(
+            result = build_dynamic_agent(
                 ctx,
                 name="test-agent",
                 description="Test agent",
@@ -147,17 +144,15 @@ class TestBuildDynamicAgent:
                 model="openai:gpt-4.1",
             )
 
-        assert agent is None
-        assert config is None
-        assert error is not None
-        assert "Invalid configuration" in error
+        assert isinstance(result, str)
+        assert "Invalid configuration" in result
 
     @pytest.mark.asyncio
     async def test_build_generic_exception(self):
         ctx = MockRunContext(deps=MockDeps())
         with patch("subagents_pydantic_ai.dynamic_agent.Agent") as mock_agent_class:
             mock_agent_class.side_effect = RuntimeError("Something went wrong")
-            agent, config, error = build_dynamic_agent(
+            result = build_dynamic_agent(
                 ctx,
                 name="test-agent",
                 description="Test agent",
@@ -165,7 +160,5 @@ class TestBuildDynamicAgent:
                 model="openai:gpt-4.1",
             )
 
-        assert agent is None
-        assert config is None
-        assert error is not None
-        assert "Error creating agent" in error
+        assert isinstance(result, str)
+        assert "Error creating agent" in result

--- a/tests/test_dynamic_agent.py
+++ b/tests/test_dynamic_agent.py
@@ -1,0 +1,171 @@
+"""Tests for dynamic agent helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pydantic_ai.toolsets import FunctionToolset
+
+from subagents_pydantic_ai.dynamic_agent import (
+    build_dynamic_agent,
+    validate_agent_name,
+    validate_capabilities,
+    validate_capabilities_with_factory,
+    validate_model,
+)
+
+
+@dataclass
+class MockDeps:
+    subagents: dict[str, Any] = field(default_factory=dict)
+
+    def clone_for_subagent(self, max_depth: int = 0) -> MockDeps:
+        return MockDeps(subagents={} if max_depth <= 0 else self.subagents.copy())
+
+
+@dataclass
+class MockRunContext:
+    deps: MockDeps
+
+
+class TestDynamicAgentValidation:
+    def test_validate_agent_name(self):
+        assert validate_agent_name("valid-agent") is None
+        assert validate_agent_name("") is not None
+        assert validate_agent_name("bad name") is not None
+
+    def test_validate_model(self):
+        assert validate_model("openai:gpt-4", ["openai:gpt-4"]) is None
+        assert validate_model("anthropic:claude", ["openai:gpt-4"]) is not None
+
+    def test_validate_capabilities(self):
+        caps_map = {"filesystem": lambda deps: []}
+        assert validate_capabilities(["filesystem"], caps_map) is None
+        assert validate_capabilities(["missing"], caps_map) is not None
+
+    def test_validate_capabilities_with_factory(self):
+        assert validate_capabilities_with_factory(["filesystem"], MagicMock()) is not None
+        assert validate_capabilities_with_factory(None, MagicMock()) is None
+
+
+class TestBuildDynamicAgent:
+    @pytest.mark.asyncio
+    async def test_build_success(self):
+        ctx = MockRunContext(deps=MockDeps())
+        with patch("subagents_pydantic_ai.dynamic_agent.Agent") as mock_agent_class:
+            mock_agent_class.return_value = MagicMock()
+            agent, config, error = build_dynamic_agent(
+                ctx,
+                name="test-agent",
+                description="Test agent",
+                instructions="Do testing",
+                model="openai:gpt-4.1",
+            )
+
+        assert error is None
+        assert agent is not None
+        assert config is not None
+        assert config["name"] == "test-agent"
+
+    @pytest.mark.asyncio
+    async def test_build_disallowed_model(self):
+        ctx = MockRunContext(deps=MockDeps())
+        agent, config, error = build_dynamic_agent(
+            ctx,
+            name="test-agent",
+            description="Test agent",
+            instructions="Do testing",
+            model="anthropic:claude",
+            allowed_models=["openai:gpt-4.1"],
+        )
+
+        assert agent is None
+        assert config is None
+        assert error is not None
+        assert "not allowed" in error
+
+    @pytest.mark.asyncio
+    async def test_build_with_capabilities(self):
+        ctx = MockRunContext(deps=MockDeps())
+
+        def mock_capability_factory(deps: MockDeps) -> list[FunctionToolset[Any]]:
+            toolset: FunctionToolset[Any] = FunctionToolset(id="mock_cap")
+            return [toolset]
+
+        with patch("subagents_pydantic_ai.dynamic_agent.Agent") as mock_agent_class:
+            mock_agent_class.return_value = MagicMock()
+            agent, config, error = build_dynamic_agent(
+                ctx,
+                name="test-agent",
+                description="Test agent",
+                instructions="Do testing",
+                model="openai:gpt-4.1",
+                capabilities=["filesystem"],
+                capabilities_map={"filesystem": mock_capability_factory},
+            )
+
+        assert error is None
+        assert agent is not None
+        mock_agent_class.assert_called_once()
+        assert mock_agent_class.call_args.kwargs.get("toolsets") is not None
+
+    @pytest.mark.asyncio
+    async def test_build_rejects_capabilities_with_custom_factory(self):
+        ctx = MockRunContext(deps=MockDeps())
+        factory = MagicMock(return_value=MagicMock())
+
+        agent, config, error = build_dynamic_agent(
+            ctx,
+            name="test-agent",
+            description="Test agent",
+            instructions="Do testing",
+            model="openai:gpt-4.1",
+            capabilities=["filesystem"],
+            capabilities_map={"filesystem": lambda deps: []},
+            default_agent_factory=factory,
+        )
+
+        assert agent is None
+        assert config is None
+        assert error is not None
+        assert "not supported" in error
+        factory.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_build_value_error(self):
+        ctx = MockRunContext(deps=MockDeps())
+        with patch("subagents_pydantic_ai.dynamic_agent.Agent") as mock_agent_class:
+            mock_agent_class.side_effect = ValueError("Invalid configuration")
+            agent, config, error = build_dynamic_agent(
+                ctx,
+                name="test-agent",
+                description="Test agent",
+                instructions="Do testing",
+                model="openai:gpt-4.1",
+            )
+
+        assert agent is None
+        assert config is None
+        assert error is not None
+        assert "Invalid configuration" in error
+
+    @pytest.mark.asyncio
+    async def test_build_generic_exception(self):
+        ctx = MockRunContext(deps=MockDeps())
+        with patch("subagents_pydantic_ai.dynamic_agent.Agent") as mock_agent_class:
+            mock_agent_class.side_effect = RuntimeError("Something went wrong")
+            agent, config, error = build_dynamic_agent(
+                ctx,
+                name="test-agent",
+                description="Test agent",
+                instructions="Do testing",
+                model="openai:gpt-4.1",
+            )
+
+        assert agent is None
+        assert config is None
+        assert error is not None
+        assert "Error creating agent" in error

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -66,7 +66,7 @@ class TestCreateAgentFactoryToolset:
 
         ctx = MockRunContext(deps=MockDeps())
 
-        with patch("subagents_pydantic_ai.factory.Agent") as mock_agent_class:
+        with patch("subagents_pydantic_ai.dynamic_agent.Agent") as mock_agent_class:
             mock_agent_class.return_value = MagicMock()
             result = await create_tool.function(
                 ctx,
@@ -112,7 +112,7 @@ class TestCreateAgentFactoryToolset:
 
         ctx = MockRunContext(deps=MockDeps())
 
-        with patch("subagents_pydantic_ai.factory.Agent") as mock_agent_class:
+        with patch("subagents_pydantic_ai.dynamic_agent.Agent") as mock_agent_class:
             mock_agent_class.return_value = MagicMock()
 
             # Create first agent
@@ -178,7 +178,7 @@ class TestCreateAgentFactoryToolset:
 
         ctx = MockRunContext(deps=MockDeps())
 
-        with patch("subagents_pydantic_ai.factory.Agent") as mock_agent_class:
+        with patch("subagents_pydantic_ai.dynamic_agent.Agent") as mock_agent_class:
             mock_agent = MagicMock()
             mock_agent_class.return_value = mock_agent
 
@@ -236,7 +236,7 @@ class TestCreateAgentFactoryToolset:
 
         ctx = MockRunContext(deps=MockDeps())
 
-        with patch("subagents_pydantic_ai.factory.Agent") as mock_agent_class:
+        with patch("subagents_pydantic_ai.dynamic_agent.Agent") as mock_agent_class:
             mock_agent = MagicMock()
             mock_agent_class.return_value = mock_agent
 
@@ -273,7 +273,7 @@ class TestCreateAgentFactoryToolset:
 
         ctx = MockRunContext(deps=MockDeps())
 
-        with patch("subagents_pydantic_ai.factory.Agent") as mock_agent_class:
+        with patch("subagents_pydantic_ai.dynamic_agent.Agent") as mock_agent_class:
             mock_agent_class.return_value = MagicMock()
 
             await create_tool.function(
@@ -304,7 +304,7 @@ class TestCreateAgentFactoryToolset:
 
         ctx = MockRunContext(deps=MockDeps())
 
-        with patch("subagents_pydantic_ai.factory.Agent") as mock_agent_class:
+        with patch("subagents_pydantic_ai.dynamic_agent.Agent") as mock_agent_class:
             mock_agent_class.return_value = MagicMock()
 
             # Create agent
@@ -342,7 +342,7 @@ class TestCreateAgentFactoryToolset:
 
         ctx = MockRunContext(deps=MockDeps())
 
-        with patch("subagents_pydantic_ai.factory.Agent") as mock_agent_class:
+        with patch("subagents_pydantic_ai.dynamic_agent.Agent") as mock_agent_class:
             mock_agent_class.return_value = MagicMock()
 
             # Create agent
@@ -383,7 +383,7 @@ class TestCreateAgentFactoryToolset:
 
         ctx = MockRunContext(deps=MockDeps())
 
-        with patch("subagents_pydantic_ai.factory.Agent") as mock_agent_class:
+        with patch("subagents_pydantic_ai.dynamic_agent.Agent") as mock_agent_class:
             mock_agent_class.return_value = MagicMock()
 
             # Create agent with long instructions
@@ -411,7 +411,7 @@ class TestCreateAgentFactoryToolset:
 
         ctx = MockRunContext(deps=MockDeps())
 
-        with patch("subagents_pydantic_ai.factory.Agent") as mock_agent_class:
+        with patch("subagents_pydantic_ai.dynamic_agent.Agent") as mock_agent_class:
             mock_agent_class.return_value = MagicMock()
 
             # Create first agent
@@ -441,7 +441,7 @@ class TestCreateAgentFactoryToolset:
 
         ctx = MockRunContext(deps=MockDeps())
 
-        with patch("subagents_pydantic_ai.factory.Agent") as mock_agent_class:
+        with patch("subagents_pydantic_ai.dynamic_agent.Agent") as mock_agent_class:
             mock_agent_class.side_effect = ValueError("Invalid configuration")
 
             result = await create_tool.function(
@@ -462,7 +462,7 @@ class TestCreateAgentFactoryToolset:
 
         ctx = MockRunContext(deps=MockDeps())
 
-        with patch("subagents_pydantic_ai.factory.Agent") as mock_agent_class:
+        with patch("subagents_pydantic_ai.dynamic_agent.Agent") as mock_agent_class:
             mock_agent_class.side_effect = RuntimeError("Something went wrong")
 
             result = await create_tool.function(

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from subagents_pydantic_ai import SubAgentConfig
 from subagents_pydantic_ai.prompts import (
     DEFAULT_GENERAL_PURPOSE_DESCRIPTION,
+    DELEGATE_TOOL_DESCRIPTION,
     DUAL_MODE_SYSTEM_PROMPT,
     SUBAGENT_SYSTEM_PROMPT,
     TASK_TOOL_DESCRIPTION,
@@ -38,6 +39,12 @@ class TestSystemPrompts:
         assert "sync" in TASK_TOOL_DESCRIPTION
         assert "async" in TASK_TOOL_DESCRIPTION
         assert "subagent_type" in TASK_TOOL_DESCRIPTION
+
+    def test_delegate_tool_description(self):
+        """Test DELEGATE_TOOL_DESCRIPTION has expected content."""
+        assert "ephemeral" in DELEGATE_TOOL_DESCRIPTION.lower()
+        assert "create_agent" in DELEGATE_TOOL_DESCRIPTION
+        assert "instructions" in DELEGATE_TOOL_DESCRIPTION
 
 
 class TestGetSubagentSystemPrompt:

--- a/tests/test_toolset.py
+++ b/tests/test_toolset.py
@@ -4028,7 +4028,9 @@ class TestDelegationConfiguration:
                 instructions="You are a data analyst.",
             )
 
-        assert result.startswith("oneshot result\n\nChat Trace ID: ")
+        # No chat trace: a one-shot specialist is unreachable from `task`, so an
+        # id the orchestrator cannot redeem would only invite a failed retry.
+        assert result == "oneshot result"
 
     @pytest.mark.asyncio
     async def test_delegate_does_not_register_agent(self, registry):
@@ -4049,7 +4051,7 @@ class TestDelegationConfiguration:
                 instructions="You are a worker.",
             )
 
-        assert result.startswith("oneshot result\n\nChat Trace ID: ")
+        assert result == "oneshot result"
         assert registry.count() == 0
 
     @pytest.mark.asyncio
@@ -4079,7 +4081,7 @@ class TestDelegationConfiguration:
                 instructions="You are a worker.",
             )
 
-        assert result.startswith("still works\n\nChat Trace ID: ")
+        assert result == "still works"
         assert registry.count() == 1
 
     @pytest.mark.asyncio
@@ -4170,6 +4172,134 @@ class TestDelegationConfiguration:
 
         assert "Error executing task" in result
         assert "delegate failed" in result
+
+    @pytest.mark.asyncio
+    async def test_delegate_async_reports_no_chat_trace(self):
+        """An async one-shot handle carries no trace, so neither listing shows one."""
+        toolset = create_subagent_toolset(
+            delegation_configuration="persisted_and_oneshot",
+            include_general_purpose=False,
+        )
+        ctx = MockRunContext(deps=MockDeps())
+
+        with patch("subagents_pydantic_ai.dynamic_agent.Agent") as mock_agent_class:
+            mock_agent_class.return_value = FakeAgent(
+                result=MockResultWithMessages("async oneshot", messages=["m"])
+            )
+            start_result = await toolset.tools["delegate"].function(
+                ctx,
+                description="Long analysis",
+                instructions="You are an analyst.",
+                mode="async",
+            )
+
+        assert "Chat Trace ID" not in start_result
+        task_id = start_result.split("Task ID: ")[1].split("\n")[0]
+
+        waited = await toolset.tools["wait_tasks"].function(ctx, [task_id], timeout=5.0)
+        assert "COMPLETED" in waited
+        assert "Chat Trace ID" not in waited
+
+        status = await toolset.tools["check_task"].function(ctx, task_id)
+        assert "Chat Trace ID" not in status
+        assert toolset.task_manager.get_handle(task_id).chat_trace_id is None
+
+    @pytest.mark.asyncio
+    async def test_delegate_does_not_evict_resumable_chat_traces(self):
+        """One-shot runs must not spend slots in the bounded chat-trace LRU.
+
+        Regression test: they used to save history under a key nothing could
+        resolve, so a burst of `delegate` calls flushed the conversations a
+        `task` subagent could actually continue.
+        """
+        researcher = FakeAgent(result=MockResultWithMessages("researched", messages=["m1"]))
+        toolset = create_subagent_toolset(
+            subagents=[
+                SubAgentConfig(
+                    name="researcher",
+                    description="Researches topics",
+                    instructions="You research.",
+                    agent=researcher,
+                )
+            ],
+            delegation_configuration="persisted_and_oneshot",
+            include_general_purpose=False,
+            max_chat_traces=1,
+        )
+        ctx = MockRunContext(deps=MockDeps())
+
+        started = await toolset.tools["task"].function(
+            ctx, description="research X", subagent_type="researcher"
+        )
+        trace_id = started.split("Chat Trace ID: ")[1].strip()
+
+        with patch("subagents_pydantic_ai.dynamic_agent.Agent") as mock_agent_class:
+            mock_agent_class.return_value = FakeAgent(
+                result=MockResultWithMessages("oneshot", messages=["m2"])
+            )
+            for _ in range(3):
+                await toolset.tools["delegate"].function(
+                    ctx, description="unrelated job", instructions="You are a specialist."
+                )
+
+        resumed = await toolset.tools["task"].function(
+            ctx,
+            description="follow up",
+            subagent_type="researcher",
+            chat_trace_id=trace_id,
+        )
+        assert not resumed.startswith("Error:")
+        assert researcher.iter_calls[-1]["message_history"] == ["m1"]
+
+
+class TestDelegationConfigurationRejectsUnreachableConfig:
+    """A hidden tool must not leave its configuration silently inert."""
+
+    def test_oneshot_only_rejects_registry(self):
+        with pytest.raises(ValueError, match="cannot be combined with a registry"):
+            create_subagent_toolset(
+                delegation_configuration="oneshot_only",
+                registry=DynamicAgentRegistry(),
+            )
+
+    @pytest.mark.parametrize(
+        ("kwargs", "expected"),
+        [
+            ({"allowed_models": ["openai:gpt-4.1"]}, "allowed_models"),
+            ({"capabilities_map": {"filesystem": lambda deps: []}}, "capabilities_map"),
+            ({"default_agent_factory": lambda config: MagicMock()}, "default_agent_factory"),
+        ],
+    )
+    def test_default_mode_rejects_dynamic_agent_config(
+        self, kwargs: dict[str, Any], expected: str
+    ) -> None:
+        with pytest.raises(ValueError, match=f"exposes no dynamic-agent tool.*{expected}"):
+            create_subagent_toolset(include_general_purpose=False, **kwargs)
+
+    def test_error_lists_every_unreachable_argument(self):
+        with pytest.raises(ValueError) as exc_info:
+            create_subagent_toolset(
+                include_general_purpose=False,
+                allowed_models=["openai:gpt-4.1"],
+                capabilities_map={"filesystem": lambda deps: []},
+                default_agent_factory=lambda config: MagicMock(),
+            )
+        assert "allowed_models, capabilities_map, default_agent_factory" in str(exc_info.value)
+
+    @pytest.mark.parametrize(
+        "delegation_configuration",
+        ["persisted", "persisted_and_oneshot", "oneshot_only"],
+    )
+    def test_modes_with_a_dynamic_agent_tool_accept_the_config(
+        self, delegation_configuration: Any
+    ) -> None:
+        toolset = create_subagent_toolset(
+            delegation_configuration=delegation_configuration,
+            include_general_purpose=False,
+            allowed_models=["openai:gpt-4.1"],
+            capabilities_map={"filesystem": lambda deps: []},
+        )
+        assert {"create_agent", "delegate"} & set(toolset.tools)
 
 
 class TestObservabilityHelpers:

--- a/tests/test_toolset.py
+++ b/tests/test_toolset.py
@@ -3204,3 +3204,179 @@ class TestSendMessageToSubagent:
         assert len(msgs) == 1
         assert msgs[0].type == MessageType.TASK_UPDATE
         assert msgs[0].payload == {"message": "narrow the scope"}
+
+
+class TestOneshotDelegation:
+    """Tests for the optional delegate tool."""
+
+    def test_delegate_hidden_by_default(self):
+        toolset = create_subagent_toolset(include_general_purpose=False)
+        assert "delegate" not in toolset.tools
+
+    def test_delegate_exposed_when_enabled(self):
+        toolset = create_subagent_toolset(
+            oneshot_delegation=True,
+            include_general_purpose=False,
+        )
+        assert "delegate" in toolset.tools
+        assert "task" in toolset.tools
+
+    @pytest.mark.asyncio
+    async def test_delegate_sync_success(self):
+        toolset = create_subagent_toolset(
+            oneshot_delegation=True,
+            include_general_purpose=False,
+        )
+        delegate_tool = toolset.tools["delegate"]
+        ctx = MockRunContext(deps=MockDeps())
+
+        with patch("subagents_pydantic_ai.dynamic_agent.Agent") as mock_agent_class:
+            mock_agent_class.return_value = FakeAgent(result=MockResult("oneshot result"))
+            result = await delegate_tool.function(
+                ctx,
+                description="Analyze the data",
+                instructions="You are a data analyst.",
+            )
+
+        assert result == "oneshot result"
+
+    @pytest.mark.asyncio
+    async def test_delegate_does_not_register_agent(self, registry):
+        registry.max_agents = 1
+        toolset = create_subagent_toolset(
+            oneshot_delegation=True,
+            registry=registry,
+            include_general_purpose=False,
+        )
+        delegate_tool = toolset.tools["delegate"]
+        ctx = MockRunContext(deps=MockDeps())
+
+        with patch("subagents_pydantic_ai.dynamic_agent.Agent") as mock_agent_class:
+            mock_agent_class.return_value = FakeAgent(result=MockResult("oneshot result"))
+            result = await delegate_tool.function(
+                ctx,
+                description="Do work",
+                instructions="You are a worker.",
+            )
+
+        assert result == "oneshot result"
+        assert registry.count() == 0
+
+    @pytest.mark.asyncio
+    async def test_delegate_works_when_registry_full(self, registry):
+        registry.max_agents = 1
+        registry.register(
+            SubAgentConfig(
+                name="existing",
+                description="Existing agent",
+                instructions="Existing",
+            ),
+            MagicMock(),
+        )
+        toolset = create_subagent_toolset(
+            oneshot_delegation=True,
+            registry=registry,
+            include_general_purpose=False,
+        )
+        delegate_tool = toolset.tools["delegate"]
+        ctx = MockRunContext(deps=MockDeps())
+
+        with patch("subagents_pydantic_ai.dynamic_agent.Agent") as mock_agent_class:
+            mock_agent_class.return_value = FakeAgent(result=MockResult("still works"))
+            result = await delegate_tool.function(
+                ctx,
+                description="Do work",
+                instructions="You are a worker.",
+            )
+
+        assert result == "still works"
+        assert registry.count() == 1
+
+    @pytest.mark.asyncio
+    async def test_delegate_async_success(self):
+        toolset = create_subagent_toolset(
+            oneshot_delegation=True,
+            include_general_purpose=False,
+        )
+        delegate_tool = toolset.tools["delegate"]
+        check_tool = toolset.tools["check_task"]
+        ctx = MockRunContext(deps=MockDeps())
+
+        with patch("subagents_pydantic_ai.dynamic_agent.Agent") as mock_agent_class:
+            mock_agent_class.return_value = FakeAgent(result=MockResult("async oneshot"))
+            start_result = await delegate_tool.function(
+                ctx,
+                description="Long analysis",
+                instructions="You are an analyst.",
+                mode="async",
+            )
+
+        assert "Task ID:" in start_result
+        task_id = start_result.split("Task ID: ")[1].split("\n")[0]
+        handle = toolset.task_manager.get_handle(task_id)
+        assert handle is not None
+        assert handle.subagent_name.startswith("oneshot-")
+
+        await asyncio.sleep(0.05)
+        status = await check_tool.function(ctx, task_id)
+        assert "COMPLETED" in status or "async oneshot" in status
+
+    @pytest.mark.asyncio
+    async def test_delegate_disallowed_model(self):
+        toolset = create_subagent_toolset(
+            oneshot_delegation=True,
+            include_general_purpose=False,
+            allowed_models=["openai:gpt-4.1"],
+        )
+        delegate_tool = toolset.tools["delegate"]
+        ctx = MockRunContext(deps=MockDeps())
+
+        result = await delegate_tool.function(
+            ctx,
+            description="Do work",
+            instructions="You are a worker.",
+            model="anthropic:claude-3",
+        )
+
+        assert "Error" in result
+        assert "not allowed" in result
+
+    @pytest.mark.asyncio
+    async def test_delegate_invalid_capability(self):
+        toolset = create_subagent_toolset(
+            oneshot_delegation=True,
+            include_general_purpose=False,
+            capabilities_map={"filesystem": lambda deps: []},
+        )
+        delegate_tool = toolset.tools["delegate"]
+        ctx = MockRunContext(deps=MockDeps())
+
+        result = await delegate_tool.function(
+            ctx,
+            description="Do work",
+            instructions="You are a worker.",
+            capabilities=["missing"],
+        )
+
+        assert "Error" in result
+        assert "Unknown capabilities" in result
+
+    @pytest.mark.asyncio
+    async def test_delegate_execution_error(self):
+        toolset = create_subagent_toolset(
+            oneshot_delegation=True,
+            include_general_purpose=False,
+        )
+        delegate_tool = toolset.tools["delegate"]
+        ctx = MockRunContext(deps=MockDeps())
+
+        with patch("subagents_pydantic_ai.dynamic_agent.Agent") as mock_agent_class:
+            mock_agent_class.return_value = FakeAgent(error=Exception("delegate failed"))
+            result = await delegate_tool.function(
+                ctx,
+                description="Do work",
+                instructions="You are a worker.",
+            )
+
+        assert "Error executing task" in result
+        assert "delegate failed" in result

--- a/tests/test_toolset.py
+++ b/tests/test_toolset.py
@@ -3206,25 +3206,73 @@ class TestSendMessageToSubagent:
         assert msgs[0].payload == {"message": "narrow the scope"}
 
 
-class TestOneshotDelegation:
-    """Tests for the optional delegate tool."""
+class TestDelegationConfiguration:
+    """Tests for configurable delegation entry points."""
 
-    def test_delegate_hidden_by_default(self):
+    def test_default_exposes_persisted_tools(self):
         toolset = create_subagent_toolset(include_general_purpose=False)
         assert "delegate" not in toolset.tools
+        assert "create_agent" in toolset.tools
+        assert "task" in toolset.tools
 
-    def test_delegate_exposed_when_enabled(self):
+    def test_persisted_and_oneshot_exposes_all_entry_points(self):
         toolset = create_subagent_toolset(
-            oneshot_delegation=True,
+            delegation_configuration="persisted_and_oneshot",
             include_general_purpose=False,
         )
         assert "delegate" in toolset.tools
+        assert "create_agent" in toolset.tools
         assert "task" in toolset.tools
+
+    def test_oneshot_only_exposes_only_delegate_entry_point(self):
+        toolset = create_subagent_toolset(
+            delegation_configuration="oneshot_only",
+            include_general_purpose=False,
+        )
+        assert "delegate" in toolset.tools
+        assert "create_agent" not in toolset.tools
+        assert "task" not in toolset.tools
+        assert "check_task" in toolset.tools
+
+    def test_invalid_configuration_is_rejected(self):
+        with pytest.raises(ValueError, match="Invalid delegation_configuration"):
+            create_subagent_toolset(
+                delegation_configuration="invalid",  # type: ignore[arg-type]
+                include_general_purpose=False,
+            )
+
+    @pytest.mark.asyncio
+    async def test_create_agent_registers_reusable_agent(self, registry):
+        toolset = create_subagent_toolset(
+            registry=registry,
+            include_general_purpose=False,
+        )
+        create_tool = toolset.tools["create_agent"]
+        ctx = MockRunContext(deps=MockDeps())
+
+        with patch("subagents_pydantic_ai.dynamic_agent.Agent") as mock_agent_class:
+            mock_agent_class.return_value = FakeAgent(result=MockResult("persisted result"))
+            result = await create_tool.function(
+                ctx,
+                name="analyst",
+                description="Analyzes data",
+                instructions="You are a data analyst.",
+            )
+
+        assert "created successfully" in result
+        assert registry.exists("analyst")
+
+        task_result = await toolset.tools["task"].function(
+            ctx,
+            description="Analyze the data",
+            subagent_type="analyst",
+        )
+        assert task_result == "persisted result"
 
     @pytest.mark.asyncio
     async def test_delegate_sync_success(self):
         toolset = create_subagent_toolset(
-            oneshot_delegation=True,
+            delegation_configuration="persisted_and_oneshot",
             include_general_purpose=False,
         )
         delegate_tool = toolset.tools["delegate"]
@@ -3244,7 +3292,7 @@ class TestOneshotDelegation:
     async def test_delegate_does_not_register_agent(self, registry):
         registry.max_agents = 1
         toolset = create_subagent_toolset(
-            oneshot_delegation=True,
+            delegation_configuration="persisted_and_oneshot",
             registry=registry,
             include_general_purpose=False,
         )
@@ -3274,7 +3322,7 @@ class TestOneshotDelegation:
             MagicMock(),
         )
         toolset = create_subagent_toolset(
-            oneshot_delegation=True,
+            delegation_configuration="persisted_and_oneshot",
             registry=registry,
             include_general_purpose=False,
         )
@@ -3295,7 +3343,7 @@ class TestOneshotDelegation:
     @pytest.mark.asyncio
     async def test_delegate_async_success(self):
         toolset = create_subagent_toolset(
-            oneshot_delegation=True,
+            delegation_configuration="persisted_and_oneshot",
             include_general_purpose=False,
         )
         delegate_tool = toolset.tools["delegate"]
@@ -3324,7 +3372,7 @@ class TestOneshotDelegation:
     @pytest.mark.asyncio
     async def test_delegate_disallowed_model(self):
         toolset = create_subagent_toolset(
-            oneshot_delegation=True,
+            delegation_configuration="persisted_and_oneshot",
             include_general_purpose=False,
             allowed_models=["openai:gpt-4.1"],
         )
@@ -3344,7 +3392,7 @@ class TestOneshotDelegation:
     @pytest.mark.asyncio
     async def test_delegate_invalid_capability(self):
         toolset = create_subagent_toolset(
-            oneshot_delegation=True,
+            delegation_configuration="persisted_and_oneshot",
             include_general_purpose=False,
             capabilities_map={"filesystem": lambda deps: []},
         )
@@ -3364,7 +3412,7 @@ class TestOneshotDelegation:
     @pytest.mark.asyncio
     async def test_delegate_execution_error(self):
         toolset = create_subagent_toolset(
-            oneshot_delegation=True,
+            delegation_configuration="persisted_and_oneshot",
             include_general_purpose=False,
         )
         delegate_tool = toolset.tools["delegate"]

--- a/tests/test_toolset.py
+++ b/tests/test_toolset.py
@@ -15,7 +15,7 @@ from pydantic_ai.models.test import TestModel
 from pydantic_ai.toolsets import FunctionToolset
 from pydantic_graph import End
 
-from subagents_pydantic_ai import SubAgentConfig, create_subagent_toolset
+from subagents_pydantic_ai import DynamicAgentRegistry, SubAgentConfig, create_subagent_toolset
 from subagents_pydantic_ai.toolset import (
     _create_ask_parent_toolset,
     _create_general_purpose_config,
@@ -3209,11 +3209,20 @@ class TestSendMessageToSubagent:
 class TestDelegationConfiguration:
     """Tests for configurable delegation entry points."""
 
-    def test_default_exposes_persisted_tools(self):
+    def test_default_exposes_task_only(self):
         toolset = create_subagent_toolset(include_general_purpose=False)
         assert "delegate" not in toolset.tools
+        assert "create_agent" not in toolset.tools
+        assert "task" in toolset.tools
+
+    def test_persisted_exposes_create_agent_and_task(self):
+        toolset = create_subagent_toolset(
+            delegation_configuration="persisted",
+            include_general_purpose=False,
+        )
         assert "create_agent" in toolset.tools
         assert "task" in toolset.tools
+        assert "delegate" not in toolset.tools
 
     def test_persisted_and_oneshot_exposes_all_entry_points(self):
         toolset = create_subagent_toolset(
@@ -3241,9 +3250,24 @@ class TestDelegationConfiguration:
                 include_general_purpose=False,
             )
 
+    def test_oneshot_only_rejects_configured_subagents(self):
+        with pytest.raises(ValueError, match="cannot be combined with"):
+            create_subagent_toolset(
+                delegation_configuration="oneshot_only",
+                subagents=[
+                    SubAgentConfig(
+                        name="researcher",
+                        description="Researches topics",
+                        instructions="Research.",
+                    )
+                ],
+                include_general_purpose=False,
+            )
+
     @pytest.mark.asyncio
     async def test_create_agent_registers_reusable_agent(self, registry):
         toolset = create_subagent_toolset(
+            delegation_configuration="persisted",
             registry=registry,
             include_general_purpose=False,
         )
@@ -3268,6 +3292,82 @@ class TestDelegationConfiguration:
             subagent_type="analyst",
         )
         assert task_result == "persisted result"
+
+    @pytest.mark.asyncio
+    async def test_create_agent_duplicate_name(self, registry):
+        toolset = create_subagent_toolset(
+            delegation_configuration="persisted",
+            registry=registry,
+            include_general_purpose=False,
+        )
+        create_tool = toolset.tools["create_agent"]
+        ctx = MockRunContext(deps=MockDeps())
+
+        with patch("subagents_pydantic_ai.dynamic_agent.Agent") as mock_agent_class:
+            mock_agent_class.return_value = FakeAgent(result=MockResult("ok"))
+            await create_tool.function(
+                ctx,
+                name="analyst",
+                description="Analyzes data",
+                instructions="You are a data analyst.",
+            )
+            result = await create_tool.function(
+                ctx,
+                name="analyst",
+                description="Analyzes data",
+                instructions="You are a data analyst.",
+            )
+
+        assert "already exists" in result
+
+    @pytest.mark.asyncio
+    async def test_create_agent_register_max_agents(self):
+        registry = DynamicAgentRegistry(max_agents=1)
+        toolset = create_subagent_toolset(
+            delegation_configuration="persisted",
+            registry=registry,
+            include_general_purpose=False,
+        )
+        create_tool = toolset.tools["create_agent"]
+        ctx = MockRunContext(deps=MockDeps())
+
+        with patch("subagents_pydantic_ai.dynamic_agent.Agent") as mock_agent_class:
+            mock_agent_class.return_value = FakeAgent(result=MockResult("ok"))
+            await create_tool.function(
+                ctx,
+                name="first",
+                description="First",
+                instructions="First",
+            )
+            result = await create_tool.function(
+                ctx,
+                name="second",
+                description="Second",
+                instructions="Second",
+            )
+
+        assert "Error" in result
+        assert "Maximum" in result
+
+    @pytest.mark.asyncio
+    async def test_create_agent_validation_error(self, registry):
+        toolset = create_subagent_toolset(
+            delegation_configuration="persisted",
+            registry=registry,
+            include_general_purpose=False,
+        )
+        create_tool = toolset.tools["create_agent"]
+        ctx = MockRunContext(deps=MockDeps())
+
+        result = await create_tool.function(
+            ctx,
+            name="bad name",
+            description="Invalid",
+            instructions="Invalid",
+        )
+
+        assert "Error" in result
+        assert "letters, numbers, and hyphens" in result
 
     @pytest.mark.asyncio
     async def test_delegate_sync_success(self):


### PR DESCRIPTION
## Summary
- Add `delegation_configuration` with four explicit modes:
  - `default`: expose `task` only (backward-compatible)
  - `persisted`: expose `create_agent` and `task`
  - `persisted_and_oneshot`: expose `create_agent`, `task`, and `delegate`
  - `oneshot_only`: expose `delegate` as the sole delegation entry point
- Add one-shot `delegate`, which creates an ephemeral specialist and executes its task in one call without touching the persistent registry.
- Share dynamic-agent validation and construction between persistent and one-shot delegation paths.

## Why this helps
The main benefit is a simpler toolset for the orchestrating agent. Applications can expose only the delegation behavior they need instead of presenting every creation and execution option to the model.

- `oneshot_only` minimizes tool-choice ambiguity for agents that only need ad-hoc delegation.
- `default` stays backward-compatible with existing deployments (`task` + lifecycle tools).
- `persisted` opts into reusable agent creation deliberately.
- `persisted_and_oneshot` supports both workflows when the extra flexibility is worth the larger tool surface.
- Fewer irrelevant tools reduce schema/context overhead and make delegation behavior easier to prompt, reason about, and configure.
- Async lifecycle tools remain available across modes so background execution can still be checked, steered, awaited, answered, or cancelled.

## Compatibility and behavior
- `default` does **not** add `create_agent` on upgrade.
- One-shot agents remain ephemeral, do not consume registry capacity, and cannot collide with persisted agent names.
- `oneshot_only` rejects a non-empty `subagents` list at construction time.
- Registry-backed agents now receive `ask_parent` at run time (changelog note included).
- `DelegationConfiguration` is exported as a public type, and both `create_subagent_toolset` and `SubAgentCapability` accept the new configuration.

## Test plan
- [x] `uv run pytest -q` — 342 passed
- [x] `uv run coverage report` — 100%
- [x] `uv run ruff format`
- [x] `uv run ruff check`
- [x] `uv run pyright` — 0 errors
- [x] Coverage for all four tool-exposure modes, invalid configuration, oneshot_only + subagents rejection, persisted agent reuse, create_agent validation/duplicate/max_agents, one-shot registry isolation, sync/async execution