### PR TITLE
fix: require a name for one-shot delegate specialists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Required `name` on `delegate`.** One-shot specialists must be given a label
+  (letters, numbers, hyphens) so they show a readable name in logs and async
+  task handles. The specialist remains unregistered and cannot be reused via
+  `task`.
+
 ## [0.2.11] - 2026-07-31
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ toolset = create_subagent_toolset(
 # delegate(
 #     description="Analyze this CSV and summarize trends",
 #     instructions="You are a data analyst. Return concise findings.",
+#     name="data-analyst",
 #     mode="sync",
 # )
 ```

--- a/docs/advanced/dynamic-agents.md
+++ b/docs/advanced/dynamic-agents.md
@@ -411,6 +411,7 @@ toolset = create_subagent_toolset(
 |-----------|------|-------------|
 | `description` | `str` | Task prompt for the specialist |
 | `instructions` | `str` | Specialist system prompt |
+| `name` | `str` | Label for logs and async task handles (letters, numbers, hyphens) |
 | `model` | `str \| None` | Optional model override |
 | `capabilities` | `list[str] \| None` | Optional capability names |
 | `can_ask_questions` | `bool` | Whether the specialist can ask the parent (default: `True`) |
@@ -422,8 +423,8 @@ One-shot specialists are **ephemeral**:
 
 - They are **not** registered in `DynamicAgentRegistry`
 - They do **not** count toward `max_agents`
-- They cannot be reused via `task(subagent_type=...)`
-- An internal name like `oneshot-{task_id}` is generated for logging and async task handles
+- They cannot be reused via `task(subagent_type=...)`, even though they have a `name`
+- `name` is a display label for logging and async task handles
 - They report **no chat trace**. A `Chat Trace ID` is only useful if `task` can
   resolve the subagent it belongs to, which is never true for a one-shot, so
   `delegate` results omit it and one-shot runs never occupy a slot in the

--- a/docs/concepts/toolset.md
+++ b/docs/concepts/toolset.md
@@ -185,6 +185,7 @@ Create an ephemeral specialist and delegate a task in one call. Available in
 delegate(
     description="Analyze this dataset and summarize key trends",
     instructions="You are a data analyst. Return concise findings.",
+    name="data-analyst",
     mode="sync",
 )
 ```
@@ -195,12 +196,14 @@ delegate(
 |-----------|------|-------------|
 | `description` | `str` | Task prompt for the specialist |
 | `instructions` | `str` | Specialist system prompt |
+| `name` | `str` | Label for logs and async task handles (letters, numbers, hyphens) |
 | `model` | `str \| None` | Optional model override |
 | `capabilities` | `list[str] \| None` | Optional capability names |
 | `can_ask_questions` | `bool` | Whether the specialist can ask the parent |
 | `mode` | `str` | `"sync"`, `"async"`, or `"auto"` |
 
-The specialist is not registered and cannot be reused by name.
+The specialist is not registered and cannot be reused via `task`, even though
+it has a `name`.
 
 ### check_task
 

--- a/src/subagents_pydantic_ai/prompts.py
+++ b/src/subagents_pydantic_ai/prompts.py
@@ -69,6 +69,8 @@ configured subagent or create a persistent agent first
 ## Parameters
 - **description**: The task prompt for the specialist to execute
 - **instructions**: The specialist's system prompt / role definition
+- **name**: Label for logs and async task handles (letters, numbers, hyphens). \
+Does not register the specialist — it still cannot be reused via `task`
 - **model**: Optional model override
 - **capabilities**: Optional capability names to attach to the specialist
 - **mode**: `"sync"` (default), `"async"`, or `"auto"`

--- a/src/subagents_pydantic_ai/toolset.py
+++ b/src/subagents_pydantic_ai/toolset.py
@@ -918,6 +918,7 @@ def create_subagent_toolset(  # noqa: C901
             ctx: RunContext[SubAgentDepsProtocol],
             description: str,
             instructions: str,
+            name: str,
             model: str | None = None,
             capabilities: list[str] | None = None,
             can_ask_questions: bool = True,
@@ -929,13 +930,12 @@ def create_subagent_toolset(  # noqa: C901
         ) -> str:
             """Create an ephemeral specialist and delegate a task in one call."""
             task_id = str(uuid.uuid4())[:8]
-            agent_name = f"oneshot-{task_id}"
             agent_description = description[:120] or "Ephemeral specialist"
             actual_model = model or default_model
 
             result = build_dynamic_agent(
                 ctx,
-                name=agent_name,
+                name=name,
                 description=agent_description,
                 instructions=instructions,
                 model=actual_model,
@@ -951,7 +951,7 @@ def create_subagent_toolset(  # noqa: C901
             agent, config = result
 
             subagent = CompiledSubAgent(
-                name=agent_name,
+                name=name,
                 description=agent_description,
                 agent=agent,
                 config=config,

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -45,6 +45,8 @@ class TestSystemPrompts:
         assert "ephemeral" in DELEGATE_TOOL_DESCRIPTION.lower()
         assert "create_agent" in DELEGATE_TOOL_DESCRIPTION
         assert "instructions" in DELEGATE_TOOL_DESCRIPTION
+        assert "name" in DELEGATE_TOOL_DESCRIPTION
+        assert "hyphens" in DELEGATE_TOOL_DESCRIPTION
 
 
 class TestGetSubagentSystemPrompt:

--- a/tests/test_toolset.py
+++ b/tests/test_toolset.py
@@ -4026,11 +4026,56 @@ class TestDelegationConfiguration:
                 ctx,
                 description="Analyze the data",
                 instructions="You are a data analyst.",
+                name="data-analyst",
             )
 
         # No chat trace: a one-shot specialist is unreachable from `task`, so an
         # id the orchestrator cannot redeem would only invite a failed retry.
         assert result == "oneshot result"
+
+    @pytest.mark.asyncio
+    async def test_delegate_uses_name_on_handle(self):
+        toolset = create_subagent_toolset(
+            delegation_configuration="persisted_and_oneshot",
+            include_general_purpose=False,
+        )
+        delegate_tool = toolset.tools["delegate"]
+        ctx = MockRunContext(deps=MockDeps())
+
+        with patch("subagents_pydantic_ai.dynamic_agent.Agent") as mock_agent_class:
+            mock_agent_class.return_value = FakeAgent(result=MockResult("named result"))
+            start_result = await delegate_tool.function(
+                ctx,
+                description="Analyze the data",
+                instructions="You are a data analyst.",
+                name="data-analyst",
+                mode="async",
+            )
+
+        assert "Task ID:" in start_result
+        task_id = start_result.split("Task ID: ")[1].split("\n")[0]
+        handle = toolset.task_manager.get_handle(task_id)
+        assert handle is not None
+        assert handle.subagent_name == "data-analyst"
+
+    @pytest.mark.asyncio
+    async def test_delegate_rejects_invalid_name(self):
+        toolset = create_subagent_toolset(
+            delegation_configuration="persisted_and_oneshot",
+            include_general_purpose=False,
+        )
+        delegate_tool = toolset.tools["delegate"]
+        ctx = MockRunContext(deps=MockDeps())
+
+        result = await delegate_tool.function(
+            ctx,
+            description="Analyze the data",
+            instructions="You are a data analyst.",
+            name="bad name",
+        )
+
+        assert "Error" in result
+        assert "letters, numbers, and hyphens" in result
 
     @pytest.mark.asyncio
     async def test_delegate_does_not_register_agent(self, registry):
@@ -4049,6 +4094,7 @@ class TestDelegationConfiguration:
                 ctx,
                 description="Do work",
                 instructions="You are a worker.",
+                name="worker",
             )
 
         assert result == "oneshot result"
@@ -4079,6 +4125,7 @@ class TestDelegationConfiguration:
                 ctx,
                 description="Do work",
                 instructions="You are a worker.",
+                name="worker",
             )
 
         assert result == "still works"
@@ -4100,6 +4147,7 @@ class TestDelegationConfiguration:
                 ctx,
                 description="Long analysis",
                 instructions="You are an analyst.",
+                name="analyst",
                 mode="async",
             )
 
@@ -4107,7 +4155,7 @@ class TestDelegationConfiguration:
         task_id = start_result.split("Task ID: ")[1].split("\n")[0]
         handle = toolset.task_manager.get_handle(task_id)
         assert handle is not None
-        assert handle.subagent_name.startswith("oneshot-")
+        assert handle.subagent_name == "analyst"
 
         await asyncio.sleep(0.05)
         status = await check_tool.function(ctx, task_id)
@@ -4127,6 +4175,7 @@ class TestDelegationConfiguration:
             ctx,
             description="Do work",
             instructions="You are a worker.",
+            name="worker",
             model="anthropic:claude-3",
         )
 
@@ -4147,6 +4196,7 @@ class TestDelegationConfiguration:
             ctx,
             description="Do work",
             instructions="You are a worker.",
+            name="worker",
             capabilities=["missing"],
         )
 
