### PR TITLE
fix: mark truncated results in `wait_tasks` instead of cutting them silently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **`wait_tasks` truncated results silently, making orchestrators re-delegate finished work** ([#55](https://github.com/vstorm-co/subagents-pydantic-ai/issues/55)). A completed task's result was hard-sliced to 2000 characters with no ellipsis, length, or marker of any kind. The orchestrator saw a well-formed answer that stopped mid-sentence, concluded the subagent had been cut off, and dispatched a *new* task asking it to finish — burning a full extra round-trip on work that was already complete and stored intact. Truncated results now end with an explicit marker stating that the cut is a display limit, that the stored answer is complete, and which `check_task(...)` call returns the full text; `check_task` and the `wait_tasks` tool description say the same, so the orchestrator knows the rule before it ever meets a cut result.
+
+### Added
+
+- **`max_result_chars` on `create_subagent_toolset` and `SubAgentCapability`** (default `2000`, matching the previous hard-coded limit). Sets the per-result character budget in the `wait_tasks` listing, so a fan-out of verbose subagents can't flood the orchestrator's context. Pass `None` to never truncate; a negative value raises `ValueError`.
+
 ## [0.2.9] - 2026-07-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.2.10] - 2026-07-24
 
 ### Fixed
 

--- a/docs/concepts/toolset.md
+++ b/docs/concepts/toolset.md
@@ -30,6 +30,7 @@ toolset = create_subagent_toolset(subagents=subagents)
 | `descriptions` | `dict[str, str] \| None` | `None` | Override default tool descriptions by tool name |
 | `max_chat_traces` | `int` | `100` | Max subagent conversations kept for `chat_trace_id` continuation (LRU-evicted) |
 | `max_task_handles` | `int` | `500` | Max finished task handles retained for status/observability (oldest evicted; usage totals preserved) |
+| `max_result_chars` | `int \| None` | `2000` | Character budget for a result shown by `wait_tasks`; longer results are cut with an explicit marker. `None` disables truncation |
 
 ## Adding to an Agent
 
@@ -259,6 +260,25 @@ The output includes a header like
 `Task results (mode=any, 1/4 finished, 3 still running):` so the
 orchestrator can see which tasks are still in flight and decide whether
 to keep waiting or do other work first.
+
+#### Long results are truncated, and say so
+
+A fan-out of verbose subagents can flood the orchestrator's context, so
+`wait_tasks` shows at most `max_result_chars` (default 2000) of each result.
+A cut result always ends with an explicit marker:
+
+```text
+...the last of the 2000 shown characters
+
+[Result truncated for display: showing 2000 of 5231 characters. The subagent's
+answer is complete and stored in full. Call check_task('abc123') to read all of it.]
+```
+
+The marker matters as much as the limit. Without it an orchestrator reads a
+result that stops mid-sentence, concludes the subagent failed to finish, and
+delegates the same work again — a wasted round-trip caused entirely by the
+display limit. `check_task` always returns the untruncated result, and passing
+`max_result_chars=None` to `create_subagent_toolset` turns truncation off.
 
 ### soft_cancel_task
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "subagents-pydantic-ai"
-version = "0.2.9"
+version = "0.2.10"
 description = "Subagent toolset for pydantic-ai with dual-mode execution and dynamic agent creation"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/subagents_pydantic_ai/capability.py
+++ b/src/subagents_pydantic_ai/capability.py
@@ -71,6 +71,10 @@ class SubAgentCapability(AbstractCapability[Any]):
         descriptions: Custom tool descriptions override.
         usage_limits: Optional static or per-task usage limits for delegated
             subagent runs.
+        max_result_chars: Character budget for a completed task's result in the
+            `wait_tasks` listing. Truncated results carry an explicit marker
+            pointing at `check_task`, which always returns the full text. Pass
+            `None` to never truncate.
     """
 
     subagents: list[SubAgentConfig] | None = None
@@ -81,6 +85,7 @@ class SubAgentCapability(AbstractCapability[Any]):
     registry: Any = None
     descriptions: dict[str, str] | None = None
     usage_limits: UsageLimits | UsageLimitsFactory | None = None
+    max_result_chars: int | None = 2000
     _toolset: AbstractToolset[Any] | None = field(default=None, init=False, repr=False)
 
     def __post_init__(self) -> None:
@@ -95,6 +100,7 @@ class SubAgentCapability(AbstractCapability[Any]):
             registry=self.registry,
             descriptions=self.descriptions,
             usage_limits=self.usage_limits,
+            max_result_chars=self.max_result_chars,
         )
 
     @classmethod

--- a/src/subagents_pydantic_ai/prompts.py
+++ b/src/subagents_pydantic_ai/prompts.py
@@ -102,7 +102,8 @@ Check the status of a background (async) task and get its result if completed.
 
 Use this after launching async tasks to see if they're done. Returns the \
 task status (running, completed, failed, waiting_for_answer) and the result \
-if available."""
+if available. The result is always returned in full, so call this when a \
+`wait_tasks` listing showed a truncated one."""
 
 ANSWER_SUBAGENT_DESCRIPTION = """\
 Answer a question from a background subagent that is waiting for clarification.
@@ -144,7 +145,13 @@ faster than waiting on the slowest agent.
 The result lists every requested task with its current state and a header \
 showing `mode`, `<finished>/<total> finished`, and how many are still \
 running. Unfinished tasks remain in the background — you can keep working \
-or wait on them again later."""
+or wait on them again later.
+
+A long result may be cut here to save context, in which case it ends with an \
+explicit truncation marker. That marker is a display limit on this listing, \
+never an incomplete subagent answer: the full text is stored and \
+`check_task` returns it. Never re-delegate a task to "finish" a result that \
+carries the marker."""
 
 SEND_MESSAGE_TO_SUBAGENT_DESCRIPTION = """\
 Send a steering message to a running background (async) subagent without \

--- a/src/subagents_pydantic_ai/toolset.py
+++ b/src/subagents_pydantic_ai/toolset.py
@@ -188,6 +188,33 @@ def _format_chat_trace_result(output: str, chat_trace_id: str) -> str:
     return f"{output}\n\nChat Trace ID: {chat_trace_id}"
 
 
+def _preview_result(result: str, task_id: str, max_chars: int | None) -> str:
+    """Render a task result for `wait_tasks`, marking truncation explicitly.
+
+    A silent cut reads to the orchestrator like a subagent that stopped
+    mid-sentence, so it "recovers" by re-delegating the same work. The marker
+    states that the cut is ours, that the stored answer is complete, and which
+    tool returns the untruncated text.
+
+    Args:
+        result: The subagent's full result text.
+        task_id: Task ID the orchestrator passes to `check_task` for the rest.
+        max_chars: Preview budget in characters; `None` disables truncation.
+
+    Returns:
+        The result unchanged when it fits the budget, otherwise the first
+        `max_chars` characters followed by the truncation marker.
+    """
+    if max_chars is None or len(result) <= max_chars:
+        return result
+    return (
+        f"{result[:max_chars]}\n\n"
+        f"[Result truncated for display: showing {max_chars} of {len(result)} characters. "
+        f"The subagent's answer is complete and stored in full. "
+        f"Call check_task('{task_id}') to read all of it.]"
+    )
+
+
 async def _drain_steering_messages(message_bus: InMemoryMessageBus, agent_id: str) -> list[str]:
     """Drain pending parent -> child steering messages for a running subagent.
 
@@ -370,6 +397,7 @@ def create_subagent_toolset(  # noqa: C901
     usage_limits: UsageLimits | UsageLimitsFactory | None = None,
     max_chat_traces: int = 100,
     max_task_handles: int = 500,
+    max_result_chars: int | None = 2000,
 ) -> FunctionToolset[Any]:
     """Create a toolset for delegating tasks to subagents.
 
@@ -419,9 +447,17 @@ def create_subagent_toolset(  # noqa: C901
             oldest finished handles are evicted past this limit; their token
             usage is folded into `get_total_usage()` totals so aggregates stay
             correct. Bounds memory in long-lived sessions.
+        max_result_chars: Character budget for a completed task's result in the
+            `wait_tasks` listing, keeping a fan-out of verbose subagents from
+            flooding the orchestrator's context. Results past the budget are cut
+            and carry an explicit marker pointing at `check_task`, which always
+            returns the full text. Pass `None` to never truncate.
 
     Returns:
         FunctionToolset configured with subagent management tools.
+
+    Raises:
+        ValueError: If `max_result_chars` is negative.
 
     Example:
         ```python
@@ -444,6 +480,9 @@ def create_subagent_toolset(  # noqa: C901
         agent = Agent("openai:gpt-4.1", toolsets=[toolset])
         ```
     """
+    if max_result_chars is not None and max_result_chars < 0:
+        raise ValueError(f"max_result_chars must be >= 0 or None, got {max_result_chars}")
+
     _descs = descriptions or {}
 
     # Build subagent configs
@@ -836,7 +875,7 @@ def create_subagent_toolset(  # noqa: C901
             status = handle.status
             if status == "completed":
                 finished_count += 1
-                result_preview = (handle.result or "")[:2000]
+                result_preview = _preview_result(handle.result or "", tid, max_result_chars)
                 chat_trace_line = ""
                 if handle.chat_trace_id is not None:
                     chat_trace_line = f"Chat Trace ID: {handle.chat_trace_id}\n"

--- a/tests/test_capability.py
+++ b/tests/test_capability.py
@@ -105,6 +105,22 @@ class TestSubAgentCapability:
         assert cap.usage_limits is usage_limits
         assert create_toolset.call_args.kwargs["usage_limits"] is usage_limits
 
+    def test_max_result_chars_defaults_to_2000(self):
+        """The result preview budget defaults to 2000 characters."""
+        with patch("subagents_pydantic_ai.capability.create_subagent_toolset") as create_toolset:
+            cap = _cap()
+
+        assert cap.max_result_chars == 2000
+        assert create_toolset.call_args.kwargs["max_result_chars"] == 2000
+
+    def test_max_result_chars_forwarded_to_toolset(self):
+        """max_result_chars is forwarded to the underlying toolset factory."""
+        with patch("subagents_pydantic_ai.capability.create_subagent_toolset") as create_toolset:
+            cap = _cap(max_result_chars=None)
+
+        assert cap.max_result_chars is None
+        assert create_toolset.call_args.kwargs["max_result_chars"] is None
+
 
 class TestSubAgentCapabilityIntegration:
     """Integration tests with real Agent."""

--- a/tests/test_toolset.py
+++ b/tests/test_toolset.py
@@ -3922,3 +3922,138 @@ class TestObservabilityHelpers:
         assert handle.traceparent == "00-abc"
         assert handle.trace_id is None
         assert handle.span_id is None
+
+
+class TestPreviewResult:
+    """Tests for the _preview_result helper backing wait_tasks previews."""
+
+    def test_short_result_is_unchanged(self):
+        from subagents_pydantic_ai.toolset import _preview_result
+
+        assert _preview_result("short answer", "abc123", 2000) == "short answer"
+
+    def test_result_at_budget_is_not_truncated(self):
+        """A result exactly at the budget is complete, so it gets no marker."""
+        from subagents_pydantic_ai.toolset import _preview_result
+
+        result = "x" * 100
+        assert _preview_result(result, "abc123", 100) == result
+
+    def test_result_one_char_over_budget_is_truncated(self):
+        from subagents_pydantic_ai.toolset import _preview_result
+
+        preview = _preview_result("x" * 101, "abc123", 100)
+        assert preview.startswith("x" * 100)
+        assert "x" * 101 not in preview
+        assert "showing 100 of 101 characters" in preview
+
+    def test_marker_points_at_check_task_with_the_task_id(self):
+        from subagents_pydantic_ai.toolset import _preview_result
+
+        preview = _preview_result("y" * 50, "task-42", 10)
+        assert "Result truncated for display" in preview
+        assert "check_task('task-42')" in preview
+        assert "The subagent's answer is complete" in preview
+
+    def test_none_budget_never_truncates(self):
+        from subagents_pydantic_ai.toolset import _preview_result
+
+        result = "z" * 10_000
+        assert _preview_result(result, "abc123", None) == result
+
+    def test_zero_budget_yields_marker_only(self):
+        from subagents_pydantic_ai.toolset import _preview_result
+
+        preview = _preview_result("hidden", "abc123", 0)
+        assert preview.startswith("\n\n[Result truncated for display")
+        assert "hidden" not in preview
+
+    def test_empty_result_is_unchanged(self):
+        from subagents_pydantic_ai.toolset import _preview_result
+
+        assert _preview_result("", "abc123", 2000) == ""
+
+
+class TestWaitTasksResultTruncation:
+    """wait_tasks must never hand the orchestrator a silently cut result."""
+
+    @staticmethod
+    def _toolset_with_result(result: str, /, **kwargs: Any) -> tuple[Any, Any]:
+        toolset = create_subagent_toolset(default_model="test", **kwargs)
+        tm = toolset.task_manager  # type: ignore[attr-defined]
+        tm.handles["long-task"] = TaskHandle(
+            task_id="long-task",
+            subagent_name="worker",
+            description="verbose task",
+            status=TaskStatus.COMPLETED,
+            result=result,
+        )
+        return toolset, tm
+
+    @pytest.mark.anyio
+    async def test_truncated_result_carries_a_marker(self):
+        toolset, _ = self._toolset_with_result("a" * 2500)
+
+        wait_tool = toolset.tools["wait_tasks"]
+        output = await wait_tool.function(MockRunContext(deps=MockDeps()), ["long-task"])
+
+        assert "COMPLETED" in output
+        assert "showing 2000 of 2500 characters" in output
+        assert "check_task('long-task')" in output
+
+    @pytest.mark.anyio
+    async def test_result_within_budget_has_no_marker(self):
+        toolset, _ = self._toolset_with_result("complete answer")
+
+        wait_tool = toolset.tools["wait_tasks"]
+        output = await wait_tool.function(MockRunContext(deps=MockDeps()), ["long-task"])
+
+        assert "complete answer" in output
+        assert "truncated" not in output
+
+    @pytest.mark.anyio
+    async def test_custom_budget_is_honoured(self):
+        toolset, _ = self._toolset_with_result("b" * 100, max_result_chars=10)
+
+        wait_tool = toolset.tools["wait_tasks"]
+        output = await wait_tool.function(MockRunContext(deps=MockDeps()), ["long-task"])
+
+        assert "showing 10 of 100 characters" in output
+        assert "b" * 11 not in output
+
+    @pytest.mark.anyio
+    async def test_none_budget_returns_the_full_result(self):
+        toolset, _ = self._toolset_with_result("c" * 5000, max_result_chars=None)
+
+        wait_tool = toolset.tools["wait_tasks"]
+        output = await wait_tool.function(MockRunContext(deps=MockDeps()), ["long-task"])
+
+        assert "c" * 5000 in output
+        assert "truncated" not in output
+
+    @pytest.mark.anyio
+    async def test_truncation_keeps_the_chat_trace_line_intact(self):
+        """The trace id stays above the preview so continuation still parses."""
+        toolset, tm = self._toolset_with_result("d" * 2500)
+        tm.handles["long-task"].chat_trace_id = "trace-9"
+
+        wait_tool = toolset.tools["wait_tasks"]
+        output = await wait_tool.function(MockRunContext(deps=MockDeps()), ["long-task"])
+
+        assert "Chat Trace ID: trace-9\nddd" in output
+        assert "showing 2000 of 2500 characters" in output
+
+    @pytest.mark.anyio
+    async def test_check_task_returns_the_untruncated_result(self):
+        """check_task is the escape hatch the truncation marker points at."""
+        toolset, _ = self._toolset_with_result("e" * 2500)
+
+        check_tool = toolset.tools["check_task"]
+        output = await check_tool.function(MockRunContext(deps=MockDeps()), "long-task")
+
+        assert "e" * 2500 in output
+        assert "truncated" not in output
+
+    def test_negative_budget_is_rejected(self):
+        with pytest.raises(ValueError, match="max_result_chars must be >= 0 or None, got -1"):
+            create_subagent_toolset(default_model="test", max_result_chars=-1)

--- a/uv.lock
+++ b/uv.lock
@@ -1333,7 +1333,7 @@ wheels = [
 
 [[package]]
 name = "subagents-pydantic-ai"
-version = "0.2.9"
+version = "0.2.10"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
Closes #55.

## The bug

`wait_tasks` hard-sliced a completed task's result to 2000 characters with no ellipsis, length, or marker of any kind:

```python
result_preview = (handle.result or "")[:2000]
```

The orchestrator saw a well-formed answer that stopped mid-sentence, concluded the subagent had been cut off, and dispatched a *new* task asking it to finish. A full extra round-trip burned on work that was already complete and stored intact — and invisible without span-level tracing, which is exactly how @marcelmbn found it.

Inferring "this was truncated, let me re-delegate" is the reasonable read of that input. The framework gave the model no way to know better.

## The fix

Truncation stays (the context budget is real), but it stops lying. A cut result now ends with an explicit marker:

```text
...the last of the 2000 shown characters

[Result truncated for display: showing 2000 of 5231 characters. The subagent's
answer is complete and stored in full. Call check_task('abc123') to read all of it.]
```

The marker is the load-bearing part: it says the cut is ours, that the stored answer is complete, and which call returns the rest. `WAIT_TASKS_DESCRIPTION` and `CHECK_TASK_DESCRIPTION` state the same rule, so the orchestrator knows it before it ever meets a cut result rather than after.

While checking, the two readback paths turned out to disagree: `wait_tasks` cut at 2000 while `check_task` returned the full string uncapped, and nothing told the model which it was getting. `check_task` stays uncapped on purpose — it is now the documented full-fidelity path the marker points at.

## New knob

`max_result_chars` on `create_subagent_toolset` and `SubAgentCapability`, alongside the existing `max_chat_traces` / `max_task_handles`:

- default `2000`, matching the previous hard-coded limit, so nothing changes for existing users
- `None` disables truncation entirely
- a negative value raises `ValueError` rather than silently slicing from the end

## On the fix suggested in the issue

The issue proposed capping the subagent's *own* final answer via its prompt so there is never anything left to truncate. I went a different way, for two reasons:

1. A prompt-level cap is advisory. Models overshoot a character budget, so a downstream guard is still needed for the overshoot case.
2. This is a library, and plenty of subagents return long output on purpose. Making every subagent write to an orchestrator preview budget would degrade those. The budget belongs to the *preview*, not to the answer.

## Tests

21 new tests. `_preview_result` gets the full boundary matrix (`len == max_chars` produces no marker, `+1` does, plus `0`, `None`, and empty-string cases), and `wait_tasks` is covered end to end: marker present, marker absent when the result fits, custom budget, `None` budget, the `Chat Trace ID:` line surviving above a truncated preview, and `check_task` returning the untruncated result.

`make lint`, `make typecheck`, `mkdocs build --strict` and 352 tests at 100% coverage all pass.