@@ -4168,6 +4218,7 @@ class TestDelegationConfiguration:
                 ctx,
                 description="Do work",
                 instructions="You are a worker.",
+                name="worker",
             )
 
         assert "Error executing task" in result
@@ -4190,6 +4241,7 @@ class TestDelegationConfiguration:
                 ctx,
                 description="Long analysis",
                 instructions="You are an analyst.",
+                name="analyst",
                 mode="async",
             )
 
@@ -4239,7 +4291,10 @@ class TestDelegationConfiguration:
             )
             for _ in range(3):
                 await toolset.tools["delegate"].function(
-                    ctx, description="unrelated job", instructions="You are a specialist."
+                    ctx,
+                    description="unrelated job",
+                    instructions="You are a specialist.",
+                    name="specialist",
                 )
 
         resumed = await toolset.tools["task"].function(


### PR DESCRIPTION
## Summary
- Make `name` a required parameter on `delegate` so one-shot specialists always have a readable label in logs and async task handles
- Keep the specialist ephemeral (not registered, not reusable via `task`)
- Update tool description, docs, README, and changelog

## Test plan
- [x] `uv run ruff check && uv run ruff format --check`
- [x] `uv run pyright`
- [x] `uv run coverage run -m pytest && uv run coverage report` (100%)
- [ ] Confirm `delegate(..., name="data-analyst")` shows that name on async `TaskHandle.subagent_name`
- [ ] Confirm invalid names (e.g. spaces) return the validation error


Made with [Cursor](https://cursor.com)