### PR TITLE
refactor: fix delegation defects, raise typing bar, expand docs (0.2.12)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         run: uv run pyright
 
       - name: Run MyPy
-        run: uv run mypy src/subagents_pydantic_ai
+        run: uv run mypy src/subagents_pydantic_ai tests
 
   test:
     name: Test Python ${{ matrix.python-version }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,160 @@
+# Subagents for Pydantic AI
+
+## Repository purpose
+
+`subagents-pydantic-ai` gives any Pydantic AI agent the ability to delegate work to
+child agents -- synchronously, in the background, or by letting the library choose.
+It owns the delegation policy: which specialists exist, how a task is dispatched,
+how a running child is steered or cancelled, and what a failure looks like to the
+parent model.
+
+Pydantic AI core owns the runtime underneath: the agent loop, normalized messages,
+tool execution, capability hooks, and `AgentRun`. When a change needs new core
+semantics, propose the core change rather than reimplementing it here. `retry.py` is
+the one place that mirrors core internals, and it says why in its module docstring.
+
+## Vocabulary
+
+- **Subagent** -- a child agent the parent can delegate to, defined by a
+  `SubAgentConfig` and compiled into a `CompiledSubAgent`.
+- **Delegation** -- one task handed to one subagent. Sync delegations block the
+  parent; background ones return a task id.
+- **Task handle** -- `TaskHandle`, the record of a delegation: status, result,
+  timestamps, usage, cost, trace ids.
+- **Chat trace** -- a stored subagent conversation that a later delegation can
+  continue with `chat_trace_id`.
+- **Steering** -- an unprompted parent-to-child message delivered to a running
+  background task, distinct from answering a question the child asked.
+- **Delegation configuration** -- which entry-point tools the model sees: `task`,
+  `create_agent`, `delegate`, or a combination.
+
+## Preflight
+
+Before changing delegation behaviour:
+
+1. Read the relevant `agent_docs/` guide (`agent_docs/index.md` lists them).
+2. Read the public Pydantic AI docs for every integration point you touch:
+   - capabilities: <https://ai.pydantic.dev/capabilities/>
+   - toolsets: <https://ai.pydantic.dev/toolsets/>
+   - agents: <https://ai.pydantic.dev/agents/>
+   - testing: <https://ai.pydantic.dev/testing/>
+3. Check the installed `pydantic_ai` source for exact signatures. Do not assume a
+   contributor's checkout layout.
+4. Check whether pydantic-ai already provides the primitive. `AgentRun.enqueue`
+   replaced a hand-rolled message-part injection; `AgentRun.next` and
+   `RunContext.run_id` cover more than they look like they do.
+
+## Reference repositories
+
+`pydantic-ai-harness` sets the bar for module shape, typing, and writing style, and
+has its own sub-agent capability worth comparing against.
+`pydantic-ai-backend` sets the bar for documentation structure.
+
+## Coding standards
+
+- Python 3.10+, supported through 3.13.
+- **pyright strict** and **mypy strict**, over `src/` and `tests/`. No
+  `# type: ignore` in `src/`. The per-rule exemptions in `pyproject.toml` each carry
+  a comment saying why.
+- **ruff**: line-length 100, double quotes, `max-complexity = 15`, no per-function
+  `noqa`. If a function trips the ceiling, split it.
+- **100% branch coverage** is the merge gate. Coverage is necessary, not
+  sufficient: this library once shipped a defect that changed every model-facing
+  status string while reporting 100%. Assert the output a caller or a model actually
+  sees, not just that a branch executed.
+- Docstrings use single backticks for inline code, never double.
+- Comments explain **why**. Delete anything that restates the code.
+- No `Any` in a new public signature. `CompiledSubAgent.agent` is the documented
+  exception: consumers pass their own agent objects.
+
+## Writing style
+
+Applies to docs, docstrings, comments, commit messages, and PR text.
+
+- State facts, not sales copy. No "blazingly fast", "battle-tested", "footgun".
+- Avoid absolute claims unless they are literally true and load-bearing. Name the
+  mechanism instead of the slogan.
+- Document the constraint and the non-obvious. Do not restate the signature.
+- Bold sparingly -- the lead-in term of a list item, not whole sentences.
+
+## Package management
+
+Use `uv` for every dependency operation (`uv add`, `uv remove`, `uv sync`). Do not
+hand-edit `pyproject.toml` dependency lists or `uv.lock`.
+
+## Commands
+
+```bash
+make format      # ruff format + ruff check --fix
+make lint        # ruff format --check + ruff check
+make typecheck   # pyright strict
+make typecheck-both  # pyright + mypy over src and tests
+make test        # pytest with coverage
+make testcov     # coverage HTML report
+make docs        # mkdocs build
+make all         # format, lint, typecheck, testcov
+```
+
+Run `make lint && make typecheck-both && make test` before committing, and
+`uv run mkdocs build --strict` before pushing a docs change.
+
+## File structure
+
+```
+src/subagents_pydantic_ai/
+  __init__.py          # public API, one `X as X` re-export per name
+  toolset.py           # SubAgentToolset, create_subagent_toolset, _compile_subagent
+  capability.py        # SubAgentCapability, including the wrap_run finalizer
+  types.py             # SubAgentConfig, TaskHandle, enums, type aliases
+  protocols.py         # SubAgentDepsProtocol, MessageBusProtocol
+  prompts.py           # system prompts and model-facing tool descriptions
+  registry.py          # DynamicAgentRegistry
+  dynamic_agent.py     # validate + build a runtime specialist
+  factory.py           # create_agent_factory_toolset
+  message_bus.py       # TaskManager, InMemoryMessageBus
+  retry.py             # transient-failure retry, resuming from history
+  _execution.py        # runs one delegation; owns the error contract
+  _observability.py    # telemetry captured onto a TaskHandle
+  _chat_trace.py       # LRU-bounded conversation store
+  _state.py            # per-delegation state for ask_parent
+tests/
+  __init__.py          # required: mypy's `tests.*` override needs the package name
+  test_<module>.py     # mirrors the source module
+  test_lifecycle.py    # cross-module regressions (isolation, cancellation, status)
+  test_docs.py         # snippets in docs/ and README compile and match the API
+```
+
+`toolset.py` must keep importing `Agent` at module level and defining
+`_compile_subagent`: pydantic-deep patches `subagents_pydantic_ai.toolset.Agent` and
+imports `_compile_subagent`.
+
+## Compatibility
+
+pydantic-deep is a first-party consumer and reaches past the public API. Before
+changing a signature, an export, or a module path, check it:
+
+```bash
+cd ../pydantic-deep
+PYTHONPATH=../pydantic-ai-subagents/src uv run pytest -q
+```
+
+Known couplings: `subagents_pydantic_ai.toolset.Agent` (patched in tests),
+`subagents_pydantic_ai.toolset._compile_subagent`, and
+`getattr(toolset, "task_manager")`.
+
+## Testing patterns
+
+- No live model calls. Use `pydantic_ai.models.test.TestModel`, or the local
+  `StubAgent` / `FakeAgent` fakes, which drive `.iter()` the way `Agent.run` does.
+- Group tests in `TestSomething` classes; name methods for the behaviour
+  (`test_check_task_renders_status_value`).
+- `asyncio_mode = "auto"`, so async tests need no marker.
+- A regression test names the defect it pins in its docstring.
+- `# pragma: no cover` needs a reason a reviewer will accept.
+
+## Git
+
+- Conventional Commits (`fix:`, `feat:`, `docs:`, `refactor:`).
+- Never commit to `main`; branch first.
+- Update `CHANGELOG.md` for anything user-visible.
+- Do not attribute commits to an AI.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,26 @@ entry point keeps its name and signature, so no import or call site changes.
 - **`TaskHandle.finish()` and `TaskHandle.is_finished`** for idempotent terminal
   transitions, plus `TERMINAL_STATUSES` and `utcnow` as exports.
 - **`TaskManager.cancel_all()`** and **`TaskManager.resolve_answer()`**.
+- **`SubAgentToolset.answer_task()` and `SubAgentToolset.steer_task()`** — the
+  Python halves of the `answer_subagent` and `send_message_to_subagent` tools, for
+  an application that drives delegation itself instead of letting a model call the
+  tools. Both return a `bool` rather than raising. The tools now delegate to them,
+  so there is one implementation.
+- **`SubAgentSpec` covers the whole serialisable config.** It mirrored 11 keys, so a
+  YAML-defined subagent could not set `max_retries`, any `retry_*` option,
+  `agent_kwargs`, `on_failure`, or `contain_errors` — the loader silently ignored
+  what it had no field for. It also validates now: `max_retries` cannot be negative,
+  `retry_backoff_multiplier` cannot shrink the delay, and `retry_max_delay` cannot
+  sit below `retry_initial_delay` (which pinned every retry to the cap instead of
+  backing off). `tests/test_spec.py` fails if the config gains a serialisable key
+  the spec cannot carry.
+
+### Removed
+
+- **`SubAgentDepsProtocol.subagents`.** The library never read it, so every
+  application carried a `dict` for nothing. Dropping a requirement only widens what
+  satisfies the protocol, so a deps class that still declares the field is
+  unaffected.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,16 @@ entry point keeps its name and signature, so no import or call site changes.
   satisfies the protocol, so a deps class that still declares the field is
   unaffected.
 
+### Changed (breaking)
+
+- **`delegate` requires a `name`.** A one-shot specialist was labelled
+  `oneshot-{task_id}`, which told an operator reading logs or a `TaskHandle`
+  nothing about what the specialist was for. The caller now supplies the label
+  (letters, numbers, hyphens, validated the same way as `create_agent`), and it
+  becomes `TaskHandle.subagent_name`. Naming a one-shot still does not register it:
+  it does not count toward `max_agents`, cannot be reached via `task`, and reports
+  no chat trace. Any code or prompt that calls `delegate` must pass `name`.
+
 ### Changed
 
 - **`SubAgentConfig` enforces its required keys.** `name`, `description`, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.2.12] - 2026-08-01
 
 Correctness, typing, and documentation pass over the whole library. Every public
 entry point keeps its name and signature, so no import or call site changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,126 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+Correctness, typing, and documentation pass over the whole library. Every public
+entry point keeps its name and signature, so no import or call site changes.
+
+### Fixed
+
+- **Task statuses leaked their enum member name to the model.** `TaskStatus` is a
+  `str`-mixin `Enum`, and Python 3.11 changed `Enum.__format__` for mixin enums, so
+  `check_task` reported `Status: TaskStatus.WAITING_FOR_ANSWER` on 3.11+ while the
+  tool descriptions and docs promised `waiting_for_answer`. `list_active_tasks` and
+  `wait_tasks` had the same leak. Statuses, priorities, and message types now render
+  as their values on every supported Python.
+- **Deferred tools and human approval could not work inside a subagent.**
+  `except Exception` around the run swallowed pydantic-ai's control-flow signals
+  (`CallDeferred`, `ApprovalRequired`, `SkipModelRequest`, `SkipToolValidation`,
+  `SkipToolExecution`) and turned them into a string result the parent read as a
+  finished task. Those signals, `UserError`, and a shared `UsageLimitExceeded` now
+  propagate. A background delegation cannot suspend at all, so it reports a `failed`
+  status explaining to delegate with `mode="sync"` instead.
+- **A failed delegation looked like a successful one.** A crash returned
+  `"Error executing task: ..."` as a normal tool result, so pydantic-ai's retry
+  budget never engaged and the failure could be folded into a final answer. Failures
+  now reach the parent as `ModelRetry`. See `contain_errors` and `on_failure` under
+  *Added*.
+- **Background tasks outlived their parent run.** Nothing cancelled the
+  `asyncio.Task` behind a background delegation when the run ended, so it kept
+  executing against torn-down deps, and one blocked in `ask_parent` waited out the
+  full timeout. `SubAgentCapability` now cancels its run's tasks in a `wrap_run`
+  finalizer, and `TaskManager.cancel_all()` exposes the same thing to the toolset API.
+- **Tasks were not isolated per run.** One toolset instance is typically built per
+  agent and shared by every run it serves, so any run could inspect, answer, steer,
+  or cancel another run's task by id. Handles record `parent_run_id` and the tools
+  refuse ids belonging to another run.
+- **`hard_cancel` could overwrite a completed task's result.** The guard was
+  `if not task.done()`, which is still true while the task runs its `finally`, so a
+  cancel arriving in that window replaced the real result with `cancelled`.
+  `TaskHandle.finish()` makes the first terminal transition win.
+- **The library wrote a private attribute onto the caller's deps object.**
+  `deps._subagent_state = {...}` raised `AttributeError` for a deps class declared
+  `frozen=True` or `slots=True`, both of which `SubAgentDepsProtocol` allows. The
+  state is a typed `SubAgentState` carried in a `ContextVar` instead. Reading a
+  caller-injected `deps._subagent_state` still works.
+- **Timestamps were naive local time.** `TaskHandle.created_at`, `started_at`, and
+  `completed_at` are timezone-aware UTC, so elapsed time and eviction order stay
+  correct across a DST transition.
+- **`get_subagent_system_prompt(include_dual_mode=...)` was accepted and ignored.**
+  It now appends `DUAL_MODE_SYSTEM_PROMPT` when asked. The default changed to
+  `False`, so output is unchanged for callers that never passed it.
+- **Steering could be spliced into the wrong place.** Parent-to-child steering
+  appended `UserPromptPart`s directly into a graph node's request. It now goes
+  through pydantic-ai's `AgentRun.enqueue`, so core places the parts and they can
+  never land between a tool call and its return.
+- **The retry driver had drifted from the loop it mirrors.** `Agent.run` drains the
+  wrapped event stream after the handler returns, unconditionally; the copy drained
+  only when there was no handler, leaving stream wrappers unfinished for a handler
+  that stopped reading early.
+- **409 Conflict and 425 Too Early were retried as transient.** Both signal a request
+  the server rejected on its merits, so replaying it unchanged is not expected to
+  help.
+- **A message-bus handler that raised was silently swallowed** by a bare
+  `except Exception: pass`. Failures are logged and delivery continues.
+- **`asyncio.get_event_loop()` inside a coroutine** (deprecated since 3.10) is now
+  `get_running_loop()`.
+- **Cancelling a finished task reported "not found"**, inviting the model to conclude
+  the work was lost. It now reports the task's status and points at `check_task`.
+- **`make typecheck-mypy` was broken.** The `module = "tests.*"` override never
+  matched, because `tests/` had no `__init__.py` and mypy named the modules
+  `test_toolset` rather than `tests.test_toolset`; the target reported 583 errors the
+  config intended to relax. It is green and runs in CI.
+
+### Added
+
+- **`contain_errors`** on `create_subagent_toolset`, `SubAgentCapability`, and
+  `SubAgentConfig`. Defaults to `True`: an unexpected subagent crash becomes a
+  `ModelRetry` for the parent, logged with its traceback, so one failed delegation
+  cannot abort the run. Set `False` to let crashes propagate.
+- **`on_failure`** on `SubAgentConfig`. Returns a steering message to the parent as
+  an ordinary tool result instead of raising `ModelRetry`, for a failure where
+  re-delegating is pointless.
+- **`ask_timeout_seconds`** on `create_subagent_toolset` and `SubAgentCapability`,
+  replacing a hardcoded 300-second wait in `ask_parent`.
+- **`SubAgentToolset` is a real class.** It was an alias for
+  `create_subagent_toolset`, whose result had `task_manager`,
+  `message_history_store`, and `get_total_usage` attached afterwards behind three
+  `type: ignore` comments. It is now a `FunctionToolset` subclass with those as typed
+  members, and `create_subagent_toolset()` returns an instance —
+  `SubAgentToolset(subagents=[...])`, `toolset.task_manager`, and
+  `isinstance(t, FunctionToolset)` all keep working.
+- **`TaskHandle.finish()` and `TaskHandle.is_finished`** for idempotent terminal
+  transitions, plus `TERMINAL_STATUSES` and `utcnow` as exports.
+- **`TaskManager.cancel_all()`** and **`TaskManager.resolve_answer()`**.
+
+### Changed
+
+- **`SubAgentConfig` enforces its required keys.** `name`, `description`, and
+  `instructions` were documented as required but optional to the type checker, and
+  the library indexed them directly, so a config missing one raised `KeyError` mid
+  delegation. Call sites are unchanged; both type checkers now catch it.
+- **Typing bar raised to match `pydantic-ai-harness`.** pyright runs in **strict**
+  mode, `src/` has no `type: ignore`, mypy strict covers tests as well as source, and
+  ruff's complexity ceiling dropped from 30 to 15 with no per-function `noqa`.
+  `TaskHandle.usage` is `RunUsage | None`, `finish_reason` is `FinishReason | None`,
+  and `TaskManager.handles` is `dict[str, TaskHandle]`.
+- **`ToolsetFactory` returns a `Sequence`**, so a factory annotated
+  `list[FunctionToolset[MyDeps]]` satisfies it — `list` is invariant.
+- **`toolset.py` split into focused modules** (`_execution`, `_observability`,
+  `_chat_trace`, `_state`), with the historical names still importable from
+  `subagents_pydantic_ai.toolset`.
+- **Documentation.** New pages for [observability](https://vstorm-co.github.io/subagents-pydantic-ai/concepts/observability/),
+  [steering](https://vstorm-co.github.io/subagents-pydantic-ai/advanced/steering/), [chat traces](https://vstorm-co.github.io/subagents-pydantic-ai/advanced/chat-traces/),
+  [failure handling](https://vstorm-co.github.io/subagents-pydantic-ai/advanced/errors/), and
+  [usage limits](https://vstorm-co.github.io/subagents-pydantic-ai/advanced/usage-limits/); API reference pages for the
+  registry, message bus, retry, spec, and dynamic-agent helpers; a changelog page.
+  Corrected the stale tool and feature tables on the index, the
+  `general_purpose_config` parameter that never existed, and the nesting guide's
+  claim that `max_nesting_depth` enforces a limit — it does not, the gate is what
+  `toolsets_factory` hands the child. Snippets in `docs/` and `README.md` are now
+  checked for syntax and API drift by `tests/test_docs.py`.
+
 ## [0.2.11] - 2026-07-31
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ typecheck-mypy:
 	uv run mypy src/subagents_pydantic_ai tests
 
 .PHONY: typecheck
-typecheck: typecheck-pyright ## Run static type checking
+typecheck: typecheck-pyright ## Run static type checking (pyright, strict)
 
 .PHONY: typecheck-both
 typecheck-both: typecheck-pyright typecheck-mypy ## Run static type checking with both Pyright and Mypy

--- a/README.md
+++ b/README.md
@@ -249,12 +249,14 @@ The parent agent can then respond using `answer_subagent(task_id, answer)`.
 
 | Tool | Description |
 |------|-------------|
+| `task` | Delegate a task to a configured or registry-backed subagent |
 | `create_agent` | Create a reusable registry-backed specialist (opt-in modes) |
-| `task` | Delegate a task to a subagent (sync, async, or auto) |
-| `delegate` | Create and run an ephemeral specialist in one call |
-| `check_task` | Check status and get result of a background task |
+| `delegate` | Create and run an ephemeral specialist in one call (opt-in modes) |
+| `check_task` | Check status and get the full result of a background task |
+| `wait_tasks` | Wait for background tasks, in `all` or `any` mode |
+| `list_active_tasks` | List the running background tasks of this run |
 | `answer_subagent` | Answer a question from a blocked subagent |
-| `list_active_tasks` | List all running background tasks |
+| `send_message_to_subagent` | Steer a running background subagent |
 | `soft_cancel_task` | Request cooperative cancellation |
 | `hard_cancel_task` | Immediately cancel a task |
 
@@ -315,23 +317,29 @@ SubAgentConfig(
 ## Architecture
 
 ```
-┌─────────────────────────────────────────────────────────┐
-│                     Parent Agent                        │
-│  ┌─────────────────────────────────────────────────┐    │
-│  │              Subagent Toolset                   │    │
-│  │  task() │ check_task() │ answer_subagent()      │    │
-│  └─────────────────────────────────────────────────┘    │
-│                         │                               │
-│         ┌───────────────┼───────────────┐               │
-│         ▼               ▼               ▼               │
-│  ┌────────────┐  ┌────────────┐  ┌────────────┐         │
-│  │ researcher │  │   writer   │  │   coder    │         │
-│  │  (sync)    │  │  (async)   │  │  (auto)    │         │
-│  └────────────┘  └────────────┘  └────────────┘         │
-│                                                         │
-│              Message Bus (pluggable)                    │
-└─────────────────────────────────────────────────────────┘
+┌──────────────────────────────────────────────────────────────┐
+│                        Parent Agent                          │
+│  ┌────────────────────────────────────────────────────────┐  │
+│  │                    SubAgentToolset                     │  │
+│  │  task · delegate · check_task · wait_tasks · cancel…   │  │
+│  │                                                        │  │
+│  │  TaskManager   ChatTraceStore   DynamicAgentRegistry   │  │
+│  └────────────────────────────────────────────────────────┘  │
+│                            │                                 │
+│         ┌──────────────────┼──────────────────┐              │
+│         ▼                  ▼                  ▼              │
+│  ┌────────────┐     ┌────────────┐     ┌────────────┐        │
+│  │ researcher │     │   writer   │     │   coder    │        │
+│  │   (sync)   │     │(background)│     │   (auto)   │        │
+│  └────────────┘     └────────────┘     └────────────┘        │
+│         │                  │                  │              │
+│         └──── TaskHandle: status · usage · cost · trace ──────┤
+└──────────────────────────────────────────────────────────────┘
 ```
+
+A background subagent stays reachable while it runs: the parent can steer it,
+answer its questions, and cancel it. `SubAgentCapability` cancels the run's
+background tasks when the run ends, so nothing outlives its parent.
 
 ## Vstorm OSS Ecosystem
 

--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ toolset = create_subagent_toolset(
 # delegate(
 #     description="Analyze this CSV and summarize trends",
 #     instructions="You are a data analyst. Return concise findings.",
+#     name="data-analyst",
 #     mode="sync",
 # )
 ```

--- a/agent_docs/core-boundary.md
+++ b/agent_docs/core-boundary.md
@@ -1,0 +1,45 @@
+# Core boundary
+
+This library extends Pydantic AI through public primitives. It should not become a
+second runtime.
+
+## Belongs in Pydantic AI core
+
+- new agent loop semantics
+- new normalized message parts, or message-history behaviour
+- provider or model capability facts
+- generic tool execution semantics
+- durable execution primitives
+- new capability hooks, or changes to hook ordering
+
+## Belongs here
+
+- which specialists exist and how the model is told about them
+- how a task is dispatched: sync, background, or chosen from characteristics
+- what a delegation failure looks like to the parent model
+- steering, cancellation, and question policy
+- what telemetry a delegation records
+- memory bounds on retained tasks and conversations
+
+## Decision rule
+
+If a feature would be hard for any third-party toolset to implement through public
+Pydantic AI APIs, do not work around it here. Identify the missing primitive and
+propose that change first.
+
+`retry.py` is the standing exception, and it is not a comfortable one. Driving a run
+with a custom step while keeping event streaming has no public equivalent, so
+`_drive_run` mirrors the loop inside `Agent.run` using private names. That copy has
+drifted from core once already. Its module docstring records the coupling; the fix
+is a public primitive in core, not more copying.
+
+## Primitives worth checking before writing your own
+
+| Need | Core primitive |
+|---|---|
+| Inject a message into a live run | `AgentRun.enqueue` / `RunContext.enqueue` |
+| Identify the current run | `RunContext.run_id` |
+| Drive a run node by node with hooks intact | `AgentRun.next` |
+| Recover a failed attempt's messages | `AgentRun.all_messages()` |
+| Wrap a whole run | `AbstractCapability.wrap_run` |
+| Cap tokens or requests | `UsageLimits` |

--- a/agent_docs/delegation-contracts.md
+++ b/agent_docs/delegation-contracts.md
@@ -1,0 +1,83 @@
+# Delegation contracts
+
+The invariants a change to delegation must preserve. Each one exists because
+breaking it produced a real defect.
+
+## What the model sees is part of the API
+
+Tool return strings are the interface to the orchestrating model, and it acts on
+them. `TaskStatus` is a `str`-mixin enum whose `__format__` changed in Python 3.11,
+which turned `Status: waiting_for_answer` into `Status: TaskStatus.WAITING_FOR_ANSWER`
+on 3.11+ with no test noticing.
+
+- Assert the exact rendered string, not that a branch ran.
+- Render enums as `.value`, or through `_ValueStrEnum`, never bare in an f-string.
+- A truncated result carries an explicit marker saying the cut is ours and the
+  stored answer is complete. A silent cut reads as a subagent that stopped
+  mid-sentence, and the model "recovers" by re-delegating the same work.
+
+## Signals are not failures
+
+`CallDeferred`, `ApprovalRequired`, and the `Skip*` exceptions are how core suspends
+a run for approval or a deferred tool. `UserError` is a setup bug. A shared
+`UsageLimitExceeded` means the whole tree is out of budget. All of these propagate;
+`_ALWAYS_PROPAGATE` in `_execution.py` is the list, and `contain_errors` does not
+apply to it.
+
+Everything else reaches the parent as `ModelRetry`, so pydantic-ai's retry budget
+engages. Never return a failure as a plain string result: to the model that is a
+successful tool call whose text happens to start with `Error`.
+
+A background delegation cannot suspend -- its tool result was returned long ago --
+so a human-in-the-loop signal there becomes a `failed` status telling the model to
+delegate synchronously.
+
+## A task never outlives its parent run
+
+Background delegations are `asyncio.Task`s nobody awaits. `SubAgentCapability`
+cancels its run's tasks in a `wrap_run` finalizer. If you add another entry point
+that spawns tasks, it needs the same guarantee, or an orphan keeps running against
+torn-down deps.
+
+## Tasks are scoped to the run that started them
+
+One toolset instance is typically built once per agent and shared by every run it
+serves. Handles record `parent_run_id`, and `_handle_for` refuses ids from another
+run. Any new tool that takes a `task_id` must go through it; a direct
+`task_manager.get_handle` lookup reintroduces cross-run access.
+
+`TaskManager.handles` stays globally readable on purpose -- external monitoring
+depends on it.
+
+## Terminal transitions are idempotent
+
+`TaskHandle.finish()` lets the first terminal transition win. A task inside its
+`finally` is not `asyncio.Task.done()`, so a cancel arriving in that window used to
+overwrite a real result. Do not assign `status` and `completed_at` directly on a
+finishing path.
+
+## The caller's deps are read-only
+
+`SubAgentDepsProtocol` permits a `frozen=True` or `slots=True` deps class. The
+library never writes attributes onto deps; per-delegation state is a typed
+`SubAgentState` in a `ContextVar` (`_state.py`). `clone_for_subagent` must return a
+new instance -- returning `self` shares state between concurrent subagents.
+
+## Timestamps are timezone-aware UTC
+
+`utcnow()` in `types.py`. Handles are compared and subtracted for elapsed time and
+eviction order, and naive local timestamps make that arithmetic wrong across a DST
+transition.
+
+## Memory is bounded
+
+`max_task_handles` and `max_chat_traces` are LRU limits. Eviction folds usage into
+`get_total_usage()` first, so aggregates survive it. Anything new that accumulates
+per delegation needs a bound and a documented eviction rule.
+
+## A chat trace has one owner and one writer
+
+A trace belongs to one subagent, and only one task may run on it at a time --
+concurrent tasks would both save at the end and the slower save would discard the
+faster one's history. A one-shot specialist gets no trace: `task` cannot resolve an
+unregistered agent, so the id would be unredeemable.

--- a/agent_docs/index.md
+++ b/agent_docs/index.md
@@ -1,0 +1,11 @@
+# Agent docs
+
+Guides for anyone -- human or automated -- changing this library. `AGENTS.md` in the
+repo root carries the standards; these pages carry the task-specific detail.
+
+| Guide | Read it when |
+|---|---|
+| [core-boundary.md](core-boundary.md) | Deciding whether a change belongs here or in Pydantic AI core |
+| [delegation-contracts.md](delegation-contracts.md) | Touching how a delegation runs, fails, or is cancelled |
+| [testing.md](testing.md) | Adding or changing tests |
+| [review-checklist.md](review-checklist.md) | Before opening or reviewing a PR |

--- a/agent_docs/review-checklist.md
+++ b/agent_docs/review-checklist.md
@@ -1,0 +1,36 @@
+# Review checklist
+
+## Product fit
+
+- The behaviour belongs here, not in Pydantic AI core (`core-boundary.md`).
+- The public surface is small and named around user concepts.
+- An existing core primitive was checked for first.
+
+## Implementation
+
+- Public exports are intentional; private helpers stay private.
+- No `Any` in a new public signature, and no `type: ignore` in `src/`.
+- Every invariant in `delegation-contracts.md` still holds.
+- Model-facing strings render enums as values.
+- Anything accumulating per delegation is bounded.
+- Any new `task_id` tool goes through `_handle_for`.
+- Dependency changes went through `uv` and have a reason.
+
+## Tests
+
+- New behaviour has tests; a fixed bug has a regression test naming it.
+- Tests assert the output a caller or a model sees.
+- `make lint && make typecheck-both && make test` pass, with coverage at 100%.
+
+## Compatibility
+
+- pydantic-deep still passes:
+  `cd ../pydantic-deep && PYTHONPATH=../pydantic-ai-subagents/src uv run pytest -q`
+- No public name, signature, or module path moved without a shim.
+
+## Docs
+
+- `docs/` covers the change, and `uv run mkdocs build --strict` is clean.
+- `tests/test_docs.py` passes.
+- `CHANGELOG.md` has an entry for anything user-visible, saying what broke and why
+  it mattered -- not just what changed.

--- a/agent_docs/testing.md
+++ b/agent_docs/testing.md
@@ -1,0 +1,58 @@
+# Testing
+
+## Rules
+
+- No live model calls, ever. `pydantic_ai.models.test.TestModel` for anything
+  needing a real `Agent`; `StubAgent` (`tests/test_lifecycle.py`) or `FakeAgent`
+  (`tests/test_toolset.py`) when you want to control the run.
+- The fakes drive `.iter()` the way `Agent.run` does, so they exercise the real
+  execution path rather than a shortcut around it.
+- `asyncio_mode = "auto"`: async tests need no marker, and adding
+  `@pytest.mark.asyncio` to a sync test raises a warning.
+- Construct the toolset with `default_model=TestModel()`. The `"openai:gpt-4.1"`
+  default needs the `openai` package at construction time.
+
+## What a good test asserts
+
+Assert what a caller or a model receives.
+
+```python
+# Weak: the branch ran.
+assert handle.status == TaskStatus.COMPLETED
+
+# Strong: the model was told the truth.
+result = await toolset.tools["check_task"].function(ctx, "t1")
+assert "Status: completed" in result
+assert "TaskStatus." not in result
+```
+
+100% branch coverage is the gate, and it is not enough on its own -- the suite
+reported 100% while every `check_task` call leaked an enum member name.
+
+## Regression tests
+
+A test that pins a defect says so in its docstring: what broke, and why it was not
+caught. `tests/test_lifecycle.py` is the home for cross-module ones (run isolation,
+cancellation, terminal transitions, status rendering).
+
+## Background tasks
+
+`asyncio.create_task` schedules a task; it has not started when the call returns.
+`await asyncio.sleep(0)` before asserting on a running task, or before cancelling
+one you want to observe stopping mid-run.
+
+Release blocked tasks at the end of a test:
+
+```python
+block.set()
+await asyncio.gather(*toolset.task_manager.tasks.values(), return_exceptions=True)
+```
+
+## Docs
+
+`tests/test_docs.py` checks that every fenced `python` block in `docs/` and
+`README.md` parses, imports names that exist, and passes real keyword arguments to
+the documented entry points. Snippets are not executed.
+
+Illustrative blocks -- diagrams, `...` elisions, prose comparisons -- belong in a
+```text fence, not ```python.

--- a/docs/advanced/chat-traces.md
+++ b/docs/advanced/chat-traces.md
@@ -1,0 +1,126 @@
+# Chat traces
+
+By default every delegation starts a subagent from nothing. A chat trace lets the
+next delegation continue where the last one stopped, so a follow-up does not have
+to restate the context.
+
+```python
+from pydantic_ai import Agent
+from subagents_pydantic_ai import SubAgentCapability, SubAgentConfig
+
+agent = Agent(
+    "openai:gpt-4.1",
+    capabilities=[
+        SubAgentCapability(
+            subagents=[
+                SubAgentConfig(
+                    name="analyst",
+                    description="Analyses datasets",
+                    instructions="You analyse datasets and explain your reasoning.",
+                ),
+            ],
+        )
+    ],
+)
+
+result = await agent.run(
+    "Have the analyst look at Q3 revenue, then ask the same analyst "
+    "to compare it with Q2 without re-reading Q3."
+)
+```
+
+## What the model sees
+
+Every result from a continuable delegation ends with the trace id:
+
+```text
+Revenue grew 12% quarter on quarter, driven by ...
+
+Chat Trace ID: 4f2c8a1e9b7d4c5eab3f
+```
+
+Passing that id back continues the same conversation:
+
+```text
+task(description="Now compare with Q2", subagent_type="analyst",
+     chat_trace_id="4f2c8a1e9b7d4c5eab3f")
+```
+
+Omitting it starts a fresh one. The tool description tells the model to continue
+*intentionally* -- a follow-up that genuinely builds on the previous answer, not
+every call to the same subagent.
+
+## The rules
+
+A trace belongs to one subagent and one task at a time.
+
+- **Same subagent only.** A trace records one agent's messages; replaying them
+  into a different agent produces a conversation that agent never had. Continuing
+  with the wrong subagent returns an error.
+- **One task at a time.** A trace with a running task cannot be continued. Two
+  concurrent tasks would both save their history at the end, and the slower save
+  would silently discard the faster one's work. The error tells the model to wait
+  with `check_task` or `wait_tasks`.
+- **Only successful runs are stored.** A failed first run saves nothing, so its id
+  would resume an empty conversation. Neither the result text nor `check_task`
+  advertises a trace in that case.
+
+## Where history lives
+
+Histories are kept in memory, bounded by an LRU:
+
+```python
+from subagents_pydantic_ai import create_subagent_toolset
+
+toolset = create_subagent_toolset(max_chat_traces=100)
+```
+
+Reading a trace refreshes its recency, so a conversation the orchestrator keeps
+continuing is not evicted underneath it. Past the limit the least recently used
+trace is dropped, and continuing an evicted one returns an error telling the model
+to start a new conversation rather than silently starting one.
+
+The store is readable from Python, keyed by `(subagent_name, chat_trace_id)`:
+
+```python
+for (subagent, trace_id), messages in toolset.message_history_store.items():
+    print(subagent, trace_id, len(messages))
+```
+
+!!! warning "In-process only"
+    Traces live in the toolset instance. They do not survive a restart and are not
+    shared between workers. For a conversation that must outlive the process, keep
+    pydantic-ai's own `message_history` in your own store and pass it when you
+    construct the subagent.
+
+## One-shot specialists have no trace
+
+`delegate` builds an ephemeral specialist that is never registered, so `task`
+could not resolve it later. Handing out a trace id for it would promise a
+continuation that cannot happen, so one-shot runs report no trace and store no
+history -- which also stops them from consuming LRU slots that a continuable
+conversation would use.
+
+See [Dynamic agents](dynamic-agents.md) for the difference between `create_agent`
+and `delegate`.
+
+## Background tasks
+
+An async delegation reports its trace when the task starts, and `check_task` and
+`wait_tasks` repeat it only once the task has **completed** -- a failed or still
+running task has not saved this run's history yet, so advertising the id earlier
+would invite the model to resume nothing.
+
+```text
+Task started in background.
+Task ID: a1b2c3d4
+Subagent: analyst
+Chat Trace ID: 4f2c8a1e9b7d4c5eab3f
+Use check_task('a1b2c3d4') to check status.
+```
+
+## Next steps
+
+- [Execution modes](execution-modes.md) -- sync, background, and auto
+- [Observability](../concepts/observability.md) -- `chat_trace_id` on the handle
+- [Dynamic agents](dynamic-agents.md) -- reusable versus one-shot specialists

--- a/docs/advanced/dynamic-agents.md
+++ b/docs/advanced/dynamic-agents.md
@@ -411,6 +411,7 @@ toolset = create_subagent_toolset(
 |-----------|------|-------------|
 | `description` | `str` | Task prompt for the specialist |
 | `instructions` | `str` | Specialist system prompt |
+| `name` | `str` | Label for logs and async task handles (letters, numbers, hyphens) |
 | `model` | `str \| None` | Optional model override |
 | `capabilities` | `list[str] \| None` | Optional capability names |
 | `can_ask_questions` | `bool` | Whether the specialist can ask the parent (default: `True`) |
@@ -422,8 +423,8 @@ One-shot specialists are **ephemeral**:
 
 - They are **not** registered in `DynamicAgentRegistry`
 - They do **not** count toward `max_agents`
-- They cannot be reused via `task(subagent_type=...)`
-- An internal name like `oneshot-{task_id}` is generated for logging and async task handles
+- They cannot be reused via `task(subagent_type=...)`, even though they have a `name`
+- `name` is a display label for logging and async task handles
 - They report **no chat trace**. A `Chat Trace ID` is only useful if `task` can
   resolve the subagent it belongs to, which is never true for a one-shot, so
   `delegate` results omit it and one-shot runs never occupy a slot in the

--- a/docs/advanced/dynamic-agents.md
+++ b/docs/advanced/dynamic-agents.md
@@ -436,7 +436,7 @@ Use `delegate` for ad-hoc specialists. Use `create_agent` + `task` when you need
 
 Dynamic agents cannot override pre-configured agents:
 
-```python
+```text
 # If "researcher" is pre-configured:
 create_agent(name="researcher", ...)
 # Returns: "Error: Agent 'researcher' already exists"
@@ -448,7 +448,7 @@ create_agent(name="researcher", ...)
 
 Dynamic creation has overhead. Pre-configure common agents:
 
-```python
+```text
 # Good: Pre-configure known specialists
 subagents = [
     SubAgentConfig(name="researcher", ...),
@@ -463,7 +463,7 @@ subagents = [
 
 Use descriptive names for dynamic agents:
 
-```python
+```text
 # Good
 create_agent(name="react-typescript-expert", ...)
 

--- a/docs/advanced/errors.md
+++ b/docs/advanced/errors.md
@@ -1,0 +1,156 @@
+# Failure handling
+
+A delegation can fail in several ways, and they are not interchangeable. A crashed
+subagent is a setback the parent can work around; a suspended run waiting for human
+approval is not a failure at all. This page covers how each one reaches the parent.
+
+```python
+from pydantic_ai import Agent
+from subagents_pydantic_ai import SubAgentCapability, SubAgentConfig
+
+agent = Agent(
+    "openai:gpt-4.1",
+    capabilities=[
+        SubAgentCapability(
+            subagents=[
+                SubAgentConfig(
+                    name="scraper",
+                    description="Fetches pages",
+                    instructions="You fetch and summarise web pages.",
+                    on_failure="The scraper is unavailable. Answer from what you have.",
+                ),
+            ],
+        )
+    ],
+)
+```
+
+## The four outcomes
+
+| What happened | How it reaches the parent |
+|---|---|
+| Control-flow signal (`CallDeferred`, `ApprovalRequired`, `Skip*`) | Propagates unchanged |
+| `UserError` | Propagates unchanged |
+| Shared `UsageLimitExceeded` | Propagates unchanged |
+| Anything else | `ModelRetry`, or the subagent's `on_failure` message |
+
+### Control-flow signals propagate
+
+`CallDeferred` and `ApprovalRequired` are how pydantic-ai suspends a run so a human
+can approve a tool call or a deferred tool can be resolved later. They are not
+errors. Catching them would turn a suspended run into a tool result the parent
+reads as a finished task, which breaks approval and deferred-tool flows outright,
+so they always reach the parent run.
+
+`UserError` propagates for a different reason: it means the setup is wrong, and no
+retry fixes a misconfiguration. Reporting it to the model as a task failure hides a
+bug you need to see.
+
+!!! warning "Background mode cannot suspend"
+    A background delegation returned its tool result (the task id) long before the
+    signal arrives, so there is no caller left to hand the deferred state back to.
+    The task is marked `failed` with an error saying to delegate it with
+    `mode="sync"` instead. Approval and deferred tools need synchronous
+    delegation.
+
+### Usage limits depend on whose budget it was
+
+A `UsageLimitExceeded` on a budget shared with the parent means the whole agent
+tree is out of budget, so it propagates. See [Usage limits](usage-limits.md) for
+per-task budgets, which are a soft outcome instead.
+
+### Everything else becomes a retry
+
+A subagent that crashed, timed out, or returned something unusable reaches the
+parent as `ModelRetry`:
+
+```text
+Subagent 'scraper' crashed: ConnectionError: Connection reset by peer.
+Treat this as a recoverable failure and decide from the evidence you have.
+```
+
+`ModelRetry` is what engages pydantic-ai's retry budget: the parent model sees the
+failure, can react to it, and repeated crashes eventually abort the tool call
+rather than looping forever. A plain string result whose text happens to start with
+`Error` would look to the model like a *successful* delegation, which is how a
+failure gets quietly folded into a final answer.
+
+## Containment
+
+By default a crash cannot abort the parent run -- it is converted into that
+`ModelRetry`, logged with its traceback at `WARNING`. Turn that off when you want a
+subagent crash to surface as an exception in your application:
+
+```python
+from subagents_pydantic_ai import create_subagent_toolset
+
+toolset = create_subagent_toolset(contain_errors=False)
+```
+
+Per-subagent overrides win over the toolset default:
+
+```python
+from subagents_pydantic_ai import SubAgentConfig
+
+SubAgentConfig(
+    name="critical-writer",
+    description="Writes the final report",
+    instructions="You write the final report.",
+    contain_errors=False,  # a failure here should stop the run
+)
+```
+
+Containment never applies to the signals in the table above.
+
+## Steering instead of retrying
+
+`on_failure` replaces the `ModelRetry` with an ordinary tool result, which tells
+the parent what to do next instead of inviting it to try the same delegation again:
+
+```python
+SubAgentConfig(
+    name="scraper",
+    description="Fetches pages",
+    instructions="You fetch and summarise web pages.",
+    on_failure=(
+        "The scraper is unavailable. Summarise from the sources you already have "
+        "and note the gap; do not delegate to the scraper again."
+    ),
+)
+```
+
+Use it when the failure is expected and re-delegating is pointless -- a flaky
+external service, a paywalled source, a subagent whose dependency is down. The
+handle still records `failed` with the real exception, so your telemetry sees the
+truth even though the model was steered around it.
+
+## Background failures are always soft
+
+The parent already received the task id, so a background outcome can only be
+delivered as a status transition. The task reaches `failed`, `handle.error` carries
+the exception, and the failure is logged. `check_task` reports it:
+
+```text
+Task: a1b2c3d4
+Subagent: scraper
+Status: failed
+Description: Fetch the pricing page
+Error: ConnectionError: Connection reset by peer
+```
+
+Cancellation is separate: a cancelled task reaches `cancelled`, and
+`asyncio.CancelledError` is re-raised so the task really stops. See
+[Cancellation](cancellation.md).
+
+## Transient failures never get this far
+
+A flaky gateway, a rate limit, or a dropped connection is retried with exponential
+backoff before it is treated as a failure, resuming from the accumulated message
+history rather than restarting. Only an exhausted retry budget produces the
+outcomes on this page. See [Retries](retries.md).
+
+## Next steps
+
+- [Retries](retries.md) -- transient failures and backoff
+- [Usage limits](usage-limits.md) -- per-task budgets
+- [Cancellation](cancellation.md) -- stopping a task on purpose

--- a/docs/advanced/questions.md
+++ b/docs/advanced/questions.md
@@ -60,9 +60,10 @@ Prevent infinite question loops with `max_questions`:
 ```python
 SubAgentConfig(
     name="analyst",
-    ...
+    description="Analyzes data",
+    instructions="You analyze data thoroughly.",
     can_ask_questions=True,
-    max_questions=3,  # After 3 questions, must complete without asking more
+    max_questions=3,  # After 3 questions, the subagent must finish on its own
 )
 ```
 

--- a/docs/advanced/retries.md
+++ b/docs/advanced/retries.md
@@ -120,7 +120,7 @@ a plain `agent.run()` &mdash; the legacy path, unchanged. Event streaming
 across retries, and cooperative (soft) cancellation is honoured at node boundaries
 on the retry-driven path.
 
-See the [Prompts &amp; Retry API](../api/prompts.md#retry) for full signatures.
+See the [Prompts &amp; Retry API](../api/retry.md) for full signatures.
 
 ## Next Steps
 

--- a/docs/advanced/steering.md
+++ b/docs/advanced/steering.md
@@ -1,0 +1,112 @@
+# Steering a running subagent
+
+A background subagent can be redirected mid-flight. The parent sends a message,
+the subagent folds it into its next model request, and everything it has done so
+far survives.
+
+```python
+from pydantic_ai import Agent
+from subagents_pydantic_ai import SubAgentCapability, SubAgentConfig
+
+agent = Agent(
+    "openai:gpt-4.1",
+    capabilities=[
+        SubAgentCapability(
+            subagents=[
+                SubAgentConfig(
+                    name="searcher",
+                    description="Searches a codebase",
+                    instructions="You search codebases and report matches.",
+                ),
+            ],
+        )
+    ],
+)
+
+result = await agent.run(
+    "Search the repo for the retry logic in the background. "
+    "If you learn it lives in packages/sparta, tell the searcher to narrow down."
+)
+```
+
+The model does this with two tools:
+
+```text
+task(description="Find the retry logic", subagent_type="searcher", mode="async")
+-> Task ID: a1b2c3d4
+
+send_message_to_subagent(task_id="a1b2c3d4", message="Narrow to packages/sparta/, it isn't in core/")
+-> Message delivered to task 'a1b2c3d4'; it will be applied on the subagent's next step.
+```
+
+## Why not cancel and re-delegate
+
+Cancelling throws away every tool call the subagent already made and every
+conclusion it already reached, then pays for all of it again. Steering keeps the
+run alive: the message arrives as an extra user instruction on the next model
+turn, alongside the history the subagent has built up.
+
+Reach for steering when you learn something the subagent needs:
+
+- narrowing a search that is going too wide
+- an early stop ("the first five matches are enough")
+- a correction ("that module was renamed last month")
+- a change of priority ("skip the tests, I only need the public API")
+
+## Steering versus answering
+
+Two tools deliver text to a running subagent, and they are not interchangeable.
+
+| | `send_message_to_subagent` | `answer_subagent` |
+|---|---|---|
+| Who starts it | The parent, unprompted | The subagent, by calling `ask_parent` |
+| Task status | `running` | `waiting_for_answer` |
+| Effect | Extra instruction on the next model request | Resolves the call the subagent is blocked on |
+| If it never arrives | The subagent carries on as before | The subagent blocks until `ask_timeout_seconds` |
+
+See [Questions](questions.md) for the `ask_parent` side.
+
+## How delivery works
+
+Steering rides pydantic-ai's own `AgentRun.enqueue`, so the library is not
+splicing message parts by hand:
+
+1. `send_message_to_subagent` puts the message on the internal bus, keyed by the
+   task id.
+2. The subagent's driving loop drains the bus between graph nodes.
+3. Anything pending goes to `enqueue`, and core delivers it before the next model
+   request.
+
+Because core owns placement, a steering message can never be spliced between a
+tool call and its return -- a shape most providers reject outright.
+
+!!! warning "Background tasks only"
+    Steering needs a live run to deliver into. In sync mode the parent's own run
+    loop is blocked inside the delegation, so there is no turn in which it could
+    send anything; use `ask_user` and [Questions](questions.md) instead. A task
+    that has already finished returns an error naming its status.
+
+## Isolation
+
+A steering message reaches a task only if the calling run started it:
+
+```python
+toolset = create_subagent_toolset()  # one instance, shared by every run
+```
+
+One toolset instance typically serves every run of its agent, so tasks record the
+`run_id` that started them and the tools refuse ids belonging to another run. In a
+server sharing one agent across users, run B cannot steer -- or read, answer, or
+cancel -- run A's task by guessing its id.
+
+## Ordering
+
+Messages are delivered in the order they were sent, and several sent before the
+subagent's next step arrive together on that step. Nothing is dropped while the
+task is running, and nothing is queued for a task that has finished.
+
+## Next steps
+
+- [Questions](questions.md) -- the subagent asking the parent
+- [Cancellation](cancellation.md) -- when steering is not enough
+- [Execution modes](execution-modes.md) -- why steering needs background mode

--- a/docs/advanced/steering.md
+++ b/docs/advanced/steering.md
@@ -86,6 +86,39 @@ tool call and its return -- a shape most providers reject outright.
     send anything; use `ask_user` and [Questions](questions.md) instead. A task
     that has already finished returns an error naming its status.
 
+## Driving it from Python
+
+An application that orchestrates delegation itself — a UI, a supervisor loop, a
+team abstraction — does not have a model calling tools. `SubAgentToolset` exposes
+the same two operations directly:
+
+```python
+from subagents_pydantic_ai import create_subagent_toolset
+
+toolset = create_subagent_toolset()
+
+# While the task is running: fold a message into its next model request.
+delivered = await toolset.steer_task(task_id, "Narrow to packages/sparta/")
+
+# While the task is blocked in `ask_parent`: resolve the question.
+answered = toolset.answer_task(task_id, "Use PostgreSQL")
+```
+
+Both return a `bool` rather than raising, so a supervisor can pick whichever
+applies:
+
+```python
+if toolset.answer_task(task_id, message):
+    ...  # it was waiting for an answer
+elif await toolset.steer_task(task_id, message):
+    ...  # it is running, and will see the message next step
+else:
+    ...  # the task is over; read the outcome from its handle
+```
+
+Unlike the tools, neither performs run scoping — a caller holding a `task_id`
+already knows which task it owns.
+
 ## Isolation
 
 A steering message reaches a task only if the calling run started it:

--- a/docs/advanced/usage-limits.md
+++ b/docs/advanced/usage-limits.md
@@ -1,0 +1,107 @@
+# Usage limits
+
+A fan-out of subagents can burn a lot of tokens before the parent notices. Usage
+limits put a ceiling on every delegated run, either one shared budget or a fresh
+one per task.
+
+```python
+from pydantic_ai import Agent, UsageLimits
+from subagents_pydantic_ai import SubAgentCapability, SubAgentConfig
+
+agent = Agent(
+    "openai:gpt-4.1",
+    capabilities=[
+        SubAgentCapability(
+            subagents=[
+                SubAgentConfig(
+                    name="researcher",
+                    description="Researches topics",
+                    instructions="You research topics thoroughly.",
+                ),
+            ],
+            usage_limits=UsageLimits(request_limit=10, output_tokens_limit=20_000),
+        )
+    ],
+)
+```
+
+Every delegation now runs under those limits, retries included -- a retried attempt
+does not get a fresh allowance.
+
+## Per-task limits
+
+Pass a factory instead of an instance to decide per delegation. It receives the
+parent's run context and the selected subagent's config:
+
+```python
+from pydantic_ai import RunContext, UsageLimits
+from subagents_pydantic_ai import SubAgentConfig, create_subagent_toolset
+
+
+def limits_for(ctx: RunContext[object], config: SubAgentConfig) -> UsageLimits | None:
+    if config["name"] == "summariser":
+        return UsageLimits(request_limit=3)
+    if config.get("typical_complexity") == "complex":
+        return UsageLimits(request_limit=30, output_tokens_limit=100_000)
+    return UsageLimits(request_limit=10)
+
+
+toolset = create_subagent_toolset(usage_limits=limits_for)
+```
+
+Returning `None` runs that task without explicit limits, which is how you exempt a
+specific subagent from a global ceiling.
+
+The factory is called once per delegation, before the subagent starts, so it can
+read anything on the parent context -- the tenant on `ctx.deps`, how much budget the
+run has already spent, the time of day:
+
+```python
+def limits_for(ctx: RunContext[MyDeps], config: SubAgentConfig) -> UsageLimits | None:
+    remaining = ctx.deps.budget.remaining_tokens()
+    if remaining <= 0:
+        return UsageLimits(request_limit=1)
+    return UsageLimits(output_tokens_limit=min(remaining, 50_000))
+```
+
+## What happens when a limit is hit
+
+`UsageLimitExceeded` propagates to the parent run rather than being contained. A
+budget shared with the parent means the whole agent tree is out of budget, and
+quietly reporting that as one subagent's bad luck would let the parent keep
+delegating into an empty wallet.
+
+The task handle records `failed`, so your telemetry sees which delegation hit the
+ceiling:
+
+```python
+for handle in toolset.task_manager.list_handles():
+    if handle.error == "usage limit exceeded":
+        print(f"{handle.subagent_name} ran out of budget")
+```
+
+See [Failure handling](errors.md) for how this differs from a crash.
+
+## Limits versus accounting
+
+A limit caps a run. It does not tell you what the run cost -- for that, read
+`handle.cost` and `handle.usage`, or aggregate with `get_total_usage()`:
+
+```python
+totals = toolset.get_total_usage()
+print(totals["input_tokens"], totals["output_tokens"], totals["requests"])
+```
+
+See [Observability](../concepts/observability.md).
+
+!!! tip "Pair limits with `max_result_chars`"
+    A token limit stops a subagent from *generating* too much. It does nothing about
+    a fan-out of ten verbose subagents flooding the orchestrator's context when
+    `wait_tasks` reports them. `max_result_chars` (default 2000) caps each result in
+    that listing and points the model at `check_task` for the full text.
+
+## Next steps
+
+- [Failure handling](errors.md) -- what propagates and what is contained
+- [Observability](../concepts/observability.md) -- cost and token accounting
+- [Execution modes](execution-modes.md) -- limits apply to both modes

--- a/docs/api/dynamic-agent.md
+++ b/docs/api/dynamic-agent.md
@@ -1,0 +1,33 @@
+# Dynamic agent API
+
+Helpers shared by the `create_agent` and `delegate` tools and by
+`create_agent_factory_toolset`: they validate a runtime agent request and build the
+agent instance. See [Dynamic agents](../advanced/dynamic-agents.md).
+
+## AgentFactory
+
+::: subagents_pydantic_ai.AgentFactory
+    options:
+      show_root_heading: true
+
+## build_dynamic_agent
+
+::: subagents_pydantic_ai.dynamic_agent.build_dynamic_agent
+    options:
+      show_root_heading: true
+      show_source: true
+
+## Validation helpers
+
+::: subagents_pydantic_ai.dynamic_agent
+    options:
+      show_root_heading: true
+      show_source: true
+      members:
+        - validate_agent_name
+        - validate_model
+        - validate_capabilities
+        - validate_capabilities_with_factory
+        - build_subagent_config
+        - collect_agent_toolsets
+        - build_agent_instance

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -13,16 +13,32 @@ The main entry point for creating subagent delegation capabilities.
 - [`SubAgentToolset`](toolset.md#subagenttoolset) - The toolset class
 - [`get_subagent_system_prompt()`](prompts.md#get_subagent_system_prompt) - Generate system prompt
 
-### Prompts &amp; Retry
+### Prompts
 
-Prompt builders, default tool descriptions, and auto-retry helpers.
+Prompt builders and the default model-facing tool descriptions.
 
 - [`get_subagent_system_prompt()`](prompts.md#get_subagent_system_prompt) - Generate system prompt
 - [`get_task_instructions_prompt()`](prompts.md#get_task_instructions_prompt) - Generate task instructions
-- [`RetryConfig`](prompts.md#retryconfig) - Resolved retry policy
-- [`run_with_retry()`](prompts.md#run_with_retry) - Retry driver
-- [`is_transient_error()`](prompts.md#is_transient_error) - Transient-error classifier
-- [`compute_backoff_delay()`](prompts.md#compute_backoff_delay) - Backoff computation
+
+### Retry
+
+Auto-retry for transient model and gateway failures.
+
+- [`RetryConfig`](retry.md#retryconfig) - Resolved retry policy
+- [`run_with_retry()`](retry.md#run_with_retry) - Retry driver
+- [`is_transient_error()`](retry.md#is_transient_error) - Transient-error classifier
+- [`compute_backoff_delay()`](retry.md#compute_backoff_delay) - Backoff computation
+
+### Spec
+
+- [`SubAgentSpec`](spec.md#subagentspec) - Validated YAML/JSON subagent definition
+
+### Dynamic agents
+
+Building specialists at runtime.
+
+- [`AgentFactory`](dynamic-agent.md#agentfactory) - Custom agent builder
+- [`build_dynamic_agent()`](dynamic-agent.md#build_dynamic_agent) - Validate and build
 
 ### Types
 
@@ -30,7 +46,7 @@ Data structures used throughout the library.
 
 - [`SubAgentConfig`](types.md#subagentconfig) - Subagent configuration
 - [`CompiledSubAgent`](types.md#compiledsubagent) - Pre-compiled subagent
-- [`TaskHandle`](types.md#taskhandle) - Background task handle
+- [`TaskHandle`](types.md#taskhandle) - Background task handle and its telemetry
 - [`TaskStatus`](types.md#taskstatus) - Task status enum
 - [`TaskPriority`](types.md#taskpriority) - Task priority enum
 - [`ExecutionMode`](types.md#executionmode) - Execution mode type
@@ -50,15 +66,15 @@ Interface definitions for extensibility.
 
 Communication layer components.
 
-- [`InMemoryMessageBus`](protocols.md#inmemorymessagebus) - Default message bus
-- [`TaskManager`](protocols.md#taskmanager) - Task coordination
-- [`create_message_bus()`](protocols.md#create_message_bus) - Factory function
+- [`InMemoryMessageBus`](message-bus.md#inmemorymessagebus) - Default message bus
+- [`TaskManager`](message-bus.md#taskmanager) - Task coordination
+- [`create_message_bus()`](message-bus.md#create_message_bus) - Factory function
 
 ### Registry
 
 Dynamic agent management.
 
-- [`DynamicAgentRegistry`](protocols.md#dynamicagentregistry) - Agent registry
+- [`DynamicAgentRegistry`](registry.md#dynamicagentregistry) - Agent registry
 
 ## Quick Reference
 

--- a/docs/api/message-bus.md
+++ b/docs/api/message-bus.md
@@ -1,0 +1,29 @@
+# Message bus API
+
+The bus delivers parent-to-child steering messages for background delegations. See
+[Steering](../advanced/steering.md) and [Message bus](../advanced/message-bus.md).
+
+`TaskManager` owns the lifecycle of every background delegation: its
+`asyncio.Task`, its `TaskHandle`, its cancellation event, and the future a blocked
+`ask_parent` waits on.
+
+## TaskManager
+
+::: subagents_pydantic_ai.TaskManager
+    options:
+      show_root_heading: true
+      show_source: true
+
+## InMemoryMessageBus
+
+::: subagents_pydantic_ai.InMemoryMessageBus
+    options:
+      show_root_heading: true
+      show_source: true
+
+## create_message_bus
+
+::: subagents_pydantic_ai.create_message_bus
+    options:
+      show_root_heading: true
+      show_source: true

--- a/docs/api/prompts.md
+++ b/docs/api/prompts.md
@@ -65,35 +65,3 @@ These string constants are exported for inspection and overriding. The
 ::: subagents_pydantic_ai.HARD_CANCEL_TASK_DESCRIPTION
     options:
       show_root_heading: true
-
-## Retry
-
-See [Auto-Retry](../advanced/retries.md) for a conceptual overview.
-
-### RetryConfig
-
-::: subagents_pydantic_ai.RetryConfig
-    options:
-      show_root_heading: true
-      show_source: true
-
-### run_with_retry
-
-::: subagents_pydantic_ai.run_with_retry
-    options:
-      show_root_heading: true
-      show_source: true
-
-### is_transient_error
-
-::: subagents_pydantic_ai.is_transient_error
-    options:
-      show_root_heading: true
-      show_source: true
-
-### compute_backoff_delay
-
-::: subagents_pydantic_ai.compute_backoff_delay
-    options:
-      show_root_heading: true
-      show_source: true

--- a/docs/api/protocols.md
+++ b/docs/api/protocols.md
@@ -14,35 +14,8 @@
       show_root_heading: true
       show_source: true
 
-## InMemoryMessageBus
-
-::: subagents_pydantic_ai.InMemoryMessageBus
-    options:
-      show_root_heading: true
-      show_source: true
-
-## TaskManager
-
-::: subagents_pydantic_ai.TaskManager
-    options:
-      show_root_heading: true
-      show_source: true
-
-## create_message_bus
-
-::: subagents_pydantic_ai.create_message_bus
-    options:
-      show_root_heading: true
-      show_source: true
-
-## DynamicAgentRegistry
-
-::: subagents_pydantic_ai.DynamicAgentRegistry
-    options:
-      show_root_heading: true
-      show_source: true
-
----
+The in-memory bus, `TaskManager`, and `DynamicAgentRegistry` are documented on
+their own pages: [Message Bus](message-bus.md) and [Registry](registry.md).
 
 ## Usage Examples
 

--- a/docs/api/registry.md
+++ b/docs/api/registry.md
@@ -1,0 +1,12 @@
+# Registry API
+
+`DynamicAgentRegistry` stores the specialists created at runtime by `create_agent`,
+so `task` can resolve them by name later. See
+[Dynamic agents](../advanced/dynamic-agents.md).
+
+## DynamicAgentRegistry
+
+::: subagents_pydantic_ai.DynamicAgentRegistry
+    options:
+      show_root_heading: true
+      show_source: true

--- a/docs/api/retry.md
+++ b/docs/api/retry.md
@@ -1,0 +1,33 @@
+# Retry API
+
+Auto-retry for transient model and gateway failures. Each retry resumes from the
+accumulated message history rather than starting over. See
+[Retries](../advanced/retries.md).
+
+## RetryConfig
+
+::: subagents_pydantic_ai.RetryConfig
+    options:
+      show_root_heading: true
+      show_source: true
+
+## run_with_retry
+
+::: subagents_pydantic_ai.run_with_retry
+    options:
+      show_root_heading: true
+      show_source: true
+
+## is_transient_error
+
+::: subagents_pydantic_ai.is_transient_error
+    options:
+      show_root_heading: true
+      show_source: true
+
+## compute_backoff_delay
+
+::: subagents_pydantic_ai.compute_backoff_delay
+    options:
+      show_root_heading: true
+      show_source: true

--- a/docs/api/spec.md
+++ b/docs/api/spec.md
@@ -1,0 +1,11 @@
+# Spec API
+
+`SubAgentSpec` is the validated, serialisable form of a `SubAgentConfig`, for
+loading subagent definitions from YAML or JSON.
+
+## SubAgentSpec
+
+::: subagents_pydantic_ai.SubAgentSpec
+    options:
+      show_root_heading: true
+      show_source: true

--- a/docs/api/toolset.md
+++ b/docs/api/toolset.md
@@ -126,3 +126,20 @@ agent = Agent(
     ],
 )
 ```
+
+## Programmatic access
+
+`answer_task` and `steer_task` are the Python halves of the `answer_subagent` and
+`send_message_to_subagent` tools, for an application that drives delegation itself.
+See [Steering](../advanced/steering.md#driving-it-from-python).
+
+::: subagents_pydantic_ai.SubAgentToolset
+    options:
+      show_root_heading: false
+      show_source: true
+      heading_level: 3
+      members:
+        - answer_task
+        - steer_task
+        - cancel_run_tasks
+        - get_total_usage

--- a/docs/api/types.md
+++ b/docs/api/types.md
@@ -1,15 +1,11 @@
 # Types API
 
+`SubAgentSpec`, the validated YAML/JSON form of a config, is on its own
+[Spec](spec.md) page.
+
 ## SubAgentConfig
 
 ::: subagents_pydantic_ai.SubAgentConfig
-    options:
-      show_root_heading: true
-      show_source: true
-
-## SubAgentSpec
-
-::: subagents_pydantic_ai.SubAgentSpec
     options:
       show_root_heading: true
       show_source: true

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,3 @@
+# Changelog
+
+--8<-- "CHANGELOG.md"

--- a/docs/concepts/observability.md
+++ b/docs/concepts/observability.md
@@ -1,0 +1,167 @@
+# Observability
+
+Every delegation records what it cost, which model ran it, which tools it called,
+and where its span sits in your trace. That data lands on a `TaskHandle` and stays
+queryable after the task finishes.
+
+```python
+from pydantic_ai import Agent
+from subagents_pydantic_ai import SubAgentCapability, SubAgentConfig
+
+capability = SubAgentCapability(
+    subagents=[
+        SubAgentConfig(
+            name="researcher",
+            description="Researches topics",
+            instructions="You research topics thoroughly.",
+        ),
+    ],
+)
+agent = Agent("openai:gpt-4.1", capabilities=[capability])
+
+result = await agent.run("Research Python async patterns")
+
+for handle in capability.task_manager.list_handles():
+    print(handle.subagent_name, handle.status, handle.cost, handle.tool_call_counts)
+```
+
+## What a handle carries
+
+A `TaskHandle` is created for every delegation, sync or background, and populated
+when the run finishes.
+
+| Field | What it tells you |
+|---|---|
+| `task_id` | Identifier the model uses with `check_task`, `wait_tasks`, and the cancel tools |
+| `subagent_name` | Which specialist ran |
+| `status` | `pending`, `running`, `waiting_for_answer`, `retrying`, `completed`, `failed`, `cancelled` |
+| `result` / `error` | The output, or why there isn't one |
+| `created_at` / `started_at` / `completed_at` | Timezone-aware UTC timestamps |
+| `usage` | pydantic-ai's `RunUsage` for the subagent run |
+| `cost` | Total model cost as a `Decimal`, from genai-prices |
+| `tool_call_counts` | `{tool_name: calls}`, summed across every model response |
+| `model_name`, `provider_name`, `provider_url`, `provider_response_id`, `provider_details`, `finish_reason` | Metadata from the response that produced the output |
+| `traceparent`, `trace_id`, `span_id` | W3C trace identifiers, when instrumentation is on |
+| `conversation_id`, `run_id` | pydantic-ai's own identifiers for the subagent run |
+| `message_history` | The full run serialised as JSON |
+| `retry_count` | Transient failures retried before the run succeeded |
+| `chat_trace_id` | The conversation this run belongs to, if it can be continued |
+| `parent_run_id` | The parent run that started the task |
+
+!!! note "Telemetry never fails a task"
+    Collection runs *after* the run is marked complete and is wrapped
+    best-effort, matching pydantic-ai's own instrumentation. A subagent that
+    produced an answer is never reported as `failed` because a cost lookup or a
+    serialisation raised -- the failure is logged at `WARNING` instead.
+
+## Cost and tokens across a fan-out
+
+`get_total_usage()` aggregates every task the toolset has run, including tasks
+whose handles were already evicted by `max_task_handles`:
+
+```python
+from subagents_pydantic_ai import create_subagent_toolset
+
+toolset = create_subagent_toolset(max_task_handles=500)
+
+totals = toolset.get_total_usage()
+print(totals["input_tokens"], totals["output_tokens"], totals["requests"])
+```
+
+Cost is per-handle rather than aggregated, because a fan-out across several models
+rarely wants one number:
+
+```python
+from decimal import Decimal
+
+spend = sum(
+    (h.cost for h in toolset.task_manager.list_handles() if h.cost is not None),
+    Decimal("0"),
+)
+```
+
+`cost` is `None` when genai-prices has no entry for the model and provider pair.
+That is a missing price, not a free run, so treat `None` as unknown rather than
+zero.
+
+!!! tip "Aggregates versus the final response"
+    `cost` and `tool_call_counts` are summed over every model response in the run.
+    `model_name` and the `provider_*` fields come from the *last* response -- the
+    one that produced the returned output. In a run that switched models, earlier
+    responses' model metadata is not on the handle, though their cost is.
+
+## Correlating with Logfire
+
+When the parent agent is instrumented, each subagent run gets its own span and the
+handle carries the traceparent, so you can jump from a task to its trace:
+
+```python
+import logfire
+from pydantic_ai import Agent
+from subagents_pydantic_ai import SubAgentCapability
+
+logfire.configure()
+logfire.instrument_pydantic_ai()
+
+capability = SubAgentCapability()
+agent = Agent("openai:gpt-4.1", capabilities=[capability])
+
+await agent.run("Delegate something")
+
+for handle in capability.task_manager.list_handles():
+    if handle.trace_id is not None:
+        print(f"{handle.subagent_name}: trace {handle.trace_id} span {handle.span_id}")
+```
+
+`traceparent` is the raw W3C header (`version-trace_id-span_id-flags`);
+`trace_id` and `span_id` are parsed out of it for convenience. All three are
+`None` when no instrumentation is active.
+
+## Watching background tasks from outside the agent
+
+`task_manager.handles` is a live mapping, so a UI or a monitoring loop can poll it
+while the agent is still running:
+
+```python
+import asyncio
+
+from subagents_pydantic_ai import TaskStatus
+
+
+async def report(task_manager, poll_seconds: float = 1.0) -> None:
+    """Print each background task as it reaches a terminal state."""
+    reported: set[str] = set()
+    while True:
+        for task_id, handle in list(task_manager.handles.items()):
+            if handle.is_finished and task_id not in reported:
+                reported.add(task_id)
+                print(f"{task_id} {handle.status}: {handle.result or handle.error}")
+        await asyncio.sleep(poll_seconds)
+```
+
+!!! warning "Handles are evicted"
+    Finished handles past `max_task_handles` (default 500) are dropped, oldest
+    first, so a long-lived session does not grow without bound. Their token usage
+    is folded into `get_total_usage()` before they go, but their `result` and
+    `cost` are lost. Raise the limit, or persist what you need as tasks finish.
+
+## Bounding what stays in memory
+
+Two limits keep a long-running orchestrator flat:
+
+```python
+toolset = create_subagent_toolset(
+    max_task_handles=500,  # finished handles retained for status queries
+    max_chat_traces=100,  # conversations that a chat_trace_id can still resume
+)
+```
+
+Both evict least-recently-used entries. Continuing an evicted chat trace returns
+an error telling the model to start a new conversation rather than silently
+starting one.
+
+## Next steps
+
+- [Chat traces](../advanced/chat-traces.md) -- continue a subagent's conversation
+- [Retries](../advanced/retries.md) -- what `retry_count` is counting
+- [Types](types.md) -- the full `TaskHandle` reference

--- a/docs/concepts/subagents.md
+++ b/docs/concepts/subagents.md
@@ -132,24 +132,24 @@ SubAgentConfig(
 The `description` field is crucial - it tells the parent agent when to use each subagent:
 
 ```python
-# Good descriptions - clear about capabilities
+# Good: the description says what the subagent can actually do
 SubAgentConfig(
     name="sql-expert",
     description="Writes and optimizes SQL queries for PostgreSQL databases",
-    ...
+    instructions="You write and optimize PostgreSQL queries.",
 )
 
 SubAgentConfig(
     name="code-reviewer",
     description="Reviews Python code for bugs, security issues, and style",
-    ...
+    instructions="You review Python code and report concrete findings.",
 )
 
-# Bad descriptions - too vague
+# Bad: the parent model has no basis for choosing this over anything else
 SubAgentConfig(
     name="helper",
-    description="Helps with stuff",  # Too vague!
-    ...
+    description="Helps with stuff",
+    instructions="You help.",
 )
 ```
 
@@ -188,7 +188,7 @@ Format your response as:
 
 Each subagent should do one thing well:
 
-```python
+```text
 # Good - focused
 SubAgentConfig(name="test-writer", description="Generates pytest tests", ...)
 SubAgentConfig(name="doc-writer", description="Writes documentation", ...)

--- a/docs/concepts/toolset.md
+++ b/docs/concepts/toolset.md
@@ -185,6 +185,7 @@ Create an ephemeral specialist and delegate a task in one call. Available in
 delegate(
     description="Analyze this dataset and summarize key trends",
     instructions="You are a data analyst. Return concise findings.",
+    name="data-analyst",
     mode="sync",
 )
 ```
@@ -195,12 +196,14 @@ delegate(
 |-----------|------|-------------|
 | `description` | `str` | Task prompt for the specialist |
 | `instructions` | `str` | Specialist system prompt |
+| `name` | `str` | Label for logs and async task handles (letters, numbers, hyphens) |
 | `model` | `str \| None` | Optional model override |
 | `capabilities` | `list[str] \| None` | Optional capability names |
 | `can_ask_questions` | `bool` | Whether the specialist can ask the parent |
 | `mode` | `str` | `"sync"`, `"async"`, or `"auto"` |
 
-The specialist is not registered and cannot be reused by name.
+The specialist is not registered and cannot be reused via `task`, even though it
+has a `name`.
 
 ### check_task
 

--- a/docs/concepts/toolset.md
+++ b/docs/concepts/toolset.md
@@ -395,25 +395,33 @@ toolset = create_subagent_toolset(
 )
 ```
 
-## General Purpose Subagent
+## General-purpose subagent
 
-By default, a "general" subagent is added for tasks that don't match specific subagents:
+A `general-purpose` subagent is added by default, so the model has somewhere to
+send work that matches none of your specialists. Turn it off when you want the
+model restricted to the subagents you defined:
 
 ```python
-# Customize the general subagent
 toolset = create_subagent_toolset(
     subagents=subagents,
-    general_purpose_config=SubAgentConfig(
-        name="general",
-        description="Handles miscellaneous tasks",
-        instructions="You are a general-purpose assistant.",
-    ),
+    include_general_purpose=False,
 )
+```
 
-# Disable the general subagent
+To replace it rather than remove it, disable the built-in one and define your own
+with whatever instructions you want:
+
+```python
 toolset = create_subagent_toolset(
-    subagents=subagents,
-    general_purpose_config=None,
+    subagents=[
+        *subagents,
+        SubAgentConfig(
+            name="general",
+            description="Handles miscellaneous tasks",
+            instructions="You are a general-purpose assistant.",
+        ),
+    ],
+    include_general_purpose=False,
 )
 ```
 

--- a/docs/examples/nesting.md
+++ b/docs/examples/nesting.md
@@ -2,6 +2,19 @@
 
 This example shows how subagents can have their own subagents.
 
+!!! warning "Nesting is something you build, not a switch you flip"
+    A subagent can only delegate if you give it a subagent toolset, which is what
+    `toolsets_factory` is for. `max_nesting_depth` does **not** enforce a limit
+    itself: the library passes `max_nesting_depth - 1` to your deps'
+    `clone_for_subagent`, and what that means is up to your implementation. The
+    real gate is what the factory hands the child.
+
+    Note also that calling `create_subagent_toolset()` inside the factory builds a
+    fresh toolset — with its own task manager and chat-trace store — on every
+    delegation. Nested background tasks are therefore invisible to the top-level
+    `task_manager`. Build the nested toolset once, outside the factory, if you need
+    to observe them.
+
 ## Overview
 
 Subagents can delegate to other subagents, creating hierarchical workflows:
@@ -70,20 +83,20 @@ Workflow:
 
 
 def create_manager_toolsets(deps: Deps) -> list:
-    """Create toolsets for the manager, including nested delegation."""
-    return [
-        create_subagent_toolset(
-            subagents=leaf_subagents,
-            max_nesting_depth=0,  # Leaf subagents can't delegate further
-        ),
-    ]
+    """Give the manager its own subagent toolset, so it can delegate in turn.
+
+    This is what actually creates a level of nesting: the manager can only
+    delegate to the subagents this toolset exposes. The leaves get no subagent
+    toolset at all, which is what stops the hierarchy here.
+    """
+    return [create_subagent_toolset(subagents=leaf_subagents)]
 
 
 # Top-level toolset
 toolset = create_subagent_toolset(
     subagents=manager_subagents,
     toolsets_factory=create_manager_toolsets,
-    max_nesting_depth=1,  # Allow one level of nesting
+    max_nesting_depth=1,  # Budget handed to Deps.clone_for_subagent
 )
 
 agent = Agent(
@@ -252,21 +265,21 @@ class Deps:
 
 Don't nest too deeply. 2-3 levels is usually enough:
 
-```python
-# Good: Clear hierarchy
-Parent → Manager → Worker
+```text
+# Good: clear hierarchy
+Parent -> Manager -> Worker
 
-# Avoid: Too deep
-Parent → Director → Manager → Lead → Worker → Helper
+# Avoid: too deep
+Parent -> Director -> Manager -> Lead -> Worker -> Helper
 ```
 
 ### 2. Clear Responsibilities
 
 Each level should have distinct responsibilities:
 
-```python
-# Good: Clear separation
-"project-manager": Coordinates overall project
+```text
+# Good: clear separation
+"project-manager": coordinates the overall project
 "tech-lead": Makes technical decisions
 "developer": Writes code
 

--- a/docs/examples/research-team.md
+++ b/docs/examples/research-team.md
@@ -270,7 +270,7 @@ if research_complete:
 
 Ensure each agent has what it needs:
 
-```python
+```text
 # Bad: Vague handoff
 task(description="Analyze the stuff", ...)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,13 +30,13 @@ Think of it as the building blocks for multi-agent systems - where a parent agen
 
 ## Why use Subagents?
 
-1. **Specialization**: Each subagent has focused instructions and tools for its domain. A "researcher" agent researches, a "writer" agent writes.
+1. **Specialization**: each subagent has focused instructions and tools for its domain. A "researcher" agent researches, a "writer" agent writes, and neither carries the other's context.
 
-2. **Parallel Execution**: Run multiple tasks simultaneously in async mode. Start a research task, continue with other work, check results later.
+2. **Parallel execution**: run several tasks in the background, keep working, and collect results with `wait_tasks` — reacting to the first finisher instead of stalling on the slowest.
 
-3. **Nested Hierarchies**: Subagents can spawn their own subagents. Build complex multi-agent workflows with natural delegation patterns.
+3. **Course correction**: [steer a running subagent](advanced/steering.md) when you learn something new, keeping its partial progress, and [answer its questions](advanced/questions.md) when it needs clarification.
 
-4. **Smart Mode Selection**: Auto-mode intelligently chooses sync vs async based on task complexity and requirements.
+4. **Accountability**: every delegation records its [cost, tokens, tool calls, and traceparent](concepts/observability.md), so a fan-out is not a black box.
 
 ## Quick Start (Capability API)
 
@@ -81,28 +81,35 @@ agent = Agent("openai:gpt-4.1", toolsets=[toolset])
     With the toolset API you need to wire `get_subagent_system_prompt()` into the
     agent's instructions manually. `SubAgentCapability` handles this automatically.
 
-## Core Features
+## Core features
 
 | Feature | Description |
 |---------|-------------|
-| **Dual-Mode Execution** | Run tasks sync (blocking) or async (background) |
-| **Auto-Mode Selection** | Intelligent mode selection based on task characteristics |
-| **Nested Subagents** | Subagents can spawn their own subagents |
-| **Runtime Agent Creation** | Create specialized agents on-the-fly |
-| **Parent-Child Q&A** | Subagents can ask parent for clarification |
-| **Task Cancellation** | Soft and hard cancellation support |
-| **Pluggable Message Bus** | Extensible communication layer |
+| [**Dual-mode execution**](advanced/execution-modes.md) | Run a task blocking or in the background, or let `mode="auto"` decide |
+| [**Chat traces**](advanced/chat-traces.md) | Continue a subagent's conversation across delegations |
+| [**Questions**](advanced/questions.md) | A subagent asks its parent for clarification mid-task |
+| [**Steering**](advanced/steering.md) | Redirect a running task without losing its progress |
+| [**Cancellation**](advanced/cancellation.md) | Cooperative (clean boundary) or immediate |
+| [**Retries**](advanced/retries.md) | Transient gateway failures resume from accumulated history |
+| [**Usage limits**](advanced/usage-limits.md) | One shared budget, or a fresh budget per task |
+| [**Observability**](concepts/observability.md) | Per-task cost, tokens, tool-call counts, traceparent |
+| [**Dynamic agents**](advanced/dynamic-agents.md) | Create specialists at runtime, reusable or one-shot |
 
-## Available Tools
+## Available tools
 
-When you add the subagent toolset, your agent gets these tools:
+Your agent gets these tools. `create_agent` and `delegate` are opt-in — see
+[delegation configuration](concepts/toolset.md).
 
 | Tool | Description |
 |------|-------------|
-| `task` | Delegate a task to a subagent (sync, async, or auto) |
-| `check_task` | Check status and get result of a background task |
+| `task` | Delegate a task to a configured or registry-backed subagent |
+| `create_agent` | Create a reusable specialist at runtime (opt-in) |
+| `delegate` | Create an ephemeral specialist and run a task in one call (opt-in) |
+| `check_task` | Check status and get the full result of a background task |
+| `wait_tasks` | Wait for background tasks, in `all` or `any` mode |
+| `list_active_tasks` | List the running background tasks of this run |
 | `answer_subagent` | Answer a question from a blocked subagent |
-| `list_active_tasks` | List all running background tasks |
+| `send_message_to_subagent` | Steer a running background subagent |
 | `soft_cancel_task` | Request cooperative cancellation |
 | `hard_cancel_task` | Immediately cancel a task |
 
@@ -123,12 +130,14 @@ Subagents for Pydantic AI is part of a modular ecosystem:
 pip install subagents-pydantic-ai
 ```
 
-## Next Steps
+## Next steps
 
-- [Installation](installation.md) - Get started in minutes
-- [Core Concepts](concepts/index.md) - Learn about subagents, toolsets, and types
-- [Examples](examples/index.md) - See subagents in action
-- [API Reference](api/index.md) - Complete API documentation
+- [Installation](installation.md) — get started in minutes
+- [Core concepts](concepts/index.md) — subagents, toolsets, observability, types
+- [Execution modes](advanced/execution-modes.md) — when to block and when not to
+- [Failure handling](advanced/errors.md) — what propagates and what is contained
+- [Examples](examples/index.md) — see subagents in action
+- [API reference](api/index.md) — the generated reference
 
 ---
 

--- a/docs/plans/refactor-quality-and-docs.md
+++ b/docs/plans/refactor-quality-and-docs.md
@@ -1,0 +1,397 @@
+# Refactor plan: correctness, code quality, documentation
+
+Status: proposed
+Scope decision: **source-compatible only.** `create_subagent_toolset()`, `SubAgentToolset`,
+`toolset.task_manager`, `_compile_subagent`, and every current export keep working, because
+`pydantic-deep` imports `_compile_subagent`, patches `subagents_pydantic_ai.toolset.Agent` in its
+tests, and reads `getattr(subagent_toolset, "task_manager", None)` in `pydantic_deep/agent.py`,
+`apps/cli/agent.py`, and `apps/deepresearch/src/deepresearch/app.py`.
+Message bus decision: the public bus surface (`InMemoryMessageBus`, `create_message_bus`,
+`MessageBusProtocol`) stays; only the steering internals move onto pydantic-ai's `enqueue`.
+
+Reference repos for target quality: `pydantic-ai-harness` (package shape, typing bar, writing
+style, `agent_docs/`) and `pydantic-ai-backend` (docs information architecture, mkdocs nav).
+
+## 1. Baseline as measured
+
+Measured at `3f217f4` (v0.2.11), pydantic-ai 2.0.0, Python 3.14 local / 3.10–3.13 in CI:
+
+| Check | Result |
+|---|---|
+| `pytest` | 396 passed |
+| `coverage` | 100.00% statements and branches |
+| `ruff format --check`, `ruff check` | clean |
+| `pyright` (basic mode, `src` only) | 0 errors |
+| `mypy src/` (strict) | clean |
+| `make typecheck-mypy` (`src` + `tests`) | **583 errors — target is broken** |
+| src size | 11 modules, ~3.9k lines |
+| docs size | 30 pages, ~6.5k lines |
+
+The headline number is misleading. 100% branch coverage coexists with a defect that changes what
+every model sees on every `check_task` call (B1 below), because no test asserts the tool's rendered
+output. Coverage is measuring line execution, not behaviour.
+
+Two config choices hide the rest: `pyright` runs in `basic` mode with `reportCallIssue`,
+`reportAssignmentType`, `reportUnknownMemberType`, `reportPrivateUsage`, and
+`reportTypedDictNotRequiredAccess` all disabled, and CI runs `mypy` only against `src/`. Harness
+runs pyright **strict** with no per-rule escapes.
+
+## 2. Defects
+
+Ranked by user impact. Every entry has a concrete failure, not a style objection.
+
+### B1 — Enum leaks into model-facing text (Python 3.11+)
+
+`TaskStatus` is a `str`-mixin `Enum`. Since Python 3.11, `format()` on a mixin enum returns
+`"TaskStatus.COMPLETED"`, not `"completed"`. Reproduced on 3.14:
+
+```python
+f"Status: {handle.status}"   # -> 'Status: TaskStatus.WAITING_FOR_ANSWER'
+```
+
+Affected model-facing output: `toolset.py:992` (`check_task`), `toolset.py:1099`
+(`list_active_tasks`), `toolset.py:1167` (`wait_tasks`, non-terminal branch). The orchestrating
+model is told the status is `TaskStatus.WAITING_FOR_ANSWER` while the tool descriptions and docs
+promise `waiting_for_answer`. On Python 3.10 the same code renders `completed`, so behaviour
+differs across the supported matrix.
+
+Fix: render `handle.status.value` (or convert to `StrEnum` on 3.11+ with a 3.10 shim). Add tests
+that assert the exact tool return strings, not just that a branch executed.
+
+### B2 — `except Exception` swallows pydantic-ai control-flow signals
+
+`_run_sync` (`toolset.py:1317`) and `run_task` (`toolset.py:1447`) catch `Exception` and convert it
+into a normal string result (`f"Error executing task: {e}"`). That catch also swallows
+`CallDeferred`, `ApprovalRequired`, `SkipModelRequest`, `SkipToolValidation`, `SkipToolExecution`,
+and `UserError`.
+
+Consequences: a subagent whose toolset uses deferred tools or human-in-the-loop approval cannot
+work at all — the signal that is supposed to suspend the run becomes a string the parent model
+reads as a completed task. A `UserError` (a setup bug no retry can fix) is reported to the model as
+a task failure. And a genuine child failure is presented to the parent as a *successful* tool call
+whose content happens to start with `Error`, so pydantic-ai's retry budget never engages.
+
+Fix, mirroring `pydantic_ai_harness/subagents/_toolset.py`: an `_ALWAYS_PROPAGATE` tuple that
+re-raises control-flow signals and `UserError`, and `ModelRetry` for genuine child failures. Add
+`on_failure` (soft steering message) and `contain_errors` knobs so applications can opt into the
+current containment behaviour explicitly.
+
+This is the plan's one intentional behaviour change. It is additive at the API level, but the
+string a parent model receives on child failure changes.
+
+### B3 — Background tasks outlive their parent run
+
+`_run_async` spawns `asyncio.create_task(run_task())` and nothing cancels it when the parent agent
+run ends. An orphan keeps executing against deps the application has already torn down, and one
+blocked in `ask_parent` sits on a future nobody will resolve for the full 300 s timeout.
+
+Harness guarantees the opposite explicitly: task state is keyed by `ctx.run_id` and a `wrap_run`
+finalizer ensures no task outlives its parent run.
+
+Fix inside the compatibility budget: add `TaskManager.cancel_all(run_id)` and call it from a
+`wrap_run` finalizer on `SubAgentCapability`. Keep `TaskManager.handles` globally readable so
+`deepresearch/app.py`'s iteration keeps working.
+
+### B4 — Task ids are not isolated per run
+
+`TaskManager` lives for the lifetime of the toolset, and the toolset is built once per agent
+(`pydantic_deep/agent.py` does exactly this). `check_task`, `hard_cancel_task`, `soft_cancel_task`,
+`answer_subagent`, and `send_message_to_subagent` accept any `task_id` in that shared map. In a
+server that serves several users from one agent instance, run A can inspect, answer, or cancel run
+B's task.
+
+Fix: record `run_id` on `TaskHandle` and filter lookups in the tools by `ctx.run_id`, while leaving
+`TaskManager.handles` unfiltered for the downstream observability contract.
+
+### B5 — `hard_cancel` overwrites a completed task's outcome
+
+`message_bus.py:452-465` guards with `if not task.done()`. A task that already set
+`status = COMPLETED` and is executing its `finally` block is still not `done()`, so `hard_cancel`
+overwrites the real result with `CANCELLED` and moves `completed_at`. The code comment
+acknowledges the race; the guard does not close it.
+
+Fix: an idempotent terminal transition — first terminal status wins — as in `TaskState.finish()`
+in harness.
+
+### B6 — Private attribute written onto the caller's deps object
+
+`toolset.py:1281` and `toolset.py:1385` do `deps._subagent_state = {...}`. The deps class is the
+application's, and `SubAgentDepsProtocol` places no constraint on it. A deps dataclass declared
+`frozen=True` or `slots=True` — both idiomatic, and nothing in the docs warns against them —
+raises `AttributeError` at the first delegation. The state itself is an untyped
+`dict[str, Any]` read back through `state.get("ask_callback")`.
+
+Fix: a typed `_SubAgentState` dataclass carried through a `contextvars.ContextVar` instead of
+attribute injection, with the attribute path kept as a documented fallback for one release.
+
+### B7 — `ask_parent` timeout is a hardcoded 300 s
+
+`toolset.py:371`. Not configurable at any level. Harness exposes `ask_timeout_seconds`.
+Fix: a `ask_timeout_seconds` parameter on the toolset and capability, default 300.0.
+
+### B8 — Naive local-time timestamps
+
+`datetime.now()` with no tzinfo in `types.py:286,321`, `toolset.py:752,1007,1312,1451`,
+`message_bus.py:342,465`. `TaskHandle.created_at/started_at/completed_at` are handed to consumers
+(pydantic-deep renders them), elapsed time is computed by subtraction, and `evict_finished_handles`
+sorts by them. Across a DST transition the arithmetic is wrong and ordering can invert.
+Fix: `datetime.now(timezone.utc)` throughout.
+
+### B9 — `_drive_run` has already drifted from the core loop it copies
+
+`retry.py:_drive_run` is a hand copy of `Agent.run`'s internal driving loop and depends on five
+private pydantic-ai APIs: `run._advance_graph`, `run._run_node_with_hooks`,
+`_agent_graph.build_run_context`, `_agent_graph.ModelRequestNode`, and
+`run.ctx.deps.root_capability`.
+
+It has already diverged. Core drains the wrapped stream after the handler returns, unconditionally:
+
+```python
+if _handler is not None:
+    await _handler(run_ctx, wrapped)
+async for _ in wrapped:   # core: always drains
+    pass
+```
+
+The copy drains only when there is no handler:
+
+```python
+if event_stream_handler is not None:
+    await event_stream_handler(run_ctx, wrapped)
+else:
+    async for _ in wrapped:   # copy: else-branch only
+        pass
+```
+
+So a handler that does not fully consume the stream leaves the node's stream wrappers unfinished on
+the retry path but not on the plain path.
+
+The copy cannot simply be deleted — driving via public `run.next(node)` alone loses event streaming,
+which is the reason it exists. Plan: realign it with core, pin a `pydantic-ai-slim` lower bound, add
+a drift test that asserts the handler fires and the stream is drained on the retry path, and open an
+upstream issue asking for a public way to drive a run with a custom step (or for `Agent.run` to
+accept a retry policy). This follows harness's core-boundary rule: propose the core primitive rather
+than maintaining a second runtime.
+
+### B10 — Steering mutates graph nodes instead of using the public primitive
+
+`retry.py:227-233` appends `UserPromptPart`s directly into `node.request.parts` to deliver parent →
+child steering. pydantic-ai 2.0 exposes `AgentRun.enqueue` and `RunContext.enqueue` for exactly
+this, and harness uses `run_handle.enqueue(...)`.
+
+Fix: deliver steering through `AgentRun.enqueue`. Per the scope decision the bus stays public and
+keeps carrying the messages; only the delivery mechanism changes.
+
+### B11 — `max_nesting_depth` enforces nothing
+
+The only use is `clone_for_subagent(max_nesting_depth - 1)` (`toolset.py:689`). With the default
+`0` the library calls the application's clone method with `-1`. Nothing in the library stops a
+nested toolset from delegating further; the actual gate is whatever `toolsets_factory` returns.
+
+Meanwhile `README.md` and `docs/index.md` advertise "Nested Hierarchies" and
+`create_subagent_toolset`'s docstring states "0 means subagents cannot spawn their own subagents".
+`docs/examples/nesting.md` annotates `max_nesting_depth=1  # Allow one level of nesting`, which is
+not what the parameter does.
+
+Secondary problem in the same example: it calls `create_subagent_toolset()` *inside*
+`toolsets_factory`, so every single delegation allocates a fresh `TaskManager`, message bus, and
+chat-trace LRU, and nested async tasks are unreachable from the top-level `task_manager`.
+
+Fix: track delegation depth in the toolset and refuse past the limit, or rename and document the
+parameter for what it is. Then correct the docs and the example either way.
+
+### B12 — Smaller correctness items
+
+| # | Item | Location |
+|---|---|---|
+| B12a | Handler exceptions swallowed with bare `pass` | `message_bus.py:69-73` |
+| B12b | `asyncio.get_event_loop()` inside a coroutine (deprecated since 3.10) | `message_bus.py:105` |
+| B12c | `except (AssertionError, LookupError)` around cost lookup masks real assertion failures | `toolset.py:170` |
+| B12d | `handle.status == "completed"` (string) in `wait_tasks` vs `TaskStatus.COMPLETED` in `check_task` | `toolset.py:1150` vs `997` |
+| B12e | `str(uuid.uuid4())[:8]` task ids; a collision silently overwrites a live handle | `toolset.py:699,931` |
+| B12f | `import dataclasses, json` inside the function body | `toolset.py:76-77` |
+| B12g | `evict_finished_handles()` runs before the new handle is registered, so the map transiently holds `max_task_handles + 1` | `toolset.py:731` |
+| B12h | `409 Conflict` and `425 Too Early` classified as transient | `retry.py:46` |
+
+## 3. Quality debt against the reference repos
+
+### D1 — `create_subagent_toolset` is a 17-parameter closure factory with monkey-patched output
+
+840 lines, `# noqa: C901`, and `[tool.ruff.lint.mccabe] max-complexity = 30` with the comment
+"Factory functions are intentionally complex" — the config bent to fit the code. Eleven tool bodies
+are nested closures over shared mutable state (`compiled`, `message_history_store`,
+`active_chat_traces`, `evicted_usage`, `task_manager`), so none of them is individually testable or
+typed.
+
+Then three attributes are attached to the returned object after the fact:
+
+```python
+toolset.task_manager = task_manager                  # type: ignore[attr-defined]
+toolset.message_history_store = message_history_store # type: ignore[attr-defined]
+toolset.get_total_usage = get_total_usage            # type: ignore[attr-defined]
+```
+
+`toolset.task_manager` is load-bearing downstream, so this is de facto public API expressed as
+three type errors.
+
+Fix, source-compatible: promote `SubAgentToolset` from an alias for the function to a real
+`FunctionToolset` subclass with typed attributes and methods, and let `create_subagent_toolset()`
+return an instance. `create_subagent_toolset(...)`, `SubAgentToolset(subagents=[...])`,
+`isinstance(t, FunctionToolset)`, and `toolset.task_manager` all keep working; the three
+`type: ignore`s disappear. Harness's `SubAgentToolset(FunctionToolset[AgentDepsT])` is the model.
+
+### D2 — `SubAgentConfig` is a `total=False` TypedDict with three "required" keys
+
+`name`, `description`, and `instructions` are documented as required, but `total=False` makes them
+optional to the type checker. The code then indexes them unguarded in roughly a dozen places
+(`config["name"]`, `config["description"]`, `config["instructions"]`), so a config missing one
+raises `KeyError` deep inside delegation instead of failing at construction.
+`reportTypedDictNotRequiredAccess = false` in `pyproject.toml` is what keeps this invisible.
+
+Fix, source-compatible: split into a required base plus a `total=False` extension.
+
+```python
+class _SubAgentConfigRequired(TypedDict):
+    name: str
+    description: str
+    instructions: str
+
+class SubAgentConfig(_SubAgentConfigRequired, total=False):
+    ...
+```
+
+Call sites are unchanged; both type checkers now enforce the three keys.
+
+### D3 — `Any` in public and internal signatures
+
+`CompiledSubAgent.agent: object | None` ("typed as object to avoid circular imports" — `types.py`
+does not import `message_bus`, so the circularity does not exist), `TaskHandle.usage: Any`,
+`TaskHandle.finish_reason: Any`, `ToolsetFactory = Callable[[Any], list[Any]]`,
+`AgentFactory = Callable[[SubAgentConfig], Any]`, `TaskManager.handles: dict[str, Any]`,
+`TaskManager.create_task(coro: Any, handle: Any)`, and `_run_sync`/`_run_async`'s `agent: Any`.
+
+`RunUsage`, `FinishReason`, and `TaskHandle` can all be imported under `TYPE_CHECKING`.
+`ToolsetFactory` should be generic over deps. `AbstractAgent[AgentDepsT, Any]` is the right type for
+the agent slot, as in harness.
+
+### D4 — Dead weight
+
+- `InMemoryMessageBus.ask`, `.answer`, `._pending_questions`, `.add_handler`, `.remove_handler`,
+  `.registered_agents` — none is called by the library. Retained per the scope decision, but they
+  must be documented as an extension surface rather than presented as part of how subagents work.
+- `create_message_bus(backend="memory")` — a factory over exactly one backend that raises for
+  anything else.
+- `SubAgentDepsProtocol.subagents: dict[str, Any]` — never read by the library. Every application
+  is forced to carry a field the library ignores. Cannot be removed under the compatibility budget;
+  deprecate in docs and stop requiring it in examples.
+- `DUAL_MODE_SYSTEM_PROMPT` — exported, never used internally.
+- `get_subagent_system_prompt(include_dual_mode=...)` — the parameter is accepted and ignored.
+
+### D5 — Module layout
+
+Flat modules with everything public. Harness uses a package per feature with `_`-prefixed
+implementation modules and an `__init__.py` that defines the public surface. Under the compatibility
+budget the current module paths must keep resolving (`subagents_pydantic_ai.toolset._compile_subagent`
+is imported by `pydantic_deep/features/teams/toolset.py`), so: split `toolset.py` internally into
+`_execution.py`, `_observability.py`, `_chat_trace.py`, and `_tools.py`, and keep `toolset.py` as
+the public façade re-exporting the current names.
+
+### D6 — Tooling
+
+| Item | Now | Target |
+|---|---|---|
+| pyright mode | `basic`, `tests` excluded, 12 rules off | `strict`, tests included, escapes justified per-line |
+| mypy on tests | `module = "tests.*"` override never matches (no `tests/__init__.py`), so `make typecheck-mypy` fails with 583 errors | override fixed; target green; run in CI |
+| ruff complexity | `max-complexity = 30` + one `# noqa: C901` | 15, no per-function escapes (harness's number) |
+| docs examples | not executed | `pytest-examples`, as pydantic-ai does |
+| `AGENTS.md` | unfilled template | real, modelled on harness's |
+| `agent_docs/` | absent | `index`, `review-checklist`, `testing`, `core-boundary` |
+
+## 4. Documentation
+
+The docs are substantial (30 pages, ~6.5k lines) and structurally sound — the mkdocs nav already
+mirrors backend's Concepts / Advanced / Examples / API shape. The problems are coverage gaps, stale
+content, and prose that describes the library rather than teaching it.
+
+### Undocumented public surface
+
+| Surface | Docs mentions |
+|---|---|
+| `get_total_usage()` | 0 |
+| `TaskHandle.traceparent`, `.trace_id`, `.span_id` | 0 |
+| `TaskHandle.tool_call_counts` | 0 |
+| `TaskHandle.cost`, `.model_name`, `.provider_*`, `.finish_reason` | 0 |
+| `AgentFactory` | 0 |
+| `usage_limits` / `UsageLimitsFactory` | 1 file |
+| `send_message_to_subagent` (steering) | 1 file, no dedicated page |
+| `max_result_chars` truncation | 1 file |
+| `max_task_handles` | 1 file |
+
+The whole observability story — per-task cost from genai-prices, token usage, tool-call counts, W3C
+traceparent for Logfire correlation — is implemented and invisible. It is arguably the library's
+strongest differentiator against a hand-rolled delegation tool.
+
+Missing API reference pages: `registry`, `factory`, `message_bus`, `spec`, `dynamic_agent`.
+`api/prompts.md` currently doubles as the retry reference.
+
+### Stale content
+
+- `docs/index.md` "Available Tools" table omits `wait_tasks`, `send_message_to_subagent`,
+  `create_agent`, and `delegate`.
+- `docs/index.md` "Core Features" lists "Pluggable Message Bus" as a headline feature; the
+  pluggable half is unused by the library.
+- Nesting claims and the `max_nesting_depth` annotation in `docs/examples/nesting.md` (see B11).
+- `CHANGELOG.md` (309 lines) is not in the nav. Backend ships `docs/changelog.md`.
+
+### Style target
+
+FastAPI and pydantic-ai docs share four properties this repo's docs lack:
+
+1. **Every page opens with a runnable snippet**, then explains it. Several pages here open with a
+   concept paragraph and a bullet list.
+2. **Code is tested.** pydantic-ai runs its documentation through `pytest-examples`. Adding it here
+   would have caught the stale signatures in the docs directly.
+3. **Progressive disclosure**, with admonitions carrying the sharp edges — `!!! warning` for the
+   things that bite (a chat trace cannot be continued while its task runs; a truncation marker is a
+   display limit, not an incomplete answer; `ask_user` is required for sync-mode questions).
+4. **Honest "when not to use"**, which the tool descriptions in `prompts.py` already do well for
+   the model. The human docs should match.
+
+Planned additions: `concepts/observability.md`, `advanced/steering.md`, `advanced/chat-traces.md`,
+`advanced/usage-limits.md`, `changelog.md`, and the five missing API pages. Planned rewrites:
+`index.md` (accurate feature and tool tables), `concepts/toolset.md` (491 lines, currently the
+dumping ground for every new option), `examples/nesting.md`.
+
+Open style question: harness's `AGENTS.md` bans em-dashes and hype in all prose. These docs use both
+freely. Default in this plan is to cut the hype and keep em-dashes, unless the house style should be
+unified across the OSS repos.
+
+## 5. Sequencing
+
+Seven PRs. Each is independently reviewable and leaves `main` green. No PR breaks a downstream
+import.
+
+| PR | Scope | Acceptance |
+|---|---|---|
+| **1. Correctness** | B1, B5, B8, B12a–B12h | Tests assert exact model-facing strings for every tool. Regression test per defect. |
+| **2. Task lifecycle** | B3, B4, B7 | `run_id` on `TaskHandle`; `wrap_run` finalizer cancels this run's tasks; cross-run lookup rejected; `ask_timeout_seconds` configurable. |
+| **3. Error contract** | B2, plus `on_failure` / `contain_errors` | Control-flow signals propagate; child failure raises `ModelRetry`; deferred-tool and approval flows work inside a subagent. Documented as the one behaviour change. |
+| **4. Types and tooling** | D1, D2, D3, D6 | `SubAgentToolset` is a real class; zero `type: ignore` in `src/`; pyright strict green; `make typecheck-mypy` green; ruff complexity 15 with no `noqa: C901`. Downstream smoke test against pydantic-deep. |
+| **5. Core primitives** | B6, B9, B10, D5 | Steering via `AgentRun.enqueue`; `_drive_run` realigned with core plus a drift test and a pinned lower bound; upstream issue opened; `toolset.py` split behind a façade. |
+| **6. Documentation** | Section 4 in full | `pytest-examples` green on every snippet; no public symbol without a docs mention; nav covers observability, steering, chat traces, usage limits, changelog, and all five missing API pages. |
+| **7. Repo meta** | `AGENTS.md`, `agent_docs/`, `docs/plans/` | AGENTS.md modelled on harness's; review checklist and testing guide in place. |
+
+PR 4 is where the compatibility budget is spent most carefully; it should land with a run of
+pydantic-deep's own test suite against a local build.
+
+## 6. Deliberately out of scope
+
+- Breaking the API. `SubAgentConfig` stays a TypedDict rather than becoming a Pydantic model, and
+  `create_subagent_toolset` keeps its 17 parameters. Both are the right long-term change and both
+  would break `pydantic-deep`; they belong to a 0.4 line.
+- Removing `InMemoryMessageBus.ask` / `.answer` / handlers, `create_message_bus`, and
+  `MessageBusProtocol`. Retained by decision; documented as an extension surface.
+- Removing `SubAgentDepsProtocol.subagents`. Deprecated in docs only.
+- Run-scoped state as harness does it (`RunTasks` keyed by `run_id`, no toolset-level map). The
+  downstream contract reads `task_manager.handles` globally, so PR 2 adds isolation on top of the
+  shared map instead of replacing it.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -114,6 +114,11 @@ markdown_extensions:
   - pymdownx.mark
   - pymdownx.smartsymbols
   - pymdownx.snippets:
+      # The repo root is on the path so `docs/changelog.md` can include the
+      # top-level CHANGELOG.md instead of duplicating it.
+      base_path:
+        - .
+        - docs
       auto_append:
         - includes/abbreviations.md
   - pymdownx.superfences:
@@ -153,12 +158,17 @@ nav:
     - Capability: concepts/capability.md
     - Subagents: concepts/subagents.md
     - Toolset: concepts/toolset.md
+    - Observability: concepts/observability.md
     - Types: concepts/types.md
   - Advanced Features:
     - advanced/execution-modes.md
     - advanced/questions.md
+    - advanced/steering.md
+    - advanced/chat-traces.md
     - advanced/cancellation.md
+    - advanced/errors.md
     - advanced/retries.md
+    - advanced/usage-limits.md
     - advanced/dynamic-agents.md
     - advanced/message-bus.md
   - Examples:
@@ -177,8 +187,14 @@ nav:
     - Capability: api/capability.md
     - Toolset: api/toolset.md
     - Types: api/types.md
-    - Prompts & Retry: api/prompts.md
     - Protocols: api/protocols.md
+    - Registry: api/registry.md
+    - Dynamic Agents: api/dynamic-agent.md
+    - Message Bus: api/message-bus.md
+    - Retry: api/retry.md
+    - Spec: api/spec.md
+    - Prompts: api/prompts.md
+  - Changelog: changelog.md
 
 validation:
   nav:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ dev = [
     "pytest-cov>=5.0.0",
     "ruff>=0.8.0",
     "pre-commit>=4.5.0",
+    "types-pyyaml>=6.0.12.20260724",
 ]
 docs = [
     "mkdocs>=1.6.0",
@@ -117,26 +118,29 @@ ignore = [
 ]
 
 [tool.ruff.lint.mccabe]
-max-complexity = 30  # Factory functions are intentionally complex
+max-complexity = 15
 
 [tool.ruff.format]
 quote-style = "double"
 
 [tool.pyright]
 pythonVersion = "3.10"
-typeCheckingMode = "basic"
+typeCheckingMode = "strict"
 include = ["src/subagents_pydantic_ai"]
 exclude = ["**/__pycache__", ".venv*", "site", "tests"]
 reportMissingTypeStubs = false
+# The agent slot is deliberately `Any`: consumers pass their own agent objects,
+# not a `pydantic_ai.Agent` (see `CompiledSubAgent.agent`). Reporting every use
+# of it would drown the signal from real gaps.
 reportUnknownMemberType = false
 reportUnknownArgumentType = false
 reportUnknownVariableType = false
-reportUnknownParameterType = false
+# Tools are registered through decorators and `add_function`, so pyright cannot
+# see the reference.
 reportUnusedFunction = false
+# `retry.py` mirrors the driving loop inside `Agent.run`, which has no public
+# equivalent; the coupling is documented there and covered by a drift test.
 reportPrivateUsage = false
-reportCallIssue = false
-reportAssignmentType = false
-reportTypedDictNotRequiredAccess = false
 
 [tool.mypy]
 python_version = "3.10"
@@ -145,10 +149,31 @@ warn_return_any = true
 warn_unused_configs = true
 ignore_missing_imports = true
 
+# `tests/` needs its `__init__.py` for the override below to match: without it
+# mypy names the modules `test_toolset`, not `tests.test_toolset`, so
+# `module = "tests.*"` matched nothing and `make typecheck-mypy` reported
+# hundreds of errors the config intended to relax.
 [[tool.mypy.overrides]]
 module = "tests.*"
 disallow_untyped_defs = false
-disable_error_code = ["arg-type", "list-item", "abstract"]
+# A test with annotated arguments but no return annotation is an *incomplete*
+# def, which `strict` reports separately from an untyped one. Relaxing only
+# `disallow_untyped_defs` left those errors in place.
+disallow_incomplete_defs = false
+disallow_untyped_calls = false
+disallow_untyped_decorators = false
+disable_error_code = [
+    "arg-type",
+    "list-item",
+    "abstract",
+    # `assert TaskStatus.PENDING == "pending"` is the point of the test, but mypy
+    # calls an enum-to-literal comparison non-overlapping.
+    "comparison-overlap",
+    # Tests read optional fields straight off a handle after asserting the state
+    # that guarantees them; narrowing each one adds noise, not safety.
+    "union-attr",
+    "operator",
+]
 
 [tool.codespell]
 skip = ".git,.venv*,uv.lock,site,htmlcov,.coverage"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "subagents-pydantic-ai"
-version = "0.2.11"
+version = "0.2.12"
 description = "Subagent toolset for pydantic-ai with dual-mode execution and dynamic agent creation"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/subagents_pydantic_ai/__init__.py
+++ b/src/subagents_pydantic_ai/__init__.py
@@ -3,13 +3,15 @@
 This library provides a toolset for delegating tasks to specialized
 subagents within pydantic-ai agents. It supports:
 
-- **Dual-Mode Execution**: Run tasks synchronously (blocking) or
-  asynchronously (background)
-- **Auto Mode**: Intelligent mode selection based on task characteristics
-- **Pluggable Message Bus**: Default in-memory, extensible to Redis
-- **Dynamic Agent Creation**: Create specialized agents at runtime
-- **Configurable Nesting**: Control subagent depth
-- **Task Cancellation**: Both soft and hard cancellation
+- **Dual-mode execution**: run a task synchronously (blocking) or in the
+  background, or let `mode="auto"` choose from the task's characteristics
+- **Chat traces**: continue a subagent's conversation across delegations
+- **Questions**: a subagent can ask its parent for clarification mid-task
+- **Steering**: redirect a running background task without losing its progress
+- **Cancellation**: cooperative (stops at a clean boundary) or immediate
+- **Retries**: transient model/gateway failures resume from accumulated history
+- **Observability**: per-task usage, cost, tool-call counts, and traceparent
+- **Dynamic agents**: create specialists at runtime, reusable or one-shot
 
 Basic usage:
 
@@ -118,6 +120,9 @@ from subagents_pydantic_ai.toolset import (
     create_subagent_toolset as create_subagent_toolset,
 )
 from subagents_pydantic_ai.types import (
+    TERMINAL_STATUSES as TERMINAL_STATUSES,
+)
+from subagents_pydantic_ai.types import (
     AgentMessage as AgentMessage,
 )
 from subagents_pydantic_ai.types import (
@@ -159,6 +164,9 @@ from subagents_pydantic_ai.types import (
 from subagents_pydantic_ai.types import (
     decide_execution_mode as decide_execution_mode,
 )
+from subagents_pydantic_ai.types import (
+    utcnow as utcnow,
+)
 
 __all__ = [
     # Capability
@@ -173,6 +181,7 @@ __all__ = [
     "AgentMessage",
     "MessageType",
     "TaskStatus",
+    "TERMINAL_STATUSES",
     "TaskPriority",
     "TaskCharacteristics",
     "ExecutionMode",
@@ -184,6 +193,7 @@ __all__ = [
     "CompiledSubAgent",
     # Functions
     "decide_execution_mode",
+    "utcnow",
     # Toolsets
     "create_subagent_toolset",
     "SubAgentToolset",

--- a/src/subagents_pydantic_ai/_chat_trace.py
+++ b/src/subagents_pydantic_ai/_chat_trace.py
@@ -1,0 +1,64 @@
+"""Storage for subagent conversations that a `chat_trace_id` can resume.
+
+A chat trace is one subagent's message history, kept so a later delegation can
+continue that conversation instead of starting cold. Traces are held in memory and
+bounded by an LRU, because a long-lived orchestrator would otherwise accumulate
+every conversation it ever started.
+"""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from typing import Any
+
+ChatTraceKey = tuple[str, str]
+"""`(subagent_name, chat_trace_id)`. A trace belongs to the subagent that created
+it: continuing it with a different subagent would replay one agent's history into
+another."""
+
+
+class ChatTraceStore:
+    """LRU-bounded message histories, plus the set of traces currently running.
+
+    A trace must finish before it can be continued. Two concurrent tasks on one
+    trace would both save at the end, and the slower save would silently discard
+    the faster one's history.
+    """
+
+    def __init__(self, max_traces: int) -> None:
+        self.history: OrderedDict[ChatTraceKey, list[Any]] = OrderedDict()
+        self._max_traces = max_traces
+        self._active: set[ChatTraceKey] = set()
+
+    def is_active(self, key: ChatTraceKey) -> bool:
+        """Whether a task is currently running on this trace."""
+        return key in self._active
+
+    def mark_active(self, key: ChatTraceKey) -> None:
+        """Claim the trace for a task that is about to start."""
+        self._active.add(key)
+
+    def release(self, key: ChatTraceKey) -> None:
+        """Release the trace once its task has finished."""
+        self._active.discard(key)
+
+    def __contains__(self, key: ChatTraceKey) -> bool:
+        return key in self.history
+
+    def history_for(self, key: ChatTraceKey) -> list[Any] | None:
+        """The stored history for a trace, refreshing its LRU recency.
+
+        Reading counts as use, so a trace the orchestrator keeps continuing does
+        not get evicted underneath it.
+        """
+        messages = self.history.get(key)
+        if messages is not None:
+            self.history.move_to_end(key)
+        return messages
+
+    def save(self, key: ChatTraceKey, messages: list[Any]) -> None:
+        """Store a finished run's history, evicting the least recently used traces."""
+        self.history[key] = messages
+        self.history.move_to_end(key)
+        while len(self.history) > self._max_traces:
+            self.history.popitem(last=False)

--- a/src/subagents_pydantic_ai/_execution.py
+++ b/src/subagents_pydantic_ai/_execution.py
@@ -1,0 +1,394 @@
+"""Running one delegated task, synchronously or in the background.
+
+## Error contract
+
+A delegation can fail in four distinct ways, and collapsing them into one string
+result -- which is what this module used to do -- loses information the parent run
+needs:
+
+- **Control-flow signals** (`CallDeferred`, `ApprovalRequired`, `Skip*`) are how
+  pydantic-ai suspends a run for deferred tools or human approval. Catching them
+  turns a suspended run into a tool result the parent reads as a finished task, so
+  they always propagate.
+- **`UserError`** is a setup mistake no retry can fix. Reporting it to the model as
+  a task failure hides it, so it always propagates.
+- **`UsageLimitExceeded`** on a budget shared with the parent means the whole agent
+  tree is out of budget, so it propagates too.
+- **Everything else** is a failure the parent can react to. It reaches the parent as
+  `ModelRetry`, which engages pydantic-ai's retry budget, rather than as a normal
+  tool result whose text happens to start with `Error`.
+
+Background delegations are always soft: the parent already received its tool result
+(the task id), so an outcome can only be delivered as a status transition.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Callable
+from typing import Any
+
+from pydantic_ai import UsageLimits
+from pydantic_ai.exceptions import (
+    ApprovalRequired,
+    CallDeferred,
+    ModelRetry,
+    SkipModelRequest,
+    SkipToolExecution,
+    SkipToolValidation,
+    UnexpectedModelBehavior,
+    UsageLimitExceeded,
+    UserError,
+)
+
+from subagents_pydantic_ai._observability import (
+    capture_message_history,
+    capture_observability,
+    serialize_output,
+)
+from subagents_pydantic_ai._state import SubAgentState, bind_subagent_state
+from subagents_pydantic_ai.message_bus import InMemoryMessageBus, TaskManager
+from subagents_pydantic_ai.prompts import get_task_instructions_prompt
+from subagents_pydantic_ai.retry import RetryConfig, run_with_retry
+from subagents_pydantic_ai.types import (
+    AskUserCallback,
+    MessageType,
+    SubAgentConfig,
+    TaskHandle,
+    TaskPriority,
+    TaskStatus,
+    utcnow,
+)
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_ASK_TIMEOUT_SECONDS = 300.0
+"""How long `ask_parent` waits for the parent before proceeding on its own."""
+
+_ALWAYS_PROPAGATE: tuple[type[Exception], ...] = (
+    CallDeferred,
+    ApprovalRequired,
+    SkipModelRequest,
+    SkipToolValidation,
+    SkipToolExecution,
+    UserError,
+)
+"""Signals that must reach the parent run even when errors are contained.
+
+Containing the first five breaks the agent graph -- they are deferred/approval
+control flow, not failures. `UserError` is a configuration bug that no retry fixes.
+"""
+
+_HUMAN_IN_THE_LOOP: tuple[type[Exception], ...] = (CallDeferred, ApprovalRequired)
+"""Signals a background delegation cannot deliver: they need a caller to hand the
+deferred state back to, and the delegating tool returned long ago."""
+
+
+def _build_run_kwargs(
+    deps: Any,
+    *,
+    extra_toolsets: list[Any] | None,
+    usage_limits: UsageLimits | None,
+    message_history: list[Any] | None,
+    conversation_id: str | None,
+) -> dict[str, Any]:
+    run_kwargs: dict[str, Any] = {"deps": deps}
+    if extra_toolsets:
+        run_kwargs["toolsets"] = extra_toolsets
+    if usage_limits is not None:
+        run_kwargs["usage_limits"] = usage_limits
+    if message_history is not None:
+        run_kwargs["message_history"] = message_history
+    if conversation_id is not None:
+        run_kwargs["conversation_id"] = conversation_id
+    return run_kwargs
+
+
+def _task_prompt(config: SubAgentConfig, description: str) -> str:
+    return get_task_instructions_prompt(
+        description,
+        can_ask_questions=config.get("can_ask_questions", True),
+        max_questions=config.get("max_questions"),
+    )
+
+
+async def _run_sync(
+    agent: Any,
+    config: SubAgentConfig,
+    description: str,
+    deps: Any,
+    task_id: str,
+    extra_toolsets: list[Any] | None = None,
+    ask_user: AskUserCallback | None = None,
+    usage_limits: UsageLimits | None = None,
+    handle: TaskHandle | None = None,
+    message_history: list[Any] | None = None,
+    on_message_history: Callable[[list[Any]], None] | None = None,
+    ask_timeout_seconds: float = DEFAULT_ASK_TIMEOUT_SECONDS,
+    contain_errors: bool = True,
+) -> str:
+    """Run a subagent task synchronously, blocking until it finishes.
+
+    Args:
+        agent: The agent to run.
+        config: Subagent configuration.
+        description: Task description.
+        deps: Dependencies for the subagent.
+        task_id: Unique task identifier.
+        extra_toolsets: Additional toolsets for this run.
+        ask_user: Callback backing `ask_parent`. Required for questions in sync
+            mode: the parent's run loop is blocked here, so it cannot answer
+            through `answer_subagent`.
+        usage_limits: Usage limits forwarded to the run, honoured on every retry.
+        handle: Task handle populated for observability.
+        message_history: Prior history when continuing a chat trace.
+        on_message_history: Receives the successful run's full message history.
+        ask_timeout_seconds: How long `ask_parent` waits for `ask_user`.
+        contain_errors: Whether a subagent crash is converted into a `ModelRetry`
+            for the parent instead of propagating and aborting the parent run.
+            Signals in `_ALWAYS_PROPAGATE` ignore this.
+
+    Returns:
+        The subagent's output, or the configured `on_failure` message.
+
+    Raises:
+        ModelRetry: When the subagent failed and no `on_failure` message is set.
+        Exception: Control-flow signals, `UserError`, a shared `UsageLimitExceeded`,
+            and -- when `contain_errors` is false -- any other subagent exception.
+    """
+    prompt = _task_prompt(config, description)
+    run_kwargs = _build_run_kwargs(
+        deps,
+        extra_toolsets=extra_toolsets,
+        usage_limits=usage_limits,
+        message_history=message_history,
+        conversation_id=handle.chat_trace_id if handle is not None else None,
+    )
+    state = SubAgentState(ask_timeout_seconds=ask_timeout_seconds, ask_callback=ask_user)
+
+    try:
+        with bind_subagent_state(state):
+            result = await run_with_retry(
+                agent,
+                prompt,
+                run_kwargs=run_kwargs,
+                retry=RetryConfig.from_config(config),
+            )
+    except _ALWAYS_PROPAGATE:
+        _fail(handle, "propagated")
+        raise
+    except UsageLimitExceeded:
+        _fail(handle, "usage limit exceeded")
+        raise
+    except (ModelRetry, UnexpectedModelBehavior) as exc:
+        return _degrade(handle, config, task_id, exc, crashed=False)
+    except Exception as exc:
+        if not contain_errors:
+            _fail(handle, str(exc))
+            raise
+        return _degrade(handle, config, task_id, exc, crashed=True)
+
+    capture_message_history(result, on_message_history)
+    output = serialize_output(result.output)
+    if handle is not None:
+        handle.finish(TaskStatus.COMPLETED, result=output)
+        # Telemetry runs after the run is marked complete, so a capture failure
+        # can never flip a successful run to FAILED.
+        capture_observability(handle, result)
+    return output
+
+
+def _fail(handle: TaskHandle | None, error: str) -> None:
+    if handle is not None:
+        handle.finish(TaskStatus.FAILED, error=error)
+
+
+def _degrade(
+    handle: TaskHandle | None,
+    config: SubAgentConfig,
+    task_id: str,
+    exc: BaseException,
+    *,
+    crashed: bool,
+) -> str:
+    """Record a failed delegation and tell the parent about it.
+
+    Raises `ModelRetry` unless the subagent configured an `on_failure` message, in
+    which case the parent receives that as an ordinary tool result.
+    """
+    name = config["name"]
+    _fail(handle, f"{type(exc).__name__}: {exc}")
+    if crashed:
+        # Contained, but loud: the exception rides the retry message and is logged,
+        # and the tool's retry budget still turns repeated crashes into an abort.
+        logger.warning("Contained crash from subagent %r (task %s)", name, task_id, exc_info=exc)
+    on_failure = config.get("on_failure")
+    if on_failure is not None:
+        return on_failure
+    verb = "crashed" if crashed else "failed"
+    raise ModelRetry(
+        f"Subagent {name!r} {verb}: {type(exc).__name__}: {exc}. "
+        f"Treat this as a recoverable failure and decide from the evidence you have."
+    ) from exc
+
+
+async def _run_async(
+    agent: Any,
+    config: SubAgentConfig,
+    description: str,
+    deps: Any,
+    task_id: str,
+    task_manager: TaskManager,
+    message_bus: InMemoryMessageBus,
+    priority: TaskPriority = TaskPriority.NORMAL,
+    extra_toolsets: list[Any] | None = None,
+    usage_limits: UsageLimits | None = None,
+    chat_trace_id: str | None = None,
+    message_history: list[Any] | None = None,
+    on_message_history: Callable[[list[Any]], None] | None = None,
+    on_run_finished: Callable[[], None] | None = None,
+    ask_timeout_seconds: float = DEFAULT_ASK_TIMEOUT_SECONDS,
+    parent_run_id: str | None = None,
+) -> str:
+    """Start a subagent task in the background and return its handle text.
+
+    Args:
+        agent: The agent to run.
+        config: Subagent configuration.
+        description: Task description.
+        deps: Dependencies for the subagent.
+        task_id: Unique task identifier.
+        task_manager: Owns the task, its handle, and its cancellation state.
+        message_bus: Delivers steering messages to the running subagent.
+        priority: Task priority recorded on the handle.
+        extra_toolsets: Additional toolsets for this run.
+        usage_limits: Usage limits forwarded to the run, honoured on every retry.
+        chat_trace_id: Chat trace this conversation belongs to, when continuable.
+        message_history: Prior history when continuing a chat trace.
+        on_message_history: Receives the successful run's full message history.
+        on_run_finished: Invoked once when the run finishes, however it finishes.
+        ask_timeout_seconds: How long `ask_parent` waits for the parent's answer.
+        parent_run_id: `run_id` of the parent run, so the task can be scoped to it.
+
+    Returns:
+        Text telling the parent the task id and how to check on it.
+    """
+    handle = TaskHandle(
+        task_id=task_id,
+        subagent_name=config["name"],
+        description=description,
+        status=TaskStatus.PENDING,
+        priority=priority,
+        chat_trace_id=chat_trace_id,
+        parent_run_id=parent_run_id,
+    )
+
+    agent_id = f"subagent-{task_id}"
+    try:
+        message_bus.register_agent(agent_id)
+    except ValueError:
+        pass  # Already registered
+
+    prompt = _task_prompt(config, description)
+    run_kwargs = _build_run_kwargs(
+        deps,
+        extra_toolsets=extra_toolsets,
+        usage_limits=usage_limits,
+        message_history=message_history,
+        conversation_id=chat_trace_id,
+    )
+    state = SubAgentState(
+        ask_timeout_seconds=ask_timeout_seconds,
+        task_manager=task_manager,
+        task_id=task_id,
+    )
+
+    async def run_task() -> None:
+        def on_retry(attempt: int, exc: BaseException, delay: float) -> None:
+            handle.status = TaskStatus.RETRYING
+            handle.retry_count = attempt
+            handle.error = f"Transient error (retry {attempt}): {exc}"
+
+        def cancel_requested() -> bool:
+            # Cooperative cancellation: `soft_cancel` sets this event and the run
+            # loop polls it between graph nodes, so the subagent stops at a clean
+            # boundary with its partial progress intact.
+            cancel_event = task_manager.get_cancel_event(task_id)
+            return cancel_event is not None and cancel_event.is_set()
+
+        async def pending_steering() -> list[str]:
+            return await drain_steering_messages(message_bus, agent_id)
+
+        try:
+            with bind_subagent_state(state):
+                result = await run_with_retry(
+                    agent,
+                    prompt,
+                    run_kwargs=run_kwargs,
+                    retry=RetryConfig.from_config(config),
+                    on_retry=on_retry,
+                    cancel_check=cancel_requested,
+                    inject_messages=pending_steering,
+                )
+            capture_message_history(result, on_message_history)
+            if handle.finish(TaskStatus.COMPLETED, result=serialize_output(result.output)):
+                capture_observability(handle, result)
+        except asyncio.CancelledError:
+            handle.finish(TaskStatus.CANCELLED, error="Task was cancelled")
+            raise
+        except _HUMAN_IN_THE_LOOP as exc:
+            handle.finish(
+                TaskStatus.FAILED,
+                error=(
+                    f"{type(exc).__name__}: a subagent that needs approval or defers a "
+                    f"tool call cannot run in the background; delegate it with mode='sync'."
+                ),
+            )
+        except Exception as exc:
+            logger.warning(
+                "Background subagent %r failed (task %s)", config["name"], task_id, exc_info=exc
+            )
+            handle.finish(TaskStatus.FAILED, error=f"{type(exc).__name__}: {exc}")
+        finally:
+            if handle.completed_at is None:  # pragma: no cover - every path finishes above
+                handle.completed_at = utcnow()
+            message_bus.unregister_agent(agent_id)
+            task_manager.clear_answer_future(task_id)
+            task_manager.cleanup_task(task_id)
+            if on_run_finished is not None:
+                on_run_finished()
+
+    task_manager.create_task(task_id, run_task(), handle)
+
+    response = f"Task started in background.\nTask ID: {task_id}\nSubagent: {config['name']}\n"
+    if chat_trace_id is not None:
+        response += f"Chat Trace ID: {chat_trace_id}\n"
+    response += f"Use check_task('{task_id}') to check status."
+    return response
+
+
+async def drain_steering_messages(message_bus: InMemoryMessageBus, agent_id: str) -> list[str]:
+    """Take the parent-to-child steering messages queued for a running subagent.
+
+    Only `TASK_UPDATE` carries steering. Other message types on the queue (an
+    unused `CANCEL_REQUEST` -- soft cancel runs off the cancel event, not the bus)
+    and empty payloads are ignored.
+
+    Args:
+        message_bus: The bus the running subagent is registered on.
+        agent_id: The subagent's bus id (`subagent-{task_id}`).
+
+    Returns:
+        Steering instructions in delivery order, possibly empty.
+    """
+    pending = await message_bus.get_messages(agent_id, timeout=0)
+    steering: list[str] = []
+    for msg in pending:
+        if msg.type != MessageType.TASK_UPDATE:
+            continue
+        payload = msg.payload
+        text = payload.get("message") if isinstance(payload, dict) else payload
+        if text:
+            steering.append(str(text))
+    return steering

--- a/src/subagents_pydantic_ai/_observability.py
+++ b/src/subagents_pydantic_ai/_observability.py
@@ -1,0 +1,145 @@
+"""Telemetry captured from a finished subagent run onto its `TaskHandle`.
+
+Everything here is best-effort, matching pydantic-ai's own instrumentation, which
+warns on cost and serialization failures rather than propagating them. A run that
+produced an answer must never be reported as `FAILED` because collecting its
+metadata raised.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import logging
+from collections.abc import Callable
+from decimal import Decimal
+from typing import Any
+
+from subagents_pydantic_ai.types import TaskHandle
+
+logger = logging.getLogger(__name__)
+
+_TRACEPARENT_FIELDS = 4
+"""A W3C traceparent is `version-trace_id-span_id-flags`."""
+
+
+def serialize_output(output: Any) -> str:
+    """Render a subagent's output as text, preserving structure where it exists.
+
+    Pydantic models and dataclasses become JSON so the parent model receives the
+    fields rather than a `repr`; everything else falls back to `str`.
+    """
+    if hasattr(output, "model_dump_json"):
+        return str(output.model_dump_json())
+    if dataclasses.is_dataclass(output) and not isinstance(output, type):
+        return json.dumps(dataclasses.asdict(output), default=str)
+    return str(output)
+
+
+def capture_message_history(
+    result: Any,
+    on_message_history: Callable[[list[Any]], None] | None,
+) -> None:
+    """Hand a successful run's message history to the chat-trace store.
+
+    On failure the previously saved history is kept, so continuing the trace
+    resumes from the last point that was successfully saved.
+    """
+    if on_message_history is None:
+        return
+
+    try:
+        all_messages = getattr(result, "all_messages", None)
+        if all_messages is None:
+            return
+
+        messages: Any = all_messages()
+        if messages:
+            on_message_history(list(messages))
+    except Exception as e:
+        logger.warning("Failed to capture subagent message history: %s", e)
+
+
+def result_traceparent(result: Any) -> str | None:
+    """The run's W3C traceparent, when instrumentation produced one."""
+    traceparent = getattr(result, "_traceparent", None)
+    if traceparent is None:
+        return None
+
+    value = traceparent(required=False)
+    return value if isinstance(value, str) and value else None
+
+
+def model_responses(result: Any) -> list[Any]:
+    """Every model response in the run, in order, including the final one."""
+    responses: list[Any] = []
+    for message in result.all_messages():
+        if getattr(message, "kind", None) == "response":
+            responses.append(message)
+
+    try:
+        response = result.response
+    except (AttributeError, ValueError):
+        response = None
+    if response is not None and all(response is not item for item in responses):
+        responses.append(response)
+    return responses
+
+
+def capture_result_observability(handle: TaskHandle, result: Any) -> None:
+    """Copy a finished run's telemetry onto `handle`, letting failures propagate.
+
+    `capture_observability` is the wrapper callers should use; this is the raw
+    version, kept separate so tests can assert on collection failures.
+    """
+    handle.usage = result.usage
+    handle.message_history = result.all_messages_json().decode()
+    handle.run_id = result.run_id
+    handle.conversation_id = result.conversation_id
+
+    handle.traceparent = result_traceparent(result)
+    if handle.traceparent is not None:
+        parts = handle.traceparent.split("-")
+        if len(parts) >= _TRACEPARENT_FIELDS:
+            handle.trace_id = parts[1]
+            handle.span_id = parts[2]
+
+    responses = model_responses(result)
+    if responses:
+        # The final response produced the returned output, so it owns the per-run
+        # model and provider metadata. Aggregates (`cost`, `tool_call_counts`) are
+        # summed across every response instead, which is what a multi-model run
+        # needs.
+        response = responses[-1]
+        handle.model_name = response.model_name
+        handle.provider_name = response.provider_name
+        handle.provider_url = response.provider_url
+        handle.provider_response_id = response.provider_response_id
+        handle.provider_details = response.provider_details
+        handle.finish_reason = response.finish_reason
+
+    total_cost = Decimal("0")
+    has_cost = False
+    tool_call_counts: dict[str, int] = {}
+    for response in responses:
+        if response.model_name:
+            try:
+                total_cost += response.cost().total_price
+                has_cost = True
+            except LookupError:
+                # genai-prices has no entry for this model/provider pair.
+                pass
+
+        for tool_call in response.tool_calls:
+            tool_call_counts[tool_call.tool_name] = tool_call_counts.get(tool_call.tool_name, 0) + 1
+
+    handle.cost = total_cost if has_cost else None
+    handle.tool_call_counts = tool_call_counts
+
+
+def capture_observability(handle: TaskHandle, result: Any) -> None:
+    """Copy a finished run's telemetry onto `handle` without ever failing the task."""
+    try:
+        capture_result_observability(handle, result)
+    except Exception as e:
+        logger.warning("Failed to capture subagent observability: %s", e)

--- a/src/subagents_pydantic_ai/_state.py
+++ b/src/subagents_pydantic_ai/_state.py
@@ -1,0 +1,68 @@
+"""Per-delegation state that `ask_parent` needs to reach the parent agent.
+
+The state used to be injected as an untyped `dict` onto the application's deps
+object (`deps._subagent_state = {...}`). That fails outright for a deps dataclass
+declared `frozen=True` or `slots=True`, both of which the protocol allows and the
+docs never warned against, and it left the payload stringly-typed
+(`state.get("ask_callback")`).
+
+A `ContextVar` carries it instead: `asyncio.create_task` copies the current
+context, so a background delegation sees the state set for it, and each task gets
+its own copy rather than sharing a mutable attribute.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from subagents_pydantic_ai.types import AskUserCallback
+
+if TYPE_CHECKING:
+    from subagents_pydantic_ai.message_bus import TaskManager
+
+
+@dataclass(frozen=True, slots=True)
+class SubAgentState:
+    """How the subagent currently being run can reach its parent.
+
+    Exactly one of the two channels is set. In sync mode the parent's run loop is
+    blocked inside the delegation, so a question can only be answered by
+    `ask_callback`. In async mode the parent is still running and answers through
+    `answer_subagent`, which resolves a future held by `task_manager`.
+
+    Attributes:
+        ask_callback: Sync mode. Called with the question, returns the answer.
+        task_manager: Async mode. Holds the task handle and the answer future.
+        task_id: Async mode. Identifies this delegation in `task_manager`.
+        ask_timeout_seconds: How long `ask_parent` waits for the parent's answer
+            before giving up and telling the subagent to proceed on its own.
+    """
+
+    ask_timeout_seconds: float
+    ask_callback: AskUserCallback | None = None
+    task_manager: TaskManager | None = None
+    task_id: str | None = None
+
+
+_SUBAGENT_STATE: ContextVar[SubAgentState | None] = ContextVar(
+    "subagents_pydantic_ai_state", default=None
+)
+
+
+@contextmanager
+def bind_subagent_state(state: SubAgentState) -> Iterator[None]:
+    """Make `state` the current delegation's state for the duration of the block."""
+    token = _SUBAGENT_STATE.set(state)
+    try:
+        yield
+    finally:
+        _SUBAGENT_STATE.reset(token)
+
+
+def current_subagent_state() -> SubAgentState | None:
+    """The state bound for the delegation running in this context, if any."""
+    return _SUBAGENT_STATE.get()

--- a/src/subagents_pydantic_ai/capability.py
+++ b/src/subagents_pydantic_ai/capability.py
@@ -29,13 +29,16 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from pydantic_ai import RunContext, UsageLimits
-from pydantic_ai.capabilities import AbstractCapability
+from pydantic_ai.agent import AgentRunResult
+from pydantic_ai.capabilities import AbstractCapability, WrapRunHandler
 from pydantic_ai.toolsets import AbstractToolset
 
+from subagents_pydantic_ai._execution import DEFAULT_ASK_TIMEOUT_SECONDS
 from subagents_pydantic_ai.dynamic_agent import AgentFactory, CapabilityFactory
+from subagents_pydantic_ai.message_bus import TaskManager
 from subagents_pydantic_ai.prompts import get_subagent_system_prompt
 from subagents_pydantic_ai.registry import DynamicAgentRegistry
-from subagents_pydantic_ai.toolset import create_subagent_toolset
+from subagents_pydantic_ai.toolset import SubAgentToolset, create_subagent_toolset
 from subagents_pydantic_ai.types import (
     DelegationConfiguration,
     SubAgentConfig,
@@ -116,7 +119,9 @@ class SubAgentCapability(AbstractCapability[Any]):
     default_agent_factory: AgentFactory | None = None
     max_agents: int = 10
     max_result_chars: int | None = 2000
-    _toolset: AbstractToolset[Any] | None = field(default=None, init=False, repr=False)
+    ask_timeout_seconds: float = DEFAULT_ASK_TIMEOUT_SECONDS
+    contain_errors: bool = True
+    _toolset: SubAgentToolset = field(init=False, repr=False)
 
     def __post_init__(self) -> None:
         """Create the underlying subagent toolset."""
@@ -136,6 +141,8 @@ class SubAgentCapability(AbstractCapability[Any]):
             default_agent_factory=self.default_agent_factory,
             max_agents=self.max_agents,
             max_result_chars=self.max_result_chars,
+            ask_timeout_seconds=self.ask_timeout_seconds,
+            contain_errors=self.contain_errors,
         )
 
     @classmethod
@@ -144,13 +151,31 @@ class SubAgentCapability(AbstractCapability[Any]):
         return "SubAgentCapability"
 
     @property
-    def task_manager(self) -> Any:
-        """Access the underlying task manager for observability."""
-        return getattr(self._toolset, "task_manager", None)
+    def task_manager(self) -> TaskManager:
+        """The task manager behind the toolset, for observability."""
+        return self._toolset.task_manager
 
     def get_toolset(self) -> AbstractToolset[Any] | None:
         """Return the subagent toolset with all registered tools."""
         return self._toolset
+
+    async def wrap_run(
+        self,
+        ctx: RunContext[Any],
+        *,
+        handler: WrapRunHandler,
+    ) -> AgentRunResult[Any]:
+        """Run the agent, then stop every background task this run started.
+
+        A background delegation is an `asyncio.Task` the parent run does not await.
+        Without this finalizer it keeps executing after the run returns, against
+        deps the application has already torn down, and one blocked in `ask_parent`
+        waits for an answer that can never arrive.
+        """
+        try:
+            return await handler()
+        finally:
+            await self._toolset.cancel_run_tasks(ctx.run_id)
 
     def get_instructions(self) -> Any:
         """Return dynamic instructions listing available subagents."""

--- a/src/subagents_pydantic_ai/message_bus.py
+++ b/src/subagents_pydantic_ai/message_bus.py
@@ -1,20 +1,28 @@
-"""Message bus implementations for inter-agent communication.
+"""Message bus and background-task bookkeeping for subagent delegation.
 
-This module provides message bus implementations that enable communication
-between parent agents and subagents. The default implementation uses
-asyncio queues for in-memory communication.
+`TaskManager` owns the lifecycle of background (async-mode) delegations:
+the `asyncio.Task` running each one, its `TaskHandle`, its cancellation event,
+and the future a blocked `ask_parent` is waiting on.
+
+`InMemoryMessageBus` carries parent-to-child steering messages. Its
+request-response half (`ask`, `answer`, handlers) is not used by the toolset; it
+exists as an extension point for applications that want to drive the bus
+themselves, or to back a different transport behind `MessageBusProtocol`.
 """
 
 from __future__ import annotations
 
 import asyncio
+import contextlib
+import logging
 import uuid
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Coroutine
 from dataclasses import dataclass, field
-from datetime import datetime
 from typing import Any
 
-from subagents_pydantic_ai.types import AgentMessage, MessageType, TaskStatus
+from subagents_pydantic_ai.types import AgentMessage, MessageType, TaskHandle, TaskStatus, utcnow
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -65,12 +73,14 @@ class InMemoryMessageBus:
 
         await self._queues[message.receiver].put(message)
 
-        # Notify handlers
         for handler in self._handlers:
+            # Handlers are observers (logging, tracing). One that raises must not
+            # stop delivery to the others or fail the send, but it is logged
+            # rather than discarded.
             try:
                 await handler(message)
-            except Exception:  # pragma: no cover
-                pass  # Don't let handler errors break message delivery
+            except Exception as e:
+                logger.warning("Message bus handler %r failed: %s", handler, e)
 
     async def ask(
         self,
@@ -101,13 +111,10 @@ class InMemoryMessageBus:
 
         correlation_id = str(uuid.uuid4())
 
-        # Create future for the response
-        loop = asyncio.get_event_loop()
-        response_future: asyncio.Future[AgentMessage] = loop.create_future()
+        response_future: asyncio.Future[AgentMessage] = asyncio.get_running_loop().create_future()
         self._pending_questions[correlation_id] = response_future
 
         try:
-            # Send the question
             message = AgentMessage(
                 type=MessageType.QUESTION,
                 sender=sender,
@@ -118,10 +125,8 @@ class InMemoryMessageBus:
             )
             await self.send(message)
 
-            # Wait for response
             return await asyncio.wait_for(response_future, timeout=timeout)
         finally:
-            # Clean up
             self._pending_questions.pop(correlation_id, None)
 
     async def answer(self, original: AgentMessage, answer: Any) -> None:
@@ -147,13 +152,11 @@ class InMemoryMessageBus:
             correlation_id=original.correlation_id,
         )
 
-        # If there's a pending future for this correlation_id, resolve it
         if original.correlation_id and original.correlation_id in self._pending_questions:
             future = self._pending_questions[original.correlation_id]
             if not future.done():
                 future.set_result(response)
         else:
-            # Otherwise, put in queue
             await self.send(response)
 
     def register_agent(self, agent_id: str) -> asyncio.Queue[AgentMessage]:
@@ -247,7 +250,6 @@ class InMemoryMessageBus:
         queue = self._queues[agent_id]
         messages: list[AgentMessage] = []
 
-        # If timeout > 0 and queue is empty, wait for first message
         if timeout > 0 and queue.empty():
             try:
                 msg = await asyncio.wait_for(queue.get(), timeout=timeout)
@@ -255,7 +257,6 @@ class InMemoryMessageBus:
             except asyncio.TimeoutError:
                 return messages
 
-        # Drain all available messages
         while not queue.empty():
             try:
                 msg = queue.get_nowait()
@@ -305,23 +306,26 @@ class TaskManager:
     status querying capabilities.
 
     Attributes:
-        tasks: Dictionary of task_id -> asyncio.Task
-        handles: Dictionary of task_id -> TaskHandle
-        message_bus: Message bus for communication
+        tasks: Live `asyncio.Task` per task id. An entry is removed by
+            `cleanup_task` when the task finishes.
+        handles: `TaskHandle` per task id, kept after the task finishes so its
+            result and telemetry stay queryable.
+        message_bus: Message bus used to deliver steering and cancel messages.
     """
 
-    tasks: dict[str, asyncio.Task[Any]] = field(default_factory=dict)
-    handles: dict[str, Any] = field(default_factory=dict)  # TaskHandle
+    tasks: dict[str, asyncio.Task[None]] = field(default_factory=dict)
+    handles: dict[str, TaskHandle] = field(default_factory=dict)
     message_bus: InMemoryMessageBus = field(default_factory=InMemoryMessageBus)
     _cancel_events: dict[str, asyncio.Event] = field(default_factory=dict)
     _answer_futures: dict[str, asyncio.Future[str]] = field(default_factory=dict)
+    _strong_refs: set[asyncio.Task[None]] = field(default_factory=set)
 
     def create_task(
         self,
         task_id: str,
-        coro: Any,  # Coroutine
-        handle: Any,  # TaskHandle
-    ) -> asyncio.Task[Any]:
+        coro: Coroutine[Any, Any, None],
+        handle: TaskHandle,
+    ) -> asyncio.Task[None]:
         """Create and track a new background task.
 
         Args:
@@ -332,18 +336,22 @@ class TaskManager:
         Returns:
             The created asyncio.Task.
         """
-        task = asyncio.create_task(coro)
+        task = asyncio.create_task(coro, name=f"subagent-{task_id}")
         self.tasks[task_id] = task
         self.handles[task_id] = handle
         self._cancel_events[task_id] = asyncio.Event()
+        # `cleanup_task` drops `tasks[task_id]` from inside the task's own
+        # `finally`, and the event loop only holds a weak reference, so a second
+        # strong reference keeps the task alive until it is truly done.
+        self._strong_refs.add(task)
+        task.add_done_callback(self._strong_refs.discard)
 
-        # Update handle when task starts
         handle.status = TaskStatus.RUNNING
-        handle.started_at = datetime.now()
+        handle.started_at = utcnow()
 
         return task
 
-    def get_handle(self, task_id: str) -> Any | None:
+    def get_handle(self, task_id: str) -> TaskHandle | None:
         """Get the handle for a task.
 
         Args:
@@ -393,11 +401,30 @@ class TaskManager:
         """
         self._answer_futures.pop(task_id, None)
 
+    def resolve_answer(self, task_id: str, answer: str) -> bool:
+        """Deliver an answer to a task blocked in `ask_parent`.
+
+        Args:
+            task_id: The task ID.
+            answer: The answer to deliver.
+
+        Returns:
+            Whether a waiting `ask_parent` call was resolved.
+        """
+        future = self._answer_futures.get(task_id)
+        if future is not None and not future.done():
+            future.set_result(answer)
+            return True
+        return False
+
     async def soft_cancel(self, task_id: str) -> bool:
         """Request cooperative cancellation of a task.
 
-        Sets a cancellation event that the task can check periodically.
-        The task is expected to clean up and exit gracefully.
+        Sets a cancellation event that the run loop checks between graph nodes,
+        so the subagent stops at a clean boundary with its partial progress
+        intact. A task blocked in `ask_parent` sits inside a tool call rather
+        than at a node boundary, so its pending question is resolved too --
+        otherwise the cancel would only take effect after the ask timeout.
 
         Args:
             task_id: The task to cancel.
@@ -409,35 +436,36 @@ class TaskManager:
             return False
 
         self._cancel_events[task_id].set()
+        self.resolve_answer(
+            task_id,
+            "Your parent agent cancelled this task. Stop working and wrap up immediately.",
+        )
 
-        # Send cancel request message. Only relevant when a handle exists for
-        # the task (created through create_task); the receiver is keyed off the
-        # task_id, not the handle.
         if task_id in self.handles:
-            try:
+            with contextlib.suppress(KeyError):
+                # The running subagent registers on the bus as
+                # `subagent-{task_id}`, not under its subagent name.
                 await self.message_bus.send(
                     AgentMessage(
                         type=MessageType.CANCEL_REQUEST,
                         sender="task_manager",
-                        # The running subagent registers on the bus as
-                        # `subagent-{task_id}` (see toolset.py), not under its
-                        # subagent_name - sending to the latter raised a swallowed
-                        # KeyError so the cancel request never arrived.
                         receiver=f"subagent-{task_id}",
                         payload={"reason": "soft_cancel"},
                         task_id=task_id,
                     )
                 )
-            except KeyError:
-                pass  # Agent not registered, that's OK
 
         return True
 
     async def hard_cancel(self, task_id: str) -> bool:
         """Immediately cancel a task.
 
-        Calls cancel() on the asyncio.Task, causing CancelledError
-        to be raised in the task.
+        Calls `cancel()` on the `asyncio.Task`. The task's own
+        `except asyncio.CancelledError` branch records the terminal status; the
+        handle is only marked here for a bare task registered without that
+        wrapper. `TaskHandle.finish` makes the first terminal transition win, so
+        a cancel arriving while the task is already completing cannot overwrite
+        the real outcome.
 
         Args:
             task_id: The task to cancel.
@@ -451,30 +479,56 @@ class TaskManager:
         task = self.tasks[task_id]
         if not task.done():
             task.cancel()
-            # Only mark the handle cancelled when the task was actually still
-            # running. If it already finished, its run_task `finally` has set
-            # the real outcome (COMPLETED/FAILED and `completed_at`); we must
-            # not clobber that with a spurious `cancelled` and lose the real
-            # result. When a run_task wrapper is present its
-            # `except asyncio.CancelledError` branch will set the final status
-            # once the CancelledError is delivered; setting CANCELLED here keeps
-            # the handle consistent for the bare-task case and is idempotent.
-            if task_id in self.handles:
-                handle = self.handles[task_id]
-                handle.status = TaskStatus.CANCELLED
-                handle.completed_at = datetime.now()
+            handle = self.handles.get(task_id)
+            if handle is not None:
+                handle.finish(TaskStatus.CANCELLED, error="Task was cancelled")
 
         return True
 
+    async def cancel_all(self, parent_run_id: str | None = None) -> None:
+        """Cancel every live task and wait for it to finish cleaning up.
+
+        Called when a parent run ends. A background delegation that outlives its
+        parent keeps working against deps the application has already torn down,
+        and one blocked in `ask_parent` waits for an answer that can never come.
+
+        Args:
+            parent_run_id: Only cancel tasks started by this parent run. `None`
+                cancels every live task.
+        """
+        live: list[asyncio.Task[None]] = []
+        for task_id, task in list(self.tasks.items()):
+            handle = self.handles.get(task_id)
+            if parent_run_id is not None and (
+                handle is None or handle.parent_run_id != parent_run_id
+            ):
+                continue
+            if not task.done():
+                # `cancel()` raises into whatever the task is awaiting, including a
+                # future held by `ask_parent`, so there is nothing to unblock first.
+                task.cancel()
+                live.append(task)
+                # A task cancelled before its coroutine started never reaches its
+                # own `except asyncio.CancelledError`, so record the outcome here.
+                # `finish` is idempotent, so a task that does get there wins.
+                if handle is not None:
+                    handle.finish(TaskStatus.CANCELLED, error="Task was cancelled")
+
+        for task in live:
+            # We requested the cancel, so the task acknowledging it is success.
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+
     def cleanup_task(self, task_id: str) -> None:
         """Clean up resources for a completed task.
+
+        The handle is kept so status and telemetry stay queryable.
 
         Args:
             task_id: The task to clean up.
         """
         self.tasks.pop(task_id, None)
         self._cancel_events.pop(task_id, None)
-        # Keep handle for status queries
 
     def list_active_tasks(self) -> list[str]:
         """Get list of active (non-completed) task IDs.
@@ -484,7 +538,7 @@ class TaskManager:
         """
         return [task_id for task_id, task in self.tasks.items() if not task.done()]
 
-    def list_handles(self) -> list[Any]:
+    def list_handles(self) -> list[TaskHandle]:
         """Get all task handles (completed and active).
 
         Returns:

--- a/src/subagents_pydantic_ai/prompts.py
+++ b/src/subagents_pydantic_ai/prompts.py
@@ -206,13 +206,17 @@ Use only when soft cancellation doesn't work or immediate stopping is required."
 
 def get_subagent_system_prompt(
     configs: list[SubAgentConfig],
-    include_dual_mode: bool = True,
+    include_dual_mode: bool = False,
 ) -> str:
-    """Generate system prompt section describing available subagents.
+    """Generate the system prompt section describing available subagents.
 
     Args:
-        configs: List of subagent configurations.
-        include_dual_mode: Whether to include dual-mode execution explanation.
+        configs: Subagent configurations to list.
+        include_dual_mode: Append `DUAL_MODE_SYSTEM_PROMPT`, explaining sync
+            versus background execution. Off by default because
+            `TASK_TOOL_DESCRIPTION` already covers execution modes where the
+            model needs them, and repeating it in the system prompt is wasted
+            context. The parameter used to be accepted and ignored.
 
     Returns:
         Formatted system prompt section.
@@ -229,18 +233,21 @@ def get_subagent_system_prompt(
         prompt = get_subagent_system_prompt(configs)
         ```
     """
-    lines = ["## Available Subagents", ""]
-    lines.append("Use the `task` tool to delegate work to these subagents:")
-    lines.append("")
+    lines = [
+        "## Available Subagents",
+        "",
+        "Use the `task` tool to delegate work to these subagents:",
+        "",
+    ]
 
     for config in configs:
-        name = config["name"]
-        description = config["description"]
-        lines.append(f"- **{name}**: {description}")
-
-        # Add hint if agent cannot ask questions
+        line = f"- **{config['name']}**: {config['description']}"
         if config.get("can_ask_questions") is False:
-            lines[-1] += " *(cannot ask clarifying questions)*"
+            line += " *(cannot ask clarifying questions)*"
+        lines.append(line)
+
+    if include_dual_mode:
+        lines.extend(["", DUAL_MODE_SYSTEM_PROMPT])
 
     return "\n".join(lines)
 

--- a/src/subagents_pydantic_ai/prompts.py
+++ b/src/subagents_pydantic_ai/prompts.py
@@ -69,6 +69,8 @@ configured subagent or create a persistent agent first
 ## Parameters
 - **description**: The task prompt for the specialist to execute
 - **instructions**: The specialist's system prompt / role definition
+- **name**: Label for logs and async task handles (letters, numbers, hyphens). \
+Naming the specialist does not register it — it still cannot be reused via `task`
 - **model**: Optional model override
 - **capabilities**: Optional capability names to attach to the specialist
 - **mode**: `"sync"` (default), `"async"`, or `"auto"`

--- a/src/subagents_pydantic_ai/protocols.py
+++ b/src/subagents_pydantic_ai/protocols.py
@@ -26,22 +26,16 @@ class SubAgentDepsProtocol(Protocol):
         @dataclass(slots=True)
         class MyDeps:
             backend: Backend
-            subagents: dict[str, Any] = field(default_factory=dict)
 
             def clone_for_subagent(self, max_depth: int = 0) -> "MyDeps":
-                return MyDeps(
-                    backend=self.backend,
-                    subagents={} if max_depth <= 0 else self.subagents,
-                )
+                return MyDeps(backend=self.backend)
         ```
 
-    Attributes:
-        subagents: Compiled agents the deps carries. This library never reads it;
-            it remains part of the protocol because existing applications declare
-            it and pydantic-deep uses it. New deps classes can leave it empty.
+    Earlier versions also required a `subagents: dict[str, Any]` attribute. The
+    library never read it, so every application carried a field for nothing; the
+    requirement is gone. A deps class that still declares it satisfies this
+    protocol unchanged.
     """
-
-    subagents: dict[str, Any]
 
     def clone_for_subagent(self, max_depth: int = 0) -> SubAgentDepsProtocol:
         """Create a new deps instance for a delegated subagent.

--- a/src/subagents_pydantic_ai/protocols.py
+++ b/src/subagents_pydantic_ai/protocols.py
@@ -17,37 +17,48 @@ if TYPE_CHECKING:
 class SubAgentDepsProtocol(Protocol):
     """Protocol for dependencies that support subagent management.
 
-    Any deps class that wants to use the subagent toolset must implement
-    this protocol. The key requirement is a `subagents` dict for storing
-    compiled agent instances and a `clone_for_subagent` method for creating
-    isolated deps for nested subagents.
+    The only method the library calls is `clone_for_subagent`, which decides what
+    a delegated subagent inherits from its parent. Your deps class may be frozen
+    or use `slots` -- the library never writes attributes onto it.
 
     Example:
         ```python
-        @dataclass
+        @dataclass(slots=True)
         class MyDeps:
+            backend: Backend
             subagents: dict[str, Any] = field(default_factory=dict)
 
             def clone_for_subagent(self, max_depth: int = 0) -> "MyDeps":
                 return MyDeps(
+                    backend=self.backend,
                     subagents={} if max_depth <= 0 else self.subagents,
                 )
         ```
+
+    Attributes:
+        subagents: Compiled agents the deps carries. This library never reads it;
+            it remains part of the protocol because existing applications declare
+            it and pydantic-deep uses it. New deps classes can leave it empty.
     """
 
     subagents: dict[str, Any]
 
     def clone_for_subagent(self, max_depth: int = 0) -> SubAgentDepsProtocol:
-        """Create a new deps instance for a subagent.
+        """Create a new deps instance for a delegated subagent.
 
-        Subagents typically get:
-        - Shared resources (backend, files, etc.)
-        - Empty or limited subagents dict (based on max_depth)
-        - Fresh state for task-specific data
+        Return a **new** instance rather than `self`. The library relies on each
+        delegation getting its own deps, and a shared instance leaks state
+        between concurrent subagents.
+
+        A subagent typically inherits shared resources (a backend, a filesystem)
+        and gets fresh task-specific state.
 
         Args:
-            max_depth: Maximum nesting depth for the subagent.
-                If 0, the subagent cannot spawn further subagents.
+            max_depth: Remaining nesting budget, one less than the parent's
+                `max_nesting_depth`. At or below zero the subagent should not be
+                given the means to delegate further. Enforcement is yours: the
+                library passes the number through but does not itself refuse a
+                nested delegation.
 
         Returns:
             A new deps instance configured for the subagent.

--- a/src/subagents_pydantic_ai/retry.py
+++ b/src/subagents_pydantic_ai/retry.py
@@ -23,6 +23,18 @@ each model-request/tool node so the handler receives every event.
 When retrying is disabled (`max_retries == 0`) the legacy `agent.run()`
 call path is used unchanged (it already honours the handler), so behaviour
 only differs when retrying is opted in.
+
+## Coupling to pydantic-ai internals
+
+:func:`_drive_run` mirrors the driving loop inside :meth:`Agent.run`, which
+means it uses private names (`run._advance_graph`, `run._run_node_with_hooks`,
+`_agent_graph.build_run_context`, `run.ctx.deps.root_capability`). There is no
+public way to drive a run with a custom step while keeping event streaming, so
+the copy is deliberate — but it can drift. `tests/test_retry.py` asserts the
+observable contract the copy has to preserve (node hooks fire, the handler
+receives every event, the wrapped stream is fully drained), and
+`pyproject.toml` pins a `pydantic-ai-slim` lower bound for the names above.
+Removing the copy needs a public primitive in core, not a workaround here.
 """
 
 from __future__ import annotations
@@ -35,15 +47,16 @@ from typing import Any
 
 from pydantic_ai import _agent_graph
 from pydantic_ai.exceptions import ModelAPIError, ModelHTTPError
-from pydantic_ai.messages import UserPromptPart
 from pydantic_graph import End
 
 from subagents_pydantic_ai.types import SubAgentConfig
 
-# HTTP status codes that indicate a transient, retry-worthy failure:
-# request timeout, conflict, too-early, rate limit, and 5xx server/gateway
-# errors (502/503/504 are typical of an overloaded LiteLLM proxy).
-_TRANSIENT_STATUS_CODES = frozenset({408, 409, 425, 429, 500, 502, 503, 504, 529})
+# HTTP status codes worth retrying: request timeout, rate limit, and 5xx
+# server/gateway errors (502/503/504 are typical of an overloaded LiteLLM
+# proxy). 409 Conflict and 425 Too Early are deliberately absent — they signal
+# a request the server rejected on its merits, and replaying it unchanged is
+# not expected to succeed.
+_TRANSIENT_STATUS_CODES = frozenset({408, 429, 500, 502, 503, 504, 529})
 
 RetryPredicate = Callable[[BaseException], bool]
 """Predicate deciding whether an exception is a transient, retryable error."""
@@ -57,9 +70,9 @@ def is_transient_error(exc: BaseException) -> bool:
 
     Treated as transient (worth retrying):
 
-    - `ModelHTTPError` with a 408/409/425/429/5xx status code — gateway
-      hiccups, rate limits or upstream overload, typical with proxies
-      such as LiteLLM.
+    - `ModelHTTPError` with a 408/429/5xx status code — gateway hiccups,
+      rate limits or upstream overload, typical with proxies such as
+      LiteLLM.
     - `ModelAPIError` that is *not* an HTTP error — connection resets,
       read timeouts and other transport-level problems surfaced by the
       model client.
@@ -185,12 +198,13 @@ async def _drive_run(
     caller's cancellation handling unchanged.
 
     `inject_messages` enables unprompted parent -> child steering: it is
-    awaited just before each model-request node and returns any pending
-    steering messages, which are appended as :class:`UserPromptPart`s to that
-    request. The subagent therefore sees them as extra user instructions on
-    its very next model turn, keeping all partial progress. Injecting only at
-    model-request boundaries (not before tool execution) guarantees the parts
-    are never spliced into a tool-call/tool-return pair.
+    awaited between nodes and its messages are handed to `AgentRun.enqueue`,
+    pydantic-ai's own primitive for injecting content into a live run. Core
+    delivers them before the next model request, so the subagent sees them as
+    extra user instructions while keeping all partial progress, and the parts
+    can never be spliced into a tool-call/tool-return pair. Splicing
+    `UserPromptPart`s into `node.request.parts` by hand did the same job before
+    `enqueue` existed and is no longer needed.
     """
 
     _stream_step: Any = None
@@ -205,9 +219,13 @@ async def _drive_run(
                     )
                     if event_stream_handler is not None:
                         await event_stream_handler(run_ctx, wrapped)
-                    else:
-                        async for _ in wrapped:
-                            pass
+                    # Drain whatever the handler left unconsumed so the node can
+                    # finish through any stream wrappers. Matches `Agent.run`,
+                    # which drains unconditionally; draining only in the
+                    # no-handler case left wrappers unfinished for a handler that
+                    # stops reading early.
+                    async for _ in wrapped:
+                        pass
             return await run._advance_graph(node)
 
         _stream_step = _stream_and_advance
@@ -221,16 +239,10 @@ async def _drive_run(
         # A capability's wrap_run short-circuit can publish the result early.
         if run.result is not None:
             break
-        # Fold pending parent -> child steering into the upcoming request. Only
-        # at a model-request boundary, so a UserPromptPart is never spliced
-        # between a tool call and its return.
-        if inject_messages is not None and isinstance(node, _agent_graph.ModelRequestNode):
+        if inject_messages is not None:
             steering = await inject_messages()
             if steering:
-                node.request.parts = [
-                    *node.request.parts,
-                    *(UserPromptPart(content=text) for text in steering),
-                ]
+                run.enqueue(*steering, priority="asap")
         if _stream_step is not None:
             node = await run._run_node_with_hooks(node, _stream_step)
         else:

--- a/src/subagents_pydantic_ai/spec.py
+++ b/src/subagents_pydantic_ai/spec.py
@@ -29,9 +29,31 @@ from __future__ import annotations
 
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from subagents_pydantic_ai.types import SubAgentConfig
+
+UNSERIALISABLE_CONFIG_KEYS = frozenset({"agent", "agent_factory", "toolsets", "retry_on"})
+"""`SubAgentConfig` keys holding live Python objects, which a spec cannot carry."""
+
+_OPTIONAL_FIELDS: tuple[str, ...] = (
+    "model",
+    "can_ask_questions",
+    "max_questions",
+    "preferred_mode",
+    "typical_complexity",
+    "typically_needs_context",
+    "context_files",
+    "agent_kwargs",
+    "max_retries",
+    "retry_initial_delay",
+    "retry_max_delay",
+    "retry_backoff_multiplier",
+    "retry_jitter",
+    "on_failure",
+    "contain_errors",
+)
+"""Spec fields mapped onto `SubAgentConfig` only when explicitly set."""
 
 
 class SubAgentSpec(BaseModel):
@@ -53,7 +75,20 @@ class SubAgentSpec(BaseModel):
         typical_complexity: Typical task complexity for this subagent.
         typically_needs_context: Whether this subagent typically needs user context.
         context_files: List of context file paths to inject into system prompt.
+        agent_kwargs: Extra keyword arguments for the `Agent` constructor.
+        max_retries: Extra attempts after a transient failure.
+        retry_initial_delay: Seconds before the first retry.
+        retry_max_delay: Cap for the backoff delay.
+        retry_backoff_multiplier: Delay growth factor per attempt.
+        retry_jitter: Randomise the backoff delay to avoid a thundering herd.
+        on_failure: Message returned to the parent instead of a `ModelRetry`.
+        contain_errors: Whether a crash is contained as a `ModelRetry`.
         extra: Generic extensibility dict for consumer libraries.
+
+    The `SubAgentConfig` keys that cannot survive a round trip through YAML --
+    `agent`, `agent_factory`, `toolsets`, and `retry_on`, all of which hold live
+    Python objects -- have no field here. `tests/test_spec.py` fails if a new
+    serialisable key is added to the config without being mirrored.
     """
 
     name: str
@@ -66,13 +101,40 @@ class SubAgentSpec(BaseModel):
     typical_complexity: Literal["simple", "moderate", "complex"] | None = None
     typically_needs_context: bool | None = None
     context_files: list[str] | None = None
+    agent_kwargs: dict[str, Any] | None = None
+    max_retries: int | None = Field(default=None, ge=0)
+    retry_initial_delay: float | None = Field(default=None, ge=0.0)
+    retry_max_delay: float | None = Field(default=None, ge=0.0)
+    retry_backoff_multiplier: float | None = Field(default=None, ge=1.0)
+    retry_jitter: bool | None = None
+    on_failure: str | None = None
+    contain_errors: bool | None = None
     extra: dict[str, Any] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def _check_retry_bounds(self) -> SubAgentSpec:
+        """Reject a backoff whose cap is below its starting delay.
+
+        The runtime takes `min(base, max_delay)`, so an inverted pair silently
+        pins every retry to the cap instead of backing off.
+        """
+        if (
+            self.retry_initial_delay is not None
+            and self.retry_max_delay is not None
+            and self.retry_max_delay < self.retry_initial_delay
+        ):
+            raise ValueError(
+                f"retry_max_delay ({self.retry_max_delay}) must be >= "
+                f"retry_initial_delay ({self.retry_initial_delay})"
+            )
+        return self
 
     def to_config(self) -> SubAgentConfig:
         """Convert to a SubAgentConfig TypedDict.
 
-        Only includes fields that have been explicitly set (non-None values),
-        except for `extra` which is included when non-empty.
+        Only fields that were explicitly set (non-`None`) are included, so a
+        subagent inherits the library defaults for everything the spec left out.
+        `extra` is included when non-empty.
 
         Returns:
             A SubAgentConfig dict suitable for `create_subagent_toolset()`.
@@ -83,20 +145,10 @@ class SubAgentSpec(BaseModel):
             instructions=self.instructions,
         )
 
-        if self.model is not None:
-            config["model"] = self.model
-        if self.can_ask_questions is not None:
-            config["can_ask_questions"] = self.can_ask_questions
-        if self.max_questions is not None:
-            config["max_questions"] = self.max_questions
-        if self.preferred_mode is not None:
-            config["preferred_mode"] = self.preferred_mode
-        if self.typical_complexity is not None:
-            config["typical_complexity"] = self.typical_complexity
-        if self.typically_needs_context is not None:
-            config["typically_needs_context"] = self.typically_needs_context
-        if self.context_files is not None:
-            config["context_files"] = self.context_files
+        for field_name in _OPTIONAL_FIELDS:
+            value = getattr(self, field_name)
+            if value is not None:
+                config[field_name] = value  # type: ignore[literal-required]
         if self.extra:
             config["extra"] = self.extra
 
@@ -105,6 +157,10 @@ class SubAgentSpec(BaseModel):
     @classmethod
     def from_config(cls, config: SubAgentConfig) -> SubAgentSpec:
         """Create a SubAgentSpec from a SubAgentConfig dict.
+
+        Keys holding live Python objects (`agent`, `agent_factory`, `toolsets`,
+        `retry_on`) are dropped: they cannot be serialised, and carrying them
+        would make a spec that does not round-trip.
 
         Args:
             config: A SubAgentConfig TypedDict.
@@ -118,21 +174,14 @@ class SubAgentSpec(BaseModel):
             "instructions": config.get("instructions", ""),
         }
 
-        # Map optional fields, converting Model objects to str for model field
+        # A `Model` instance cannot be serialised; its string form is the best
+        # available approximation.
         model_val = config.get("model")
         if model_val is not None:
             data["model"] = str(model_val)
 
-        for field_name in (
-            "can_ask_questions",
-            "max_questions",
-            "preferred_mode",
-            "typical_complexity",
-            "typically_needs_context",
-            "context_files",
-            "extra",
-        ):
-            if field_name in config:
+        for field_name in (*_OPTIONAL_FIELDS, "extra"):
+            if field_name != "model" and field_name in config:
                 data[field_name] = config.get(field_name)
 
         return cls(**data)

--- a/src/subagents_pydantic_ai/toolset.py
+++ b/src/subagents_pydantic_ai/toolset.py
@@ -584,6 +584,53 @@ class SubAgentToolset(FunctionToolset[Any]):
         """Cancel every background task started by `run_id` and await its cleanup."""
         await self.task_manager.cancel_all(run_id)
 
+    def answer_task(self, task_id: str, answer: str) -> bool:
+        """Answer a background task blocked in `ask_parent`, from Python.
+
+        The programmatic half of the `answer_subagent` tool, for an application
+        that drives delegation itself rather than letting a model call the tools.
+        Unlike the tool, it performs no run scoping: the caller already knows which
+        task it owns.
+
+        Args:
+            task_id: The task waiting for an answer.
+            answer: The answer to deliver.
+
+        Returns:
+            Whether a waiting `ask_parent` call was resolved. `False` means the
+            task was not waiting -- it may have finished, or never asked.
+        """
+        return self.task_manager.resolve_answer(task_id, answer)
+
+    async def steer_task(self, task_id: str, message: str) -> bool:
+        """Steer a running background task, from Python.
+
+        The programmatic half of the `send_message_to_subagent` tool. The message
+        is folded into the subagent's next model request, so it adapts without
+        losing partial progress.
+
+        Args:
+            task_id: The running task to steer.
+            message: The steering instruction.
+
+        Returns:
+            Whether the message was queued. `False` means the task is not running,
+            so there is no next model request to deliver into.
+        """
+        agent_id = f"subagent-{task_id}"
+        if not self.task_manager.message_bus.is_registered(agent_id):
+            return False
+        await self.task_manager.message_bus.send(
+            AgentMessage(
+                type=MessageType.TASK_UPDATE,
+                sender="parent",
+                receiver=agent_id,
+                payload={"message": message},
+                task_id=task_id,
+            )
+        )
+        return True
+
     # -- delegation ------------------------------------------------------------
 
     async def _execute(
@@ -967,7 +1014,7 @@ class SubAgentToolset(FunctionToolset[Any]):
         if handle.status != TaskStatus.WAITING_FOR_ANSWER:
             return f"Error: Task '{task_id}' is not waiting for an answer (status: {handle.status})"
 
-        if self.task_manager.resolve_answer(task_id, answer):
+        if self.answer_task(task_id, answer):
             return f"Answer sent to task '{task_id}'"
 
         return "Error: Could not send answer - subagent is no longer waiting"
@@ -993,23 +1040,13 @@ class SubAgentToolset(FunctionToolset[Any]):
         if handle is None:
             return f"Error: Task '{task_id}' not found"
 
-        agent_id = f"subagent-{task_id}"
-        if not self.task_manager.message_bus.is_registered(agent_id):
+        if not await self.steer_task(task_id, message):
             return (
                 f"Error: Task '{task_id}' is not accepting messages "
                 f"(status: {handle.status}). Steering only works for running "
                 "async tasks."
             )
 
-        await self.task_manager.message_bus.send(
-            AgentMessage(
-                type=MessageType.TASK_UPDATE,
-                sender="parent",
-                receiver=agent_id,
-                payload={"message": message},
-                task_id=task_id,
-            )
-        )
         return (
             f"Message delivered to task '{task_id}'; "
             "it will be applied on the subagent's next step."

--- a/src/subagents_pydantic_ai/toolset.py
+++ b/src/subagents_pydantic_ai/toolset.py
@@ -1,25 +1,39 @@
-"""Main subagent toolset with dual-mode execution support.
+"""The subagent toolset: delegate tasks to child agents, synchronously or in the background.
 
-This module provides the core toolset for delegating tasks to subagents.
-It supports both synchronous (blocking) and asynchronous (background)
-execution modes, with automatic mode selection based on task characteristics.
+`SubAgentToolset` is a `FunctionToolset` subclass that owns the delegation tools and
+the state behind them -- the task manager, the chat-trace store, and the dynamic
+agent registry. `create_subagent_toolset` builds one and is the entry point most
+applications use.
+
+The heavy lifting lives in sibling modules: `_execution` runs a delegation,
+`_observability` captures its telemetry, `_chat_trace` stores conversations a
+`chat_trace_id` can resume, and `_state` carries the channel `ask_parent` uses to
+reach the parent.
 """
 
 from __future__ import annotations
 
 import asyncio
-import logging
 import uuid
 from collections import OrderedDict
-from collections.abc import Callable
-from datetime import datetime
-from decimal import Decimal
 from typing import Any, Literal
 
 from pydantic_ai import Agent, RunContext, UsageLimits
 from pydantic_ai.models import Model
-from pydantic_ai.toolsets import FunctionToolset
+from pydantic_ai.toolsets import AbstractToolset, FunctionToolset
 
+from subagents_pydantic_ai._chat_trace import ChatTraceKey, ChatTraceStore
+from subagents_pydantic_ai._execution import DEFAULT_ASK_TIMEOUT_SECONDS, drain_steering_messages
+from subagents_pydantic_ai._execution import _run_async as _run_async
+from subagents_pydantic_ai._execution import _run_sync as _run_sync
+from subagents_pydantic_ai._observability import (
+    capture_message_history,
+    capture_result_observability,
+    model_responses,
+    result_traceparent,
+    serialize_output,
+)
+from subagents_pydantic_ai._state import current_subagent_state
 from subagents_pydantic_ai.dynamic_agent import (
     AgentFactory,
     CapabilityFactory,
@@ -38,11 +52,9 @@ from subagents_pydantic_ai.prompts import (
     SUBAGENT_SYSTEM_PROMPT,
     TASK_TOOL_DESCRIPTION,
     WAIT_TASKS_DESCRIPTION,
-    get_task_instructions_prompt,
 )
 from subagents_pydantic_ai.protocols import SubAgentDepsProtocol
 from subagents_pydantic_ai.registry import DynamicAgentRegistry
-from subagents_pydantic_ai.retry import RetryConfig, run_with_retry
 from subagents_pydantic_ai.types import (
     AgentMessage,
     AskUserCallback,
@@ -58,137 +70,34 @@ from subagents_pydantic_ai.types import (
     ToolsetFactory,
     UsageLimitsFactory,
     decide_execution_mode,
+    utcnow,
 )
 
-logger = logging.getLogger(__name__)
+# Aliases under the historical private names. The implementations moved into
+# `_execution` and `_observability`, but `_run_sync`, `_run_async`, and the capture
+# helpers are imported from this module by the test suite, and `_compile_subagent`
+# by pydantic-deep's team toolset.
+_capture_message_history = capture_message_history
+_capture_result_observability = capture_result_observability
+_drain_steering_messages = drain_steering_messages
+_get_result_traceparent = result_traceparent
+_iter_model_responses = model_responses
+_serialize_output = serialize_output
 
+_VALID_DELEGATION_CONFIGURATIONS = frozenset(
+    {"default", "persisted", "persisted_and_oneshot", "oneshot_only"}
+)
 
-def _serialize_output(output: Any) -> str:
-    """Serialize subagent output preserving structure for Pydantic models.
-
-    For Pydantic models (BaseModel), returns JSON via `model_dump_json()`.
-    For dataclasses with `__dataclass_fields__`, returns JSON via `json.dumps`.
-    For everything else, returns `str(output)`.
-    """
-    if hasattr(output, "model_dump_json"):
-        return output.model_dump_json()  # type: ignore[no-any-return]
-    if hasattr(output, "__dataclass_fields__"):
-        import dataclasses
-        import json
-
-        return json.dumps(dataclasses.asdict(output), default=str)
-    return str(output)
-
-
-def _capture_message_history(
-    result: Any,
-    on_message_history: Callable[[list[Any]], None] | None,
-) -> None:
-    """Capture a successful run's message history for a chat trace.
-
-    Best-effort, like `_capture_observability_best_effort`: a raising
-    `all_messages()` (or save callback) must never flip a successful run to
-    `FAILED`. On failure the previous saved history (if any) is kept, so a
-    continued trace resumes from the last successfully saved point.
-    """
-    if on_message_history is None:
-        return
-
-    try:
-        all_messages = getattr(result, "all_messages", None)
-        if all_messages is None:
-            return
-
-        messages: Any = all_messages()
-        if messages:
-            on_message_history(list(messages))
-    except Exception as e:
-        logger.warning("Failed to capture subagent message history: %s", e)
-
-
-def _get_result_traceparent(result: Any) -> str | None:
-    traceparent = getattr(result, "_traceparent", None)
-    if traceparent is None:
-        return None
-
-    value = traceparent(required=False)
-    return value if isinstance(value, str) and value else None
-
-
-def _iter_model_responses(result: Any) -> list[Any]:
-    responses: list[Any] = []
-    for message in result.all_messages():
-        if getattr(message, "kind", None) == "response":
-            responses.append(message)
-
-    try:
-        response = result.response
-    except (AttributeError, ValueError):
-        response = None
-    if response is not None and all(response is not item for item in responses):
-        responses.append(response)
-    return responses
-
-
-def _capture_result_observability(handle: TaskHandle, result: Any) -> None:
-    """Copy result observability onto a task handle."""
-    handle.usage = result.usage
-    handle.message_history = result.all_messages_json().decode()
-    handle.run_id = result.run_id
-    handle.conversation_id = result.conversation_id
-
-    handle.traceparent = _get_result_traceparent(result)
-    if handle.traceparent is not None:
-        parts = handle.traceparent.split("-")
-        if len(parts) >= 4:
-            handle.trace_id = parts[1]
-            handle.span_id = parts[2]
-
-    responses = _iter_model_responses(result)
-    if responses:
-        # Final response wins for per-run model/provider metadata: it is the
-        # model response that produced the returned output. In a multi-model
-        # run, earlier responses' model/provider metadata is not captured on
-        # the handle; aggregate fields such as `cost` and `tool_call_counts`
-        # are summed across all responses.
-        response = responses[-1]
-        handle.model_name = response.model_name
-        handle.provider_name = response.provider_name
-        handle.provider_url = response.provider_url
-        handle.provider_response_id = response.provider_response_id
-        handle.provider_details = response.provider_details
-        handle.finish_reason = response.finish_reason
-
-    total_cost = Decimal("0")
-    has_cost = False
-    tool_call_counts: dict[str, int] = {}
-    for response in responses:
-        if response.model_name:
-            try:
-                total_cost += response.cost().total_price
-                has_cost = True
-            except (AssertionError, LookupError):
-                pass
-
-        for tool_call in response.tool_calls:
-            tool_call_counts[tool_call.tool_name] = tool_call_counts.get(tool_call.tool_name, 0) + 1
-
-    handle.cost = total_cost if has_cost else None
-    handle.tool_call_counts = tool_call_counts
-
-
-def _capture_observability_best_effort(handle: TaskHandle, result: Any) -> None:
-    """Capture telemetry without ever failing the task.
-
-    Observability is best-effort (matching pydantic-ai's own instrumentation,
-    which warns on cost/serialization failures rather than propagating). A run
-    that succeeded must not be reported as ``FAILED`` just because a result
-    object lacks an attribute or telemetry collection raised.
-    """
-    try:
-        _capture_result_observability(handle, result)
-    except Exception as e:
-        logger.warning("Failed to capture subagent observability: %s", e)
+_DEFAULT_TOOL_DESCRIPTIONS: dict[str, str] = {
+    "check_task": CHECK_TASK_DESCRIPTION,
+    "answer_subagent": ANSWER_SUBAGENT_DESCRIPTION,
+    "send_message_to_subagent": SEND_MESSAGE_TO_SUBAGENT_DESCRIPTION,
+    "list_active_tasks": LIST_ACTIVE_TASKS_DESCRIPTION,
+    "wait_tasks": WAIT_TASKS_DESCRIPTION,
+    "soft_cancel_task": SOFT_CANCEL_TASK_DESCRIPTION,
+    "hard_cancel_task": HARD_CANCEL_TASK_DESCRIPTION,
+}
+"""Model-facing description per background-task tool, overridable via `descriptions`."""
 
 
 def _format_chat_trace_result(output: str, chat_trace_id: str) -> str:
@@ -223,32 +132,17 @@ def _preview_result(result: str, task_id: str, max_chars: int | None) -> str:
     )
 
 
-async def _drain_steering_messages(message_bus: InMemoryMessageBus, agent_id: str) -> list[str]:
-    """Drain pending parent -> child steering messages for a running subagent.
+def _already_finished(task_id: str, handle: TaskHandle | None) -> str:
+    """Explain that a cancel arrived after the task was already over.
 
-    Pulls everything currently queued for ``agent_id`` and returns the text of
-    each ``TASK_UPDATE`` (the message type emitted by ``send_message_to_subagent``).
-    Other message types on the queue (e.g. an unused ``CANCEL_REQUEST`` — soft
-    cancel runs off the cancel event, not the bus) are ignored, as are empty
-    payloads.
-
-    Args:
-        message_bus: The bus the running subagent is registered on.
-        agent_id: The subagent's bus id (``subagent-{task_id}``).
-
-    Returns:
-        Steering instructions in delivery order (may be empty).
+    Reporting "not found" for a task whose result the orchestrator can still read
+    with `check_task` invites it to conclude the work was lost.
     """
-    pending = await message_bus.get_messages(agent_id, timeout=0)
-    steering: list[str] = []
-    for msg in pending:
-        if msg.type != MessageType.TASK_UPDATE:
-            continue
-        payload = msg.payload
-        text = payload.get("message") if isinstance(payload, dict) else payload
-        if text:
-            steering.append(str(text))
-    return steering
+    status = handle.status.value if handle is not None else "unknown"
+    return (
+        f"Task '{task_id}' is no longer running (status: {status}); nothing to cancel. "
+        f"Call check_task('{task_id}') for its outcome."
+    )
 
 
 def _create_general_purpose_config() -> SubAgentConfig:
@@ -279,43 +173,32 @@ def _compile_subagent(
     Returns:
         CompiledSubAgent with agent instance.
     """
-    # 1. Pre-built agent — use as-is
-    if config.get("agent") is not None:
+    prebuilt = config.get("agent")
+    if prebuilt is not None:
         return CompiledSubAgent(
             name=config["name"],
             description=config["description"],
-            agent=config["agent"],
+            agent=prebuilt,
             config=config,
         )
 
-    # 2. Agent factory — call it
     factory = config.get("agent_factory")
     if factory is not None:
-        custom_agent = factory(config)
         return CompiledSubAgent(
             name=config["name"],
             description=config["description"],
-            agent=custom_agent,
+            agent=factory(config),
             config=config,
         )
 
-    # 3. Default: create plain pydantic-ai Agent
-    model = config.get("model", default_model)
-
-    toolsets: list[Any] = []
-    ask_parent_toolset = _create_ask_parent_toolset()
-    toolsets.append(ask_parent_toolset)
-
-    if config.get("toolsets"):
-        toolsets.extend(config["toolsets"])
-
-    agent_kwargs = config.get("agent_kwargs", {})
+    toolsets: list[AbstractToolset[Any]] = [_create_ask_parent_toolset()]
+    toolsets.extend(config.get("toolsets") or [])
 
     agent: Agent[Any, str] = Agent(
-        model,
+        config.get("model", default_model),
         system_prompt=config["instructions"],
         toolsets=toolsets,
-        **agent_kwargs,
+        **config.get("agent_kwargs", {}),
     )
 
     return CompiledSubAgent(
@@ -327,7 +210,7 @@ def _compile_subagent(
 
 
 def _create_ask_parent_toolset() -> FunctionToolset[Any]:
-    """Create toolset with ask_parent tool for subagent communication."""
+    """Create a toolset with the `ask_parent` tool a subagent uses to reach its parent."""
     toolset: FunctionToolset[Any] = FunctionToolset(id="ask_parent")
 
     @toolset.tool
@@ -344,41 +227,41 @@ def _create_ask_parent_toolset() -> FunctionToolset[Any]:
         Returns:
             The parent's answer.
         """
-        # Try _subagent_state on deps (async mode)
-        state = getattr(ctx.deps, "_subagent_state", None)
-        if state is not None:
-            ask_callback = state.get("ask_callback")
-            if ask_callback:
-                result: str = await ask_callback(question)
-                return result
+        # The state bound for this delegation, or -- for a caller that injects it
+        # onto its own deps -- the legacy attribute. The library only ever binds
+        # the context variable; writing to the caller's deps object breaks a
+        # `frozen=True` or `slots=True` deps class.
+        state = current_subagent_state()
+        legacy = getattr(ctx.deps, "_subagent_state", None)
+        ask_callback = state.ask_callback if state is not None else None
+        task_manager = state.task_manager if state is not None else None
+        task_id = state.task_id if state is not None else None
+        timeout = state.ask_timeout_seconds if state is not None else DEFAULT_ASK_TIMEOUT_SECONDS
+        if isinstance(legacy, dict):
+            ask_callback = ask_callback or legacy.get("ask_callback")
+            task_manager = task_manager or legacy.get("task_manager")
+            task_id = task_id or legacy.get("task_id")
 
-            _task_manager = state.get("task_manager")
-            _task_id = state.get("task_id")
+        if ask_callback is not None:
+            return str(await ask_callback(question))
 
-            if _task_manager and _task_id:
-                handle = _task_manager.get_handle(_task_id)
-                if handle is not None:
-                    # Set question on handle so parent can see it via check_task
-                    handle.pending_question = question
-                    handle.status = TaskStatus.WAITING_FOR_ANSWER
+        if task_manager is not None and task_id is not None:
+            handle = task_manager.get_handle(task_id)
+            if handle is not None:
+                handle.pending_question = question
+                handle.status = TaskStatus.WAITING_FOR_ANSWER
 
-                    # Create a future and wait for answer_subagent to resolve it
-                    loop = asyncio.get_running_loop()
-                    answer_future: asyncio.Future[str] = loop.create_future()
-                    _task_manager.set_answer_future(_task_id, answer_future)
+                answer_future: asyncio.Future[str] = asyncio.get_running_loop().create_future()
+                task_manager.set_answer_future(task_id, answer_future)
+                try:
+                    return await asyncio.wait_for(answer_future, timeout=timeout)
+                except asyncio.TimeoutError:
+                    return "Error: Parent did not respond in time"
+                finally:
+                    handle.status = TaskStatus.RUNNING
+                    handle.pending_question = None
+                    task_manager.clear_answer_future(task_id)
 
-                    try:
-                        answer = await asyncio.wait_for(answer_future, timeout=300.0)
-                        handle.status = TaskStatus.RUNNING
-                        handle.pending_question = None
-                        return answer
-                    except asyncio.TimeoutError:
-                        handle.status = TaskStatus.RUNNING
-                        handle.pending_question = None
-                        _task_manager.clear_answer_future(_task_id)
-                        return "Error: Parent did not respond in time"
-
-        # Fallback: use deps.ask_user callback (plan toolset compatibility)
         ask_user = getattr(ctx.deps, "ask_user", None)
         if ask_user:
             return str(await ask_user(question, []))
@@ -392,7 +275,864 @@ def _create_ask_parent_toolset() -> FunctionToolset[Any]:
     return toolset
 
 
-def create_subagent_toolset(  # noqa: C901
+class SubAgentToolset(FunctionToolset[Any]):
+    """Delegation tools plus the state that backs them.
+
+    Registers `task` (and, depending on `delegation_configuration`, `create_agent`
+    and `delegate`) alongside the background-task lifecycle tools `check_task`,
+    `answer_subagent`, `send_message_to_subagent`, `list_active_tasks`,
+    `wait_tasks`, `soft_cancel_task`, and `hard_cancel_task`.
+
+    `task_manager` and `get_total_usage()` are the supported observability surface;
+    they were previously attributes attached to a plain `FunctionToolset` after
+    construction.
+
+    Example:
+        ```python
+        from pydantic_ai import Agent
+        from subagents_pydantic_ai import SubAgentConfig, SubAgentToolset
+
+        toolset = SubAgentToolset(
+            subagents=[
+                SubAgentConfig(
+                    name="researcher",
+                    description="Researches topics",
+                    instructions="You are a research assistant.",
+                ),
+            ],
+        )
+        agent = Agent("openai:gpt-4.1", toolsets=[toolset])
+        ```
+    """
+
+    def __init__(
+        self,
+        subagents: list[SubAgentConfig] | None = None,
+        default_model: str | Model = "openai:gpt-4.1",
+        toolsets_factory: ToolsetFactory | None = None,
+        include_general_purpose: bool = True,
+        max_nesting_depth: int = 0,
+        id: str | None = None,
+        registry: DynamicAgentRegistry | None = None,
+        descriptions: dict[str, str] | None = None,
+        ask_user: AskUserCallback | None = None,
+        usage_limits: UsageLimits | UsageLimitsFactory | None = None,
+        delegation_configuration: DelegationConfiguration = "default",
+        allowed_models: list[str] | None = None,
+        capabilities_map: dict[str, CapabilityFactory] | None = None,
+        default_agent_factory: AgentFactory | None = None,
+        max_agents: int = 10,
+        max_chat_traces: int = 100,
+        max_task_handles: int = 500,
+        max_result_chars: int | None = 2000,
+        ask_timeout_seconds: float = DEFAULT_ASK_TIMEOUT_SECONDS,
+        contain_errors: bool = True,
+    ) -> None:
+        """Build the toolset. See `create_subagent_toolset` for the argument reference."""
+        super().__init__(id=id or "subagents")
+        self._validate(
+            delegation_configuration=delegation_configuration,
+            subagents=subagents,
+            registry=registry,
+            allowed_models=allowed_models,
+            capabilities_map=capabilities_map,
+            default_agent_factory=default_agent_factory,
+            max_result_chars=max_result_chars,
+            ask_timeout_seconds=ask_timeout_seconds,
+        )
+
+        self._descriptions = descriptions or {}
+        self._default_model = default_model
+        self._toolsets_factory = toolsets_factory
+        self._max_nesting_depth = max_nesting_depth
+        self._ask_user = ask_user
+        self._usage_limits = usage_limits
+        self._allowed_models = allowed_models
+        self._capabilities_map = capabilities_map
+        self._default_agent_factory = default_agent_factory
+        self._max_task_handles = max_task_handles
+        self._max_result_chars = max_result_chars
+        self._ask_timeout_seconds = ask_timeout_seconds
+        self._contain_errors = contain_errors
+
+        self.registry = (
+            registry if registry is not None else DynamicAgentRegistry(max_agents=max_agents)
+        )
+        self.task_manager = TaskManager(message_bus=InMemoryMessageBus())
+        self._chat_traces = ChatTraceStore(max_traces=max_chat_traces)
+        # Usage from evicted handles, so `get_total_usage` survives eviction.
+        self._evicted_usage = {"input_tokens": 0, "output_tokens": 0, "requests": 0}
+
+        configs: list[SubAgentConfig] = list(subagents) if subagents else []
+        if include_general_purpose and self._expose_task:
+            configs.append(_create_general_purpose_config())
+        self._compiled: dict[str, CompiledSubAgent] = {
+            config["name"]: _compile_subagent(config, default_model) for config in configs
+        }
+
+        self._register_tools()
+
+    # -- construction ----------------------------------------------------------
+
+    def _validate(
+        self,
+        *,
+        delegation_configuration: DelegationConfiguration,
+        subagents: list[SubAgentConfig] | None,
+        registry: DynamicAgentRegistry | None,
+        allowed_models: list[str] | None,
+        capabilities_map: dict[str, CapabilityFactory] | None,
+        default_agent_factory: AgentFactory | None,
+        max_result_chars: int | None,
+        ask_timeout_seconds: float,
+    ) -> None:
+        """Reject a configuration that contradicts itself.
+
+        Hiding a tool also hides everything only that tool reads, so configuration
+        for a hidden tool can never take effect. Raising here surfaces the
+        contradiction where the caller can still see their own arguments; dropping
+        it silently only shows up later as a subagent that ignores an allow-list,
+        or a capability the model is never offered.
+        """
+        if delegation_configuration not in _VALID_DELEGATION_CONFIGURATIONS:
+            valid = ", ".join(sorted(_VALID_DELEGATION_CONFIGURATIONS))
+            raise ValueError(
+                f"Invalid delegation_configuration '{delegation_configuration}'. "
+                f"Expected one of: {valid}"
+            )
+
+        self._delegation_configuration = delegation_configuration
+
+        if not self._expose_task:
+            if subagents:
+                raise ValueError(
+                    f"delegation_configuration={delegation_configuration!r} cannot be combined "
+                    "with non-empty subagents; configured subagents would be unreachable "
+                    "without the task tool. Omit subagents, or use a mode that exposes task."
+                )
+            if registry is not None:
+                raise ValueError(
+                    f"delegation_configuration={delegation_configuration!r} cannot be combined "
+                    "with a registry; registry-backed agents are only reachable through the "
+                    "task tool. Omit registry, or use a mode that exposes task."
+                )
+
+        if not self._expose_create_agent and not self._expose_delegate:
+            unreachable = [
+                name
+                for name, value in (
+                    ("allowed_models", allowed_models),
+                    ("capabilities_map", capabilities_map),
+                    ("default_agent_factory", default_agent_factory),
+                )
+                if value is not None
+            ]
+            if unreachable:
+                raise ValueError(
+                    f"delegation_configuration={delegation_configuration!r} exposes no "
+                    f"dynamic-agent tool, so {', '.join(unreachable)} would be ignored. "
+                    "Use 'persisted', 'persisted_and_oneshot', or 'oneshot_only'."
+                )
+
+        if max_result_chars is not None and max_result_chars < 0:
+            raise ValueError(f"max_result_chars must be >= 0 or None, got {max_result_chars}")
+
+        if ask_timeout_seconds <= 0:
+            raise ValueError(f"ask_timeout_seconds must be > 0, got {ask_timeout_seconds}")
+
+    @property
+    def _expose_create_agent(self) -> bool:
+        return self._delegation_configuration in {"persisted", "persisted_and_oneshot"}
+
+    @property
+    def _expose_task(self) -> bool:
+        return self._delegation_configuration != "oneshot_only"
+
+    @property
+    def _expose_delegate(self) -> bool:
+        return self._delegation_configuration in {"persisted_and_oneshot", "oneshot_only"}
+
+    def _register_tools(self) -> None:
+        models_desc = (
+            f"Allowed models: {', '.join(self._allowed_models)}"
+            if self._allowed_models
+            else "Any model is allowed"
+        )
+        caps_desc = (
+            f"Available capabilities: {', '.join(self._capabilities_map.keys())}"
+            if self._capabilities_map
+            else "No predefined capabilities available"
+        )
+        dynamic_agent_desc = (
+            f"{models_desc}\n{caps_desc}\n\n"
+            f"Default model when none is given: {self._default_model}."
+        )
+
+        if self._expose_create_agent:
+            self.add_function(
+                self.create_agent,
+                description=self._descriptions.get(
+                    "create_agent",
+                    "Create a reusable specialized agent at runtime. The agent is stored "
+                    "in the registry and can be used repeatedly with the task tool.\n\n"
+                    f"{dynamic_agent_desc}",
+                ),
+            )
+
+        if self._expose_task:
+            subagent_list = "\n".join(
+                f"- {name}: {compiled.description}" for name, compiled in self._compiled.items()
+            )
+            self.add_function(
+                self.task,
+                description=self._descriptions.get(
+                    "task",
+                    TASK_TOOL_DESCRIPTION.rstrip()
+                    + f"\n\nAvailable subagent types:\n{subagent_list}",
+                ),
+            )
+
+        if self._expose_delegate:
+            self.add_function(
+                self.delegate,
+                description=self._descriptions.get(
+                    "delegate",
+                    DELEGATE_TOOL_DESCRIPTION.rstrip() + f"\n\n{dynamic_agent_desc}",
+                ),
+            )
+
+        self.add_function(self.check_task, description=self._describe("check_task"))
+        self.add_function(self.answer_subagent, description=self._describe("answer_subagent"))
+        self.add_function(
+            self.send_message_to_subagent,
+            description=self._describe("send_message_to_subagent"),
+        )
+        self.add_function(self.list_active_tasks, description=self._describe("list_active_tasks"))
+        self.add_function(self.wait_tasks, description=self._describe("wait_tasks"))
+        self.add_function(self.soft_cancel_task, description=self._describe("soft_cancel_task"))
+        self.add_function(self.hard_cancel_task, description=self._describe("hard_cancel_task"))
+
+    def _describe(self, tool_name: str) -> str:
+        """The caller's description override for a tool, or the built-in default."""
+        return self._descriptions.get(tool_name, _DEFAULT_TOOL_DESCRIPTIONS[tool_name])
+
+    # -- observability surface -------------------------------------------------
+
+    @property
+    def message_history_store(self) -> OrderedDict[ChatTraceKey, list[Any]]:
+        """Stored chat-trace histories, keyed by `(subagent_name, chat_trace_id)`."""
+        return self._chat_traces.history
+
+    def get_total_usage(self) -> dict[str, int]:
+        """Aggregate token usage across every subagent task this toolset has run.
+
+        Usage from evicted handles is folded in, so the totals do not shrink when
+        `max_task_handles` evicts old tasks.
+
+        Returns:
+            `input_tokens`, `output_tokens`, `total_tokens`, and `requests`.
+        """
+        totals = {
+            "input_tokens": self._evicted_usage["input_tokens"],
+            "output_tokens": self._evicted_usage["output_tokens"],
+            "total_tokens": 0,
+            "requests": self._evicted_usage["requests"],
+        }
+        for handle in self.task_manager.list_handles():
+            if handle.usage is not None:
+                totals["input_tokens"] += getattr(handle.usage, "input_tokens", 0)
+                totals["output_tokens"] += getattr(handle.usage, "output_tokens", 0)
+                totals["requests"] += getattr(handle.usage, "requests", 0)
+        totals["total_tokens"] = totals["input_tokens"] + totals["output_tokens"]
+        return totals
+
+    def _evict_finished_handles(self) -> None:
+        """Drop the oldest finished handles past `max_task_handles`.
+
+        Running and waiting tasks are never evicted. Evicted usage is accumulated
+        so `get_total_usage` stays correct.
+        """
+        finished = [h for h in self.task_manager.handles.values() if h.is_finished]
+        overflow = len(finished) - self._max_task_handles
+        if overflow <= 0:
+            return
+        finished.sort(key=lambda h: h.completed_at or h.created_at)
+        for old in finished[:overflow]:
+            if old.usage is not None:
+                self._evicted_usage["input_tokens"] += getattr(old.usage, "input_tokens", 0)
+                self._evicted_usage["output_tokens"] += getattr(old.usage, "output_tokens", 0)
+                self._evicted_usage["requests"] += getattr(old.usage, "requests", 0)
+            self.task_manager.handles.pop(old.task_id, None)
+
+    def _handle_for(self, ctx: RunContext[SubAgentDepsProtocol], task_id: str) -> TaskHandle | None:
+        """The handle for `task_id`, if this run is allowed to see it.
+
+        One toolset instance is typically built per agent and shared by every run
+        that agent serves, so an unfiltered lookup would let one run inspect,
+        answer, or cancel another run's task. Handles created without a
+        `parent_run_id` (constructed directly, or by an older caller) stay visible
+        to everyone.
+        """
+        handle = self.task_manager.get_handle(task_id)
+        if handle is None:
+            return None
+        if handle.parent_run_id is not None and handle.parent_run_id != ctx.run_id:
+            return None
+        return handle
+
+    async def cancel_run_tasks(self, run_id: str | None) -> None:
+        """Cancel every background task started by `run_id` and await its cleanup."""
+        await self.task_manager.cancel_all(run_id)
+
+    # -- delegation ------------------------------------------------------------
+
+    async def _execute(
+        self,
+        ctx: RunContext[SubAgentDepsProtocol],
+        subagent: CompiledSubAgent,
+        description: str,
+        *,
+        mode: ExecutionMode,
+        priority: TaskPriority,
+        complexity: Literal["simple", "moderate", "complex"] | None,
+        requires_user_context: bool,
+        may_need_clarification: bool,
+        inject_ask_parent: bool = False,
+        task_id: str | None = None,
+        chat_trace_id: str | None = None,
+        persist_chat_trace: bool = True,
+    ) -> str:
+        """Run a compiled subagent with chat-trace and observability support.
+
+        `persist_chat_trace` must be `False` for a subagent the orchestrator cannot
+        address by name later -- a one-shot specialist. A chat trace is only worth
+        handing out if `task` can resolve the subagent it belongs to, and storing
+        one costs a slot in the chat-trace LRU that a continuable conversation
+        would otherwise keep.
+        """
+        config = subagent.config
+        agent = subagent.agent
+        if agent is None:
+            return f"Error: Subagent '{subagent.name}' is not properly initialized"
+
+        resolved_usage_limits = (
+            self._usage_limits(ctx, config) if callable(self._usage_limits) else self._usage_limits
+        )
+
+        subagent_deps = ctx.deps.clone_for_subagent(self._max_nesting_depth - 1)
+
+        runtime_toolsets: list[AbstractToolset[Any]] | None = None
+        if self._toolsets_factory or inject_ask_parent:
+            runtime_toolsets = []
+            if inject_ask_parent and config.get("can_ask_questions", True):
+                runtime_toolsets.append(_create_ask_parent_toolset())
+            if self._toolsets_factory:
+                runtime_toolsets.extend(self._toolsets_factory(subagent_deps))
+
+        actual_task_id = task_id or uuid.uuid4().hex[:8]
+        effective_chat_trace_id = chat_trace_id or uuid.uuid4().hex
+        trace_key: ChatTraceKey = (config["name"], effective_chat_trace_id)
+
+        if self._chat_traces.is_active(trace_key):
+            return (
+                f"Error: chat trace '{effective_chat_trace_id}' already has a running "
+                f"task on subagent '{config['name']}'. Wait for it to finish "
+                f"(check_task/wait_tasks) before continuing this conversation."
+            )
+        message_history = self._chat_traces.history_for(trace_key)
+        if message_history is None and chat_trace_id is not None:
+            return (
+                f"Error: no saved conversation for chat_trace_id '{chat_trace_id}' "
+                f"with subagent '{config['name']}' (unknown, evicted, or its first "
+                f"run failed). Omit chat_trace_id to start a new conversation."
+            )
+
+        def save_message_history(messages: list[Any]) -> None:
+            self._chat_traces.save(trace_key, messages)
+
+        # A one-shot run exposes no chat trace, so it neither stores history nor
+        # reports an id: `handle.chat_trace_id` stays `None` and check_task /
+        # wait_tasks skip it for the same reason the returned text does.
+        on_history = save_message_history if persist_chat_trace else None
+        reported_chat_trace_id = effective_chat_trace_id if persist_chat_trace else None
+
+        self._evict_finished_handles()
+
+        if mode == "auto":
+            characteristics = TaskCharacteristics(
+                estimated_complexity=complexity or config.get("typical_complexity", "moderate"),
+                requires_user_context=requires_user_context
+                or config.get("typically_needs_context", False),
+                may_need_clarification=may_need_clarification,
+            )
+            resolved_mode = decide_execution_mode(characteristics, config)
+        else:
+            resolved_mode = mode
+
+        if resolved_mode == "sync":
+            handle = TaskHandle(
+                task_id=actual_task_id,
+                subagent_name=config["name"],
+                description=description,
+                status=TaskStatus.RUNNING,
+                priority=priority,
+                chat_trace_id=reported_chat_trace_id,
+                started_at=utcnow(),
+                parent_run_id=ctx.run_id,
+            )
+            self.task_manager.handles[actual_task_id] = handle
+            self._chat_traces.mark_active(trace_key)
+            try:
+                result = await _run_sync(
+                    agent=agent,
+                    config=config,
+                    description=description,
+                    deps=subagent_deps,
+                    task_id=actual_task_id,
+                    extra_toolsets=runtime_toolsets,
+                    ask_user=self._ask_user,
+                    usage_limits=resolved_usage_limits,
+                    handle=handle,
+                    message_history=message_history,
+                    on_message_history=on_history,
+                    ask_timeout_seconds=self._ask_timeout_seconds,
+                    contain_errors=config.get("contain_errors", self._contain_errors),
+                )
+            finally:
+                self._chat_traces.release(trace_key)
+            # Don't advertise continuation when the run failed and nothing was ever
+            # saved for this trace -- the chat_trace_id would resume nothing.
+            if persist_chat_trace and (
+                handle.status != TaskStatus.FAILED or trace_key in self._chat_traces
+            ):
+                return _format_chat_trace_result(result, effective_chat_trace_id)
+            return result
+
+        self._chat_traces.mark_active(trace_key)
+        try:
+            return await _run_async(
+                agent=agent,
+                config=config,
+                description=description,
+                deps=subagent_deps,
+                task_id=actual_task_id,
+                task_manager=self.task_manager,
+                message_bus=self.task_manager.message_bus,
+                extra_toolsets=runtime_toolsets,
+                priority=priority,
+                usage_limits=resolved_usage_limits,
+                chat_trace_id=reported_chat_trace_id,
+                message_history=message_history,
+                on_message_history=on_history,
+                on_run_finished=lambda: self._chat_traces.release(trace_key),
+                ask_timeout_seconds=self._ask_timeout_seconds,
+                parent_run_id=ctx.run_id,
+            )
+        except BaseException:
+            # `_run_async` failed before the background task took ownership.
+            self._chat_traces.release(trace_key)
+            raise
+
+    # -- tools -----------------------------------------------------------------
+
+    async def create_agent(
+        self,
+        ctx: RunContext[SubAgentDepsProtocol],
+        name: str,
+        description: str,
+        instructions: str,
+        model: str | None = None,
+        capabilities: list[str] | None = None,
+        can_ask_questions: bool = True,
+    ) -> str:
+        """Create and register a reusable specialized agent.
+
+        Args:
+            ctx: The run context.
+            name: Unique name for the agent (letters, numbers, hyphens only).
+            description: Brief description of what the agent does.
+            instructions: System prompt for the agent.
+            model: Model to use. Defaults to the toolset's default model.
+            capabilities: Capability names to enable for the agent.
+            can_ask_questions: Whether the agent can ask the parent questions.
+        """
+        if self.registry.exists(name):
+            return f"Error: Agent '{name}' already exists"
+
+        actual_model = model or self._default_model
+        result = build_dynamic_agent(
+            ctx,
+            name=name,
+            description=description,
+            instructions=instructions,
+            model=actual_model,
+            can_ask_questions=can_ask_questions,
+            capabilities=capabilities,
+            allowed_models=self._allowed_models,
+            toolsets_factory=None,
+            capabilities_map=self._capabilities_map,
+            default_agent_factory=self._default_agent_factory,
+        )
+        if isinstance(result, str):
+            return result
+        agent, config = result
+
+        try:
+            self.registry.register(config, agent)
+        except ValueError as exc:
+            return f"Error: {exc}"
+
+        caps_info = f"\nCapabilities: {', '.join(capabilities)}" if capabilities else ""
+        return (
+            f"Agent '{name}' created successfully.\n"
+            f"Model: {actual_model}\n"
+            f"Description: {description}{caps_info}\n"
+            f"Use task(description, '{name}') to delegate tasks."
+        )
+
+    async def task(
+        self,
+        ctx: RunContext[SubAgentDepsProtocol],
+        description: str,
+        subagent_type: str,
+        mode: ExecutionMode = "sync",
+        priority: TaskPriority = TaskPriority.NORMAL,
+        complexity: Literal["simple", "moderate", "complex"] | None = None,
+        requires_user_context: bool = False,
+        may_need_clarification: bool = False,
+        chat_trace_id: str | None = None,
+    ) -> str:
+        """Delegate a task to a specialized subagent.
+
+        Args:
+            ctx: The run context with dependencies.
+            description: Detailed description of the task to perform.
+            subagent_type: Name of the subagent to use.
+            mode: Execution mode - "sync" (blocking), "async" (background), or "auto".
+            priority: Task priority level (for async tasks).
+            complexity: Override complexity estimate ("simple", "moderate", "complex").
+            requires_user_context: Whether task needs ongoing user interaction.
+            may_need_clarification: Whether task might need clarifying questions.
+            chat_trace_id: Optional explicit chat trace ID. When omitted, a new subagent
+                conversation is created. When provided, this subagent resumes from
+                the previous successful task with the same chat trace.
+        """
+        if subagent_type in self._compiled:
+            subagent = self._compiled[subagent_type]
+            inject_ask_parent = False
+        elif (registry_subagent := self.registry.get_compiled(subagent_type)) is not None:
+            subagent = registry_subagent
+            inject_ask_parent = True
+        else:
+            available = ", ".join([*self._compiled, *self.registry.list_agents()])
+            return f"Error: Unknown subagent '{subagent_type}'. Available: {available}"
+
+        return await self._execute(
+            ctx,
+            subagent,
+            description,
+            mode=mode,
+            priority=priority,
+            complexity=complexity,
+            requires_user_context=requires_user_context,
+            may_need_clarification=may_need_clarification,
+            inject_ask_parent=inject_ask_parent,
+            chat_trace_id=chat_trace_id,
+        )
+
+    async def delegate(
+        self,
+        ctx: RunContext[SubAgentDepsProtocol],
+        description: str,
+        instructions: str,
+        model: str | None = None,
+        capabilities: list[str] | None = None,
+        can_ask_questions: bool = True,
+        mode: ExecutionMode = "sync",
+        priority: TaskPriority = TaskPriority.NORMAL,
+        complexity: Literal["simple", "moderate", "complex"] | None = None,
+        requires_user_context: bool = False,
+        may_need_clarification: bool = False,
+    ) -> str:
+        """Create an ephemeral specialist and delegate a task to it in one call.
+
+        Args:
+            ctx: The run context.
+            description: The task for the specialist to execute.
+            instructions: The specialist's system prompt.
+            model: Model to use. Defaults to the toolset's default model.
+            capabilities: Capability names to attach to the specialist.
+            can_ask_questions: Whether the specialist can ask the parent questions.
+            mode: Execution mode - "sync" (blocking), "async" (background), or "auto".
+            priority: Task priority level (for async tasks).
+            complexity: Override complexity estimate.
+            requires_user_context: Whether task needs ongoing user interaction.
+            may_need_clarification: Whether task might need clarifying questions.
+        """
+        task_id = uuid.uuid4().hex[:8]
+        agent_name = f"oneshot-{task_id}"
+        agent_description = description[:120] or "Ephemeral specialist"
+
+        result = build_dynamic_agent(
+            ctx,
+            name=agent_name,
+            description=agent_description,
+            instructions=instructions,
+            model=model or self._default_model,
+            can_ask_questions=can_ask_questions,
+            capabilities=capabilities,
+            allowed_models=self._allowed_models,
+            toolsets_factory=None,
+            capabilities_map=self._capabilities_map,
+            default_agent_factory=self._default_agent_factory,
+        )
+        if isinstance(result, str):
+            return result
+        agent, config = result
+
+        return await self._execute(
+            ctx,
+            CompiledSubAgent(
+                name=agent_name,
+                description=agent_description,
+                agent=agent,
+                config=config,
+            ),
+            description,
+            mode=mode,
+            priority=priority,
+            complexity=complexity,
+            requires_user_context=requires_user_context,
+            may_need_clarification=may_need_clarification,
+            inject_ask_parent=True,
+            task_id=task_id,
+            persist_chat_trace=False,
+        )
+
+    async def check_task(
+        self,
+        ctx: RunContext[SubAgentDepsProtocol],
+        task_id: str,
+    ) -> str:
+        """Check the status of a background task.
+
+        Args:
+            ctx: The run context.
+            task_id: The task ID returned when the task was started.
+        """
+        handle = self._handle_for(ctx, task_id)
+        if handle is None:
+            return f"Error: Task '{task_id}' not found"
+
+        status_info = [
+            f"Task: {task_id}",
+            f"Subagent: {handle.subagent_name}",
+            f"Status: {handle.status}",
+            f"Description: {handle.description}",
+        ]
+        # Only advertise continuation for completed tasks -- a failed or still
+        # running task has not saved this run's history yet (matches wait_tasks).
+        if handle.chat_trace_id is not None and handle.status == TaskStatus.COMPLETED:
+            status_info.append(f"Chat Trace ID: {handle.chat_trace_id}")
+
+        if handle.status == TaskStatus.COMPLETED:
+            status_info.append(f"Result: {handle.result}")
+        elif handle.status == TaskStatus.FAILED:
+            status_info.append(f"Error: {handle.error}")
+        elif handle.status == TaskStatus.WAITING_FOR_ANSWER:
+            status_info.append(f"Question: {handle.pending_question}")
+        elif handle.started_at:
+            elapsed = (utcnow() - handle.started_at).total_seconds()
+            status_info.append(f"Running for: {elapsed:.1f}s")
+
+        return "\n".join(status_info)
+
+    async def answer_subagent(
+        self,
+        ctx: RunContext[SubAgentDepsProtocol],
+        task_id: str,
+        answer: str,
+    ) -> str:
+        """Answer a question from a subagent.
+
+        Args:
+            ctx: The run context.
+            task_id: The task ID of the waiting subagent.
+            answer: Your answer to the subagent's question.
+        """
+        handle = self._handle_for(ctx, task_id)
+        if handle is None:
+            return f"Error: Task '{task_id}' not found"
+
+        if handle.status != TaskStatus.WAITING_FOR_ANSWER:
+            return f"Error: Task '{task_id}' is not waiting for an answer (status: {handle.status})"
+
+        if self.task_manager.resolve_answer(task_id, answer):
+            return f"Answer sent to task '{task_id}'"
+
+        return "Error: Could not send answer - subagent is no longer waiting"
+
+    async def send_message_to_subagent(
+        self,
+        ctx: RunContext[SubAgentDepsProtocol],
+        task_id: str,
+        message: str,
+    ) -> str:
+        """Steer a running async subagent with an unprompted message.
+
+        The message is queued for the subagent and folded into its next model
+        request as an extra user instruction, so it adapts without losing
+        partial progress. Works only while the task is still running.
+
+        Args:
+            ctx: The run context.
+            task_id: The task ID of the running async subagent.
+            message: The steering instruction to deliver.
+        """
+        handle = self._handle_for(ctx, task_id)
+        if handle is None:
+            return f"Error: Task '{task_id}' not found"
+
+        agent_id = f"subagent-{task_id}"
+        if not self.task_manager.message_bus.is_registered(agent_id):
+            return (
+                f"Error: Task '{task_id}' is not accepting messages "
+                f"(status: {handle.status}). Steering only works for running "
+                "async tasks."
+            )
+
+        await self.task_manager.message_bus.send(
+            AgentMessage(
+                type=MessageType.TASK_UPDATE,
+                sender="parent",
+                receiver=agent_id,
+                payload={"message": message},
+                task_id=task_id,
+            )
+        )
+        return (
+            f"Message delivered to task '{task_id}'; "
+            "it will be applied on the subagent's next step."
+        )
+
+    async def list_active_tasks(self, ctx: RunContext[SubAgentDepsProtocol]) -> str:
+        """List all active background tasks."""
+        lines = ["Active background tasks:"]
+        for tid in self.task_manager.list_active_tasks():
+            handle = self._handle_for(ctx, tid)
+            if handle is None:
+                continue
+            desc = handle.description[:50]
+            lines.append(f"- {tid}: {handle.subagent_name} ({handle.status}) - {desc}...")
+
+        if len(lines) == 1:
+            return "No active background tasks."
+        return "\n".join(lines)
+
+    async def wait_tasks(
+        self,
+        ctx: RunContext[SubAgentDepsProtocol],
+        task_ids: list[str],
+        timeout: float = 300.0,
+        mode: Literal["all", "any"] = "all",
+    ) -> str:
+        """Wait for multiple background tasks to complete.
+
+        Args:
+            ctx: The run context.
+            task_ids: List of task IDs to wait for.
+            timeout: Maximum seconds to wait (default 300s / 5 minutes).
+            mode: `"all"` (default) waits for every task to finish.
+                `"any"` returns as soon as one task reaches a terminal
+                state (completed, failed, or cancelled), so the orchestrator
+                can react to the first finisher without stalling on the
+                slowest one.
+        """
+        pending = [
+            task
+            for tid in task_ids
+            if (task := self.task_manager.tasks.get(tid)) is not None and not task.done()
+        ]
+        if pending:
+            # Both modes route through `asyncio.wait`. Unlike
+            # `asyncio.wait_for(asyncio.gather(...))`, `asyncio.wait` does *not*
+            # cascade cancellation to its constituent tasks -- neither on timeout
+            # nor when its caller is cancelled (e.g. pydantic-ai's `_call_tools`
+            # sibling-cancel hitting this tool call). Workers keep owning their
+            # lifecycle, which is what an orchestrator expects.
+            return_when = asyncio.FIRST_COMPLETED if mode == "any" else asyncio.ALL_COMPLETED
+            await asyncio.wait(pending, timeout=timeout, return_when=return_when)
+
+        lines: list[str] = []
+        finished_count = 0
+        for tid in task_ids:
+            handle = self._handle_for(ctx, tid)
+            if handle is None:
+                lines.append(f"- {tid}: not found")
+                continue
+            if handle.status == TaskStatus.COMPLETED:
+                finished_count += 1
+                preview = _preview_result(handle.result or "", tid, self._max_result_chars)
+                trace_line = (
+                    f"Chat Trace ID: {handle.chat_trace_id}\n"
+                    if handle.chat_trace_id is not None
+                    else ""
+                )
+                lines.append(f"- {tid} ({handle.subagent_name}): COMPLETED\n{trace_line}{preview}")
+            elif handle.is_finished:
+                finished_count += 1
+                lines.append(
+                    f"- {tid} ({handle.subagent_name}): "
+                    f"{handle.status.value.upper()} - {handle.error}"
+                )
+            else:
+                lines.append(f"- {tid} ({handle.subagent_name}): {handle.status}")
+
+        total = len(task_ids)
+        header_parts = [f"mode={mode}", f"{finished_count}/{total} finished"]
+        if total - finished_count > 0:
+            header_parts.append(f"{total - finished_count} still running")
+
+        return f"Task results ({', '.join(header_parts)}):\n" + "\n\n".join(lines)
+
+    async def soft_cancel_task(
+        self,
+        ctx: RunContext[SubAgentDepsProtocol],
+        task_id: str,
+    ) -> str:
+        """Request cooperative cancellation of a background task.
+
+        Args:
+            ctx: The run context.
+            task_id: The task to cancel.
+        """
+        handle = self._handle_for(ctx, task_id)
+        if handle is None and task_id not in self.task_manager.tasks:
+            return f"Error: Task '{task_id}' not found"
+        if await self.task_manager.soft_cancel(task_id):
+            return f"Cancellation requested for task '{task_id}'"
+        return _already_finished(task_id, handle)
+
+    async def hard_cancel_task(
+        self,
+        ctx: RunContext[SubAgentDepsProtocol],
+        task_id: str,
+    ) -> str:
+        """Immediately cancel a background task.
+
+        Args:
+            ctx: The run context.
+            task_id: The task to cancel.
+        """
+        handle = self._handle_for(ctx, task_id)
+        if handle is None and task_id not in self.task_manager.tasks:
+            return f"Error: Task '{task_id}' not found"
+        if await self.task_manager.hard_cancel(task_id):
+            return f"Task '{task_id}' has been cancelled"
+        return _already_finished(task_id, handle)
+
+
+def create_subagent_toolset(
     subagents: list[SubAgentConfig] | None = None,
     default_model: str | Model = "openai:gpt-4.1",
     toolsets_factory: ToolsetFactory | None = None,
@@ -411,16 +1151,20 @@ def create_subagent_toolset(  # noqa: C901
     max_chat_traces: int = 100,
     max_task_handles: int = 500,
     max_result_chars: int | None = 2000,
-) -> FunctionToolset[Any]:
+    ask_timeout_seconds: float = DEFAULT_ASK_TIMEOUT_SECONDS,
+    contain_errors: bool = True,
+) -> SubAgentToolset:
     """Create a toolset for delegating tasks to subagents.
 
     This is the main entry point for using the subagent system. It creates
     a toolset with tools for:
+
     - `create_agent`: Create a reusable, registry-backed specialist (opt-in modes)
     - `task`: Delegate a task to a configured or registry-backed specialist
     - `delegate`: Create and run an ephemeral specialist in one call (opt-in modes)
     - `check_task`: Check status of an async task
     - `answer_subagent`: Answer a question from a subagent
+    - `send_message_to_subagent`: Steer a running async subagent
     - `list_active_tasks`: List all running background tasks
     - `wait_tasks`: Wait for one or more background tasks to finish
     - `soft_cancel_task`: Request cooperative cancellation
@@ -434,12 +1178,15 @@ def create_subagent_toolset(  # noqa: C901
             Called with deps when running a task.
         include_general_purpose: Whether to include the default general-purpose
             subagent. Set to False if you want only specialized subagents.
-        max_nesting_depth: Maximum depth for nested subagents. 0 means
-            subagents cannot spawn their own subagents.
+        max_nesting_depth: Depth budget handed to `deps.clone_for_subagent`, which
+            decides what a subagent may delegate to in turn. This library does not
+            itself stop a nested toolset from delegating further -- the gate is
+            whatever `toolsets_factory` gives the child.
         id: Optional toolset ID. Defaults to "subagents".
         descriptions: Optional mapping of tool name to custom description.
-            Keys are tool names (task, check_task, answer_subagent,
-            list_active_tasks, wait_tasks, soft_cancel_task, hard_cancel_task).
+            Keys are tool names (`task`, `create_agent`, `delegate`, `check_task`,
+            `answer_subagent`, `send_message_to_subagent`, `list_active_tasks`,
+            `wait_tasks`, `soft_cancel_task`, `hard_cancel_task`).
             When provided, the custom description replaces the built-in default.
         ask_user: Optional callback invoked when a subagent calls `ask_parent`
             in sync mode. Receives the question and must return the answer.
@@ -492,15 +1239,23 @@ def create_subagent_toolset(  # noqa: C901
             flooding the orchestrator's context. Results past the budget are cut
             and carry an explicit marker pointing at `check_task`, which always
             returns the full text. Pass `None` to never truncate.
+        ask_timeout_seconds: How long `ask_parent` waits for the parent's answer
+            before telling the subagent to proceed on its own.
+        contain_errors: Whether an unexpected subagent crash is converted into a
+            `ModelRetry` for the parent instead of aborting the parent run.
+            Defaults to `True`. Control-flow signals (`CallDeferred`,
+            `ApprovalRequired`, `Skip*`), `UserError`, and a shared
+            `UsageLimitExceeded` always propagate. Individual subagents can
+            override this with `SubAgentConfig["contain_errors"]`.
 
     Returns:
-        FunctionToolset configured with subagent management tools.
+        A `SubAgentToolset` configured with the subagent management tools.
 
     Raises:
-        ValueError: If `max_result_chars` is negative; if
-            `delegation_configuration` is invalid; if `"oneshot_only"` is
-            combined with `subagents` or a `registry`, neither of which is
-            reachable without `task`; or if a mode exposing neither
+        ValueError: If `max_result_chars` is negative; if `ask_timeout_seconds` is
+            not positive; if `delegation_configuration` is invalid; if
+            `"oneshot_only"` is combined with `subagents` or a `registry`, neither
+            of which is reachable without `task`; or if a mode exposing neither
             `create_agent` nor `delegate` is given `allowed_models`,
             `capabilities_map`, or `default_agent_factory`, which only those
             tools consult.
@@ -526,944 +1281,25 @@ def create_subagent_toolset(  # noqa: C901
         agent = Agent("openai:gpt-4.1", toolsets=[toolset])
         ```
     """
-    valid_configurations = {
-        "default",
-        "persisted",
-        "persisted_and_oneshot",
-        "oneshot_only",
-    }
-    if delegation_configuration not in valid_configurations:
-        valid = ", ".join(sorted(valid_configurations))
-        raise ValueError(
-            f"Invalid delegation_configuration '{delegation_configuration}'. "
-            f"Expected one of: {valid}"
-        )
-
-    expose_create_agent = delegation_configuration in {
-        "persisted",
-        "persisted_and_oneshot",
-    }
-    expose_task = delegation_configuration != "oneshot_only"
-    expose_delegate = delegation_configuration in {
-        "persisted_and_oneshot",
-        "oneshot_only",
-    }
-
-    # Hiding a tool also hides everything only that tool reads, so configuration
-    # for a hidden tool can never take effect. Rejecting it here surfaces the
-    # contradiction at construction, where the caller can still see their own
-    # arguments; dropping it silently only shows up as a subagent that ignores
-    # an allow-list, or a capability the model is never offered.
-    if not expose_task:
-        if subagents:
-            raise ValueError(
-                f"delegation_configuration={delegation_configuration!r} cannot be combined "
-                "with non-empty subagents; configured subagents would be unreachable "
-                "without the task tool. Omit subagents, or use a mode that exposes task."
-            )
-        if registry is not None:
-            raise ValueError(
-                f"delegation_configuration={delegation_configuration!r} cannot be combined "
-                "with a registry; registry-backed agents are only reachable through the "
-                "task tool. Omit registry, or use a mode that exposes task."
-            )
-
-    if not expose_create_agent and not expose_delegate:
-        unreachable = [
-            name
-            for name, value in (
-                ("allowed_models", allowed_models),
-                ("capabilities_map", capabilities_map),
-                ("default_agent_factory", default_agent_factory),
-            )
-            if value is not None
-        ]
-        if unreachable:
-            raise ValueError(
-                f"delegation_configuration={delegation_configuration!r} exposes no "
-                f"dynamic-agent tool, so {', '.join(unreachable)} would be ignored. "
-                "Use 'persisted', 'persisted_and_oneshot', or 'oneshot_only'."
-            )
-
-    if max_result_chars is not None and max_result_chars < 0:
-        raise ValueError(f"max_result_chars must be >= 0 or None, got {max_result_chars}")
-
-    _descs = descriptions or {}
-    active_registry = (
-        registry if registry is not None else DynamicAgentRegistry(max_agents=max_agents)
+    return SubAgentToolset(
+        subagents=subagents,
+        default_model=default_model,
+        toolsets_factory=toolsets_factory,
+        include_general_purpose=include_general_purpose,
+        max_nesting_depth=max_nesting_depth,
+        id=id,
+        registry=registry,
+        descriptions=descriptions,
+        ask_user=ask_user,
+        usage_limits=usage_limits,
+        delegation_configuration=delegation_configuration,
+        allowed_models=allowed_models,
+        capabilities_map=capabilities_map,
+        default_agent_factory=default_agent_factory,
+        max_agents=max_agents,
+        max_chat_traces=max_chat_traces,
+        max_task_handles=max_task_handles,
+        max_result_chars=max_result_chars,
+        ask_timeout_seconds=ask_timeout_seconds,
+        contain_errors=contain_errors,
     )
-
-    # Build subagent configs
-    configs: list[SubAgentConfig] = list(subagents) if subagents else []
-    if include_general_purpose and expose_task:
-        configs.append(_create_general_purpose_config())
-
-    # Compile subagents
-    compiled: dict[str, CompiledSubAgent] = {}
-    for config in configs:
-        compiled[config["name"]] = _compile_subagent(config, default_model)
-
-    # Create shared state
-    message_bus = InMemoryMessageBus()
-    task_manager = TaskManager(message_bus=message_bus)
-    # LRU-ordered: oldest chat trace first, evicted past max_chat_traces.
-    message_history_store: OrderedDict[tuple[str, str], list[Any]] = OrderedDict()
-    # Chat traces with a task currently running — a trace must finish before
-    # it can be continued, otherwise concurrent saves would lose history.
-    active_chat_traces: set[tuple[str, str]] = set()
-    # Usage from evicted handles, so get_total_usage() survives eviction.
-    evicted_usage: dict[str, int] = {"input_tokens": 0, "output_tokens": 0, "requests": 0}
-
-    _terminal_statuses = (TaskStatus.COMPLETED, TaskStatus.FAILED, TaskStatus.CANCELLED)
-
-    def evict_finished_handles() -> None:
-        """Drop the oldest finished handles past `max_task_handles`.
-
-        Running/waiting tasks are never evicted. Evicted usage is accumulated
-        into `evicted_usage` so `get_total_usage()` stays correct.
-        """
-        finished = [h for h in task_manager.handles.values() if h.status in _terminal_statuses]
-        overflow = len(finished) - max_task_handles
-        if overflow <= 0:
-            return
-        finished.sort(key=lambda h: h.completed_at or h.created_at)
-        for old in finished[:overflow]:
-            if old.usage is not None:
-                evicted_usage["input_tokens"] += getattr(old.usage, "input_tokens", 0)
-                evicted_usage["output_tokens"] += getattr(old.usage, "output_tokens", 0)
-                evicted_usage["requests"] += getattr(old.usage, "requests", 0)
-            task_manager.handles.pop(old.task_id, None)
-
-    # Build dynamic task description with available subagents
-    subagent_list = "\n".join(f"- {name}: {c.description}" for name, c in compiled.items())
-    task_description = _descs.get(
-        "task",
-        TASK_TOOL_DESCRIPTION.rstrip() + f"\n\nAvailable subagent types:\n{subagent_list}",
-    )
-
-    toolset: FunctionToolset[Any] = FunctionToolset(id=id or "subagents")
-
-    models_desc = (
-        f"Allowed models: {', '.join(allowed_models)}" if allowed_models else "Any model is allowed"
-    )
-    caps_desc = (
-        f"Available capabilities: {', '.join(capabilities_map.keys())}"
-        if capabilities_map
-        else "No predefined capabilities available"
-    )
-
-    async def execute_compiled_subagent(
-        ctx: RunContext[SubAgentDepsProtocol],
-        subagent: CompiledSubAgent,
-        description: str,
-        *,
-        mode: ExecutionMode,
-        priority: TaskPriority,
-        complexity: Literal["simple", "moderate", "complex"] | None,
-        requires_user_context: bool,
-        may_need_clarification: bool,
-        inject_ask_parent: bool = False,
-        task_id: str | None = None,
-        chat_trace_id: str | None = None,
-        persist_chat_trace: bool = True,
-    ) -> str:
-        """Run a compiled subagent with chat-trace and observability support.
-
-        `persist_chat_trace` must be `False` for a subagent the orchestrator
-        cannot address by name later — a one-shot specialist. A chat trace is
-        only worth handing out if `task` can resolve the subagent it belongs to,
-        and storing one costs a slot in the `max_chat_traces` LRU that a
-        continuable conversation would otherwise keep.
-        """
-        config = subagent.config
-        agent = subagent.agent
-
-        if agent is None:
-            return f"Error: Subagent '{subagent.name}' is not properly initialized"
-
-        resolved_usage_limits = (
-            usage_limits(ctx, config) if callable(usage_limits) else usage_limits
-        )
-
-        parent_deps = ctx.deps
-        subagent_deps = parent_deps.clone_for_subagent(max_nesting_depth - 1)
-
-        runtime_toolsets: list[Any] | None = None
-        if toolsets_factory or inject_ask_parent:
-            runtime_toolsets = []
-            if inject_ask_parent and config.get("can_ask_questions", True):
-                runtime_toolsets.append(_create_ask_parent_toolset())
-            if toolsets_factory:
-                runtime_toolsets.extend(toolsets_factory(subagent_deps))
-
-        actual_task_id = task_id or str(uuid.uuid4())[:8]
-
-        effective_chat_trace_id = chat_trace_id or uuid.uuid4().hex
-        chat_trace_key = (config["name"], effective_chat_trace_id)
-        if chat_trace_key in active_chat_traces:
-            return (
-                f"Error: chat trace '{effective_chat_trace_id}' already has a running "
-                f"task on subagent '{config['name']}'. Wait for it to finish "
-                f"(check_task/wait_tasks) before continuing this conversation."
-            )
-        message_history = message_history_store.get(chat_trace_key)
-        if message_history is not None:
-            message_history_store.move_to_end(chat_trace_key)
-        elif chat_trace_id is not None:
-            return (
-                f"Error: no saved conversation for chat_trace_id '{chat_trace_id}' "
-                f"with subagent '{config['name']}' (unknown, evicted, or its first "
-                f"run failed). Omit chat_trace_id to start a new conversation."
-            )
-
-        def save_message_history(messages: list[Any]) -> None:
-            message_history_store[chat_trace_key] = messages
-            message_history_store.move_to_end(chat_trace_key)
-            while len(message_history_store) > max_chat_traces:
-                message_history_store.popitem(last=False)
-
-        # A one-shot run exposes no chat trace, so it neither stores history nor
-        # reports an id: `handle.chat_trace_id` stays `None` and check_task /
-        # wait_tasks skip it for the same reason the returned text does.
-        on_history = save_message_history if persist_chat_trace else None
-        reported_chat_trace_id = effective_chat_trace_id if persist_chat_trace else None
-
-        evict_finished_handles()
-
-        if mode == "auto":
-            characteristics = TaskCharacteristics(
-                estimated_complexity=complexity or config.get("typical_complexity", "moderate"),
-                requires_user_context=requires_user_context
-                or config.get("typically_needs_context", False),
-                may_need_clarification=may_need_clarification,
-            )
-            resolved_mode = decide_execution_mode(characteristics, config)
-        else:
-            resolved_mode = mode
-
-        if resolved_mode == "sync":
-            handle = TaskHandle(
-                task_id=actual_task_id,
-                subagent_name=config["name"],
-                description=description,
-                status=TaskStatus.RUNNING,
-                priority=priority,
-                chat_trace_id=reported_chat_trace_id,
-                started_at=datetime.now(),
-            )
-            task_manager.handles[actual_task_id] = handle
-            active_chat_traces.add(chat_trace_key)
-            try:
-                result = await _run_sync(
-                    agent=agent,
-                    config=config,
-                    description=description,
-                    deps=subagent_deps,
-                    task_id=actual_task_id,
-                    extra_toolsets=runtime_toolsets,
-                    ask_user=ask_user,
-                    usage_limits=resolved_usage_limits,
-                    handle=handle,
-                    message_history=message_history,
-                    on_message_history=on_history,
-                )
-            finally:
-                active_chat_traces.discard(chat_trace_key)
-            if persist_chat_trace and (
-                handle.status != TaskStatus.FAILED or chat_trace_key in message_history_store
-            ):
-                return _format_chat_trace_result(result, effective_chat_trace_id)
-            return result
-
-        active_chat_traces.add(chat_trace_key)
-        try:
-            return await _run_async(
-                agent=agent,
-                config=config,
-                description=description,
-                deps=subagent_deps,
-                task_id=actual_task_id,
-                task_manager=task_manager,
-                message_bus=message_bus,
-                extra_toolsets=runtime_toolsets,
-                priority=priority,
-                usage_limits=resolved_usage_limits,
-                chat_trace_id=reported_chat_trace_id,
-                message_history=message_history,
-                on_message_history=on_history,
-                on_run_finished=lambda: active_chat_traces.discard(chat_trace_key),
-            )
-        except BaseException:
-            active_chat_traces.discard(chat_trace_key)
-            raise
-
-    if expose_create_agent:
-        create_agent_description = _descs.get(
-            "create_agent",
-            "Create a reusable specialized agent at runtime. The agent is stored "
-            "in the registry and can be used repeatedly with the task tool.\n\n"
-            f"{models_desc}\n{caps_desc}\n\n"
-            f"Default model when none is given: {default_model}.",
-        )
-
-        @toolset.tool(description=create_agent_description)
-        async def create_agent(
-            ctx: RunContext[SubAgentDepsProtocol],
-            name: str,
-            description: str,
-            instructions: str,
-            model: str | None = None,
-            capabilities: list[str] | None = None,
-            can_ask_questions: bool = True,
-        ) -> str:
-            """Create and register a reusable specialized agent."""
-            if active_registry.exists(name):
-                return f"Error: Agent '{name}' already exists"
-
-            actual_model = model or default_model
-            result = build_dynamic_agent(
-                ctx,
-                name=name,
-                description=description,
-                instructions=instructions,
-                model=actual_model,
-                can_ask_questions=can_ask_questions,
-                capabilities=capabilities,
-                allowed_models=allowed_models,
-                toolsets_factory=None,
-                capabilities_map=capabilities_map,
-                default_agent_factory=default_agent_factory,
-            )
-            if isinstance(result, str):
-                return result
-            agent, config = result
-
-            try:
-                active_registry.register(config, agent)
-            except ValueError as exc:
-                return f"Error: {exc}"
-
-            caps_info = f"\nCapabilities: {', '.join(capabilities)}" if capabilities else ""
-            return (
-                f"Agent '{name}' created successfully.\n"
-                f"Model: {actual_model}\n"
-                f"Description: {description}{caps_info}\n"
-                f"Use task(description, '{name}') to delegate tasks."
-            )
-
-    if expose_task:
-
-        @toolset.tool(description=task_description)
-        async def task(
-            ctx: RunContext[SubAgentDepsProtocol],
-            description: str,
-            subagent_type: str,
-            mode: ExecutionMode = "sync",
-            priority: TaskPriority = TaskPriority.NORMAL,
-            complexity: Literal["simple", "moderate", "complex"] | None = None,
-            requires_user_context: bool = False,
-            may_need_clarification: bool = False,
-            chat_trace_id: str | None = None,
-        ) -> str:
-            """Delegate a task to a specialized subagent.
-
-            Args:
-                ctx: The run context with dependencies.
-                description: Detailed description of the task to perform.
-                subagent_type: Name of the subagent to use.
-                mode: Execution mode - "sync" (blocking), "async" (background), or "auto".
-                priority: Task priority level (for async tasks).
-                complexity: Override complexity estimate ("simple", "moderate", "complex").
-                requires_user_context: Whether task needs ongoing user interaction.
-                may_need_clarification: Whether task might need clarifying questions.
-                chat_trace_id: Optional explicit chat trace ID. When omitted, a new subagent
-                    conversation is created. When provided, this subagent resumes from
-                    the previous successful task with the same chat trace.
-            """
-            if subagent_type in compiled:
-                subagent = compiled[subagent_type]
-                inject_ask_parent = False
-            elif (registry_subagent := active_registry.get_compiled(subagent_type)) is not None:
-                subagent = registry_subagent
-                inject_ask_parent = True
-            else:
-                available_names = list(compiled.keys())
-                available_names.extend(active_registry.list_agents())
-                available = ", ".join(available_names)
-                return f"Error: Unknown subagent '{subagent_type}'. Available: {available}"
-
-            return await execute_compiled_subagent(
-                ctx,
-                subagent,
-                description,
-                mode=mode,
-                priority=priority,
-                complexity=complexity,
-                requires_user_context=requires_user_context,
-                may_need_clarification=may_need_clarification,
-                inject_ask_parent=inject_ask_parent,
-                chat_trace_id=chat_trace_id,
-            )
-
-    if expose_delegate:
-        delegate_description = _descs.get(
-            "delegate",
-            DELEGATE_TOOL_DESCRIPTION.rstrip()
-            + f"\n\n{models_desc}\n{caps_desc}\n\n"
-            + f"Default model when none is given: {default_model}.",
-        )
-
-        @toolset.tool(description=delegate_description)
-        async def delegate(
-            ctx: RunContext[SubAgentDepsProtocol],
-            description: str,
-            instructions: str,
-            model: str | None = None,
-            capabilities: list[str] | None = None,
-            can_ask_questions: bool = True,
-            mode: ExecutionMode = "sync",
-            priority: TaskPriority = TaskPriority.NORMAL,
-            complexity: Literal["simple", "moderate", "complex"] | None = None,
-            requires_user_context: bool = False,
-            may_need_clarification: bool = False,
-        ) -> str:
-            """Create an ephemeral specialist and delegate a task in one call."""
-            task_id = str(uuid.uuid4())[:8]
-            agent_name = f"oneshot-{task_id}"
-            agent_description = description[:120] or "Ephemeral specialist"
-            actual_model = model or default_model
-
-            result = build_dynamic_agent(
-                ctx,
-                name=agent_name,
-                description=agent_description,
-                instructions=instructions,
-                model=actual_model,
-                can_ask_questions=can_ask_questions,
-                capabilities=capabilities,
-                allowed_models=allowed_models,
-                toolsets_factory=None,
-                capabilities_map=capabilities_map,
-                default_agent_factory=default_agent_factory,
-            )
-            if isinstance(result, str):
-                return result
-            agent, config = result
-
-            subagent = CompiledSubAgent(
-                name=agent_name,
-                description=agent_description,
-                agent=agent,
-                config=config,
-            )
-
-            return await execute_compiled_subagent(
-                ctx,
-                subagent,
-                description,
-                mode=mode,
-                priority=priority,
-                complexity=complexity,
-                requires_user_context=requires_user_context,
-                may_need_clarification=may_need_clarification,
-                inject_ask_parent=True,
-                task_id=task_id,
-                persist_chat_trace=False,
-            )
-
-    @toolset.tool(description=_descs.get("check_task", CHECK_TASK_DESCRIPTION))
-    async def check_task(
-        ctx: RunContext[SubAgentDepsProtocol],
-        task_id: str,
-    ) -> str:
-        """Check the status of a background task.
-
-        Args:
-            ctx: The run context.
-            task_id: The task ID returned when the task was started.
-        """
-        handle = task_manager.get_handle(task_id)
-        if handle is None:
-            return f"Error: Task '{task_id}' not found"
-
-        status_info = [
-            f"Task: {task_id}",
-            f"Subagent: {handle.subagent_name}",
-            f"Status: {handle.status}",
-            f"Description: {handle.description}",
-        ]
-        # Only advertise continuation for completed tasks — a failed or still
-        # running task has not saved this run's history yet (matches wait_tasks).
-        if handle.chat_trace_id is not None and handle.status == TaskStatus.COMPLETED:
-            status_info.append(f"Chat Trace ID: {handle.chat_trace_id}")
-
-        if handle.status == TaskStatus.COMPLETED:
-            status_info.append(f"Result: {handle.result}")
-        elif handle.status == TaskStatus.FAILED:
-            status_info.append(f"Error: {handle.error}")
-        elif handle.status == TaskStatus.WAITING_FOR_ANSWER:
-            status_info.append(f"Question: {handle.pending_question}")
-        elif handle.started_at:
-            elapsed = (datetime.now() - handle.started_at).total_seconds()
-            status_info.append(f"Running for: {elapsed:.1f}s")
-
-        return "\n".join(status_info)
-
-    @toolset.tool(description=_descs.get("answer_subagent", ANSWER_SUBAGENT_DESCRIPTION))
-    async def answer_subagent(
-        ctx: RunContext[SubAgentDepsProtocol],
-        task_id: str,
-        answer: str,
-    ) -> str:
-        """Answer a question from a subagent.
-
-        Args:
-            ctx: The run context.
-            task_id: The task ID of the waiting subagent.
-            answer: Your answer to the subagent's question.
-        """
-        handle = task_manager.get_handle(task_id)
-        if handle is None:
-            return f"Error: Task '{task_id}' not found"
-
-        if handle.status != TaskStatus.WAITING_FOR_ANSWER:
-            return f"Error: Task '{task_id}' is not waiting for an answer (status: {handle.status})"
-
-        # Resolve the answer future that ask_parent is waiting on
-        future = task_manager.get_answer_future(task_id)
-        if future is not None and not future.done():
-            future.set_result(answer)
-            return f"Answer sent to task '{task_id}'"
-
-        return "Error: Could not send answer - subagent is no longer waiting"
-
-    @toolset.tool(
-        description=_descs.get("send_message_to_subagent", SEND_MESSAGE_TO_SUBAGENT_DESCRIPTION)
-    )
-    async def send_message_to_subagent(
-        ctx: RunContext[SubAgentDepsProtocol],
-        task_id: str,
-        message: str,
-    ) -> str:
-        """Steer a running async subagent with an unprompted message.
-
-        The message is queued for the subagent and folded into its next model
-        request as an extra user instruction, so it adapts without losing
-        partial progress. Works only while the task is still running.
-
-        Args:
-            ctx: The run context.
-            task_id: The task ID of the running async subagent.
-            message: The steering instruction to deliver.
-        """
-        agent_id = f"subagent-{task_id}"
-        if not message_bus.is_registered(agent_id):
-            handle = task_manager.get_handle(task_id)
-            if handle is None:
-                return f"Error: Task '{task_id}' not found"
-            return (
-                f"Error: Task '{task_id}' is not accepting messages "
-                f"(status: {handle.status}). Steering only works for running "
-                "async tasks."
-            )
-
-        await message_bus.send(
-            AgentMessage(
-                type=MessageType.TASK_UPDATE,
-                sender="parent",
-                receiver=agent_id,
-                payload={"message": message},
-                task_id=task_id,
-            )
-        )
-        return (
-            f"Message delivered to task '{task_id}'; "
-            "it will be applied on the subagent's next step."
-        )
-
-    @toolset.tool(description=_descs.get("list_active_tasks", LIST_ACTIVE_TASKS_DESCRIPTION))
-    async def list_active_tasks(
-        ctx: RunContext[SubAgentDepsProtocol],
-    ) -> str:
-        """List all active background tasks."""
-        active_ids = task_manager.list_active_tasks()
-
-        if not active_ids:
-            return "No active background tasks."
-
-        lines = ["Active background tasks:"]
-        for tid in active_ids:
-            handle = task_manager.get_handle(tid)
-            if handle:  # pragma: no branch
-                desc = handle.description[:50]
-                lines.append(f"- {tid}: {handle.subagent_name} ({handle.status}) - {desc}...")
-
-        return "\n".join(lines)
-
-    @toolset.tool(description=_descs.get("wait_tasks", WAIT_TASKS_DESCRIPTION))
-    async def wait_tasks(
-        ctx: RunContext[SubAgentDepsProtocol],
-        task_ids: list[str],
-        timeout: float = 300.0,
-        mode: Literal["all", "any"] = "all",
-    ) -> str:
-        """Wait for multiple background tasks to complete.
-
-        Args:
-            ctx: The run context.
-            task_ids: List of task IDs to wait for.
-            timeout: Maximum seconds to wait (default 300s / 5 minutes).
-            mode: `"all"` (default) waits for every task to finish.
-                `"any"` returns as soon as one task reaches a terminal
-                state (completed, failed, or cancelled), so the orchestrator
-                can react to the first finisher without stalling on the
-                slowest one.
-        """
-        # Collect asyncio.Task objects for the requested task_ids
-        tasks_to_await: list[tuple[str, asyncio.Task[Any]]] = []
-        for tid in task_ids:
-            t = task_manager.tasks.get(tid)
-            if t is not None and not t.done():
-                tasks_to_await.append((tid, t))
-
-        if tasks_to_await:
-            aws = [t for _, t in tasks_to_await]
-            # Both modes route through `asyncio.wait`. Unlike
-            # `asyncio.wait_for(asyncio.gather(...))`, `asyncio.wait` does
-            # *not* cascade cancellation to its constituent tasks — neither on
-            # timeout nor when its caller is cancelled (e.g. pydantic-ai's
-            # `_call_tools` sibling-cancel hitting this tool call). Workers
-            # keep owning their lifecycle, which is what an orchestrator
-            # expects.
-            return_when = asyncio.FIRST_COMPLETED if mode == "any" else asyncio.ALL_COMPLETED
-            await asyncio.wait(aws, timeout=timeout, return_when=return_when)
-
-        # Collect results
-        lines: list[str] = []
-        finished_count = 0
-        for tid in task_ids:
-            handle = task_manager.get_handle(tid)
-            if handle is None:
-                lines.append(f"- {tid}: not found")
-                continue
-            status = handle.status
-            if status == "completed":
-                finished_count += 1
-                result_preview = _preview_result(handle.result or "", tid, max_result_chars)
-                chat_trace_line = ""
-                if handle.chat_trace_id is not None:
-                    chat_trace_line = f"Chat Trace ID: {handle.chat_trace_id}\n"
-                lines.append(
-                    f"- {tid} ({handle.subagent_name}): COMPLETED\n"
-                    f"{chat_trace_line}{result_preview}"
-                )
-            elif status == "failed":
-                finished_count += 1
-                lines.append(f"- {tid} ({handle.subagent_name}): FAILED - {handle.error}")
-            elif status == "cancelled":
-                finished_count += 1
-                lines.append(f"- {tid} ({handle.subagent_name}): CANCELLED - {handle.error}")
-            else:
-                lines.append(f"- {tid} ({handle.subagent_name}): {status}")
-
-        total = len(task_ids)
-        still_running = total - finished_count
-        header_parts = [f"mode={mode}", f"{finished_count}/{total} finished"]
-        if still_running > 0:
-            header_parts.append(f"{still_running} still running")
-        header = f"Task results ({', '.join(header_parts)}):"
-
-        return header + "\n" + "\n\n".join(lines)
-
-    @toolset.tool(description=_descs.get("soft_cancel_task", SOFT_CANCEL_TASK_DESCRIPTION))
-    async def soft_cancel_task(
-        ctx: RunContext[SubAgentDepsProtocol],
-        task_id: str,
-    ) -> str:
-        """Request cooperative cancellation of a background task.
-
-        Args:
-            ctx: The run context.
-            task_id: The task to cancel.
-        """
-        success = await task_manager.soft_cancel(task_id)
-        if success:
-            return f"Cancellation requested for task '{task_id}'"
-        return f"Error: Task '{task_id}' not found"
-
-    @toolset.tool(description=_descs.get("hard_cancel_task", HARD_CANCEL_TASK_DESCRIPTION))
-    async def hard_cancel_task(
-        ctx: RunContext[SubAgentDepsProtocol],
-        task_id: str,
-    ) -> str:
-        """Immediately cancel a background task.
-
-        Args:
-            ctx: The run context.
-            task_id: The task to cancel.
-        """
-        success = await task_manager.hard_cancel(task_id)
-        if success:
-            return f"Task '{task_id}' has been cancelled"
-        return f"Error: Task '{task_id}' not found"
-
-    # Expose task_manager for external monitoring (e.g., push notifications)
-    toolset.task_manager = task_manager  # type: ignore[attr-defined]
-    toolset.message_history_store = message_history_store  # type: ignore[attr-defined]
-
-    def get_total_usage() -> dict[str, int]:
-        """Get aggregate token usage across all completed subagent tasks.
-
-        Returns dict with `input_tokens`, `output_tokens`, `total_tokens`, `requests`.
-        """
-        totals: dict[str, int] = {
-            "input_tokens": evicted_usage["input_tokens"],
-            "output_tokens": evicted_usage["output_tokens"],
-            "total_tokens": 0,
-            "requests": evicted_usage["requests"],
-        }
-        for handle in task_manager.list_handles():
-            if handle.usage is not None:
-                totals["input_tokens"] += getattr(handle.usage, "input_tokens", 0)
-                totals["output_tokens"] += getattr(handle.usage, "output_tokens", 0)
-                totals["requests"] += getattr(handle.usage, "requests", 0)
-        totals["total_tokens"] = totals["input_tokens"] + totals["output_tokens"]
-        return totals
-
-    toolset.get_total_usage = get_total_usage  # type: ignore[attr-defined]
-
-    return toolset
-
-
-async def _run_sync(
-    agent: Any,
-    config: SubAgentConfig,
-    description: str,
-    deps: Any,
-    task_id: str,
-    extra_toolsets: list[Any] | None = None,
-    ask_user: AskUserCallback | None = None,
-    usage_limits: UsageLimits | None = None,
-    handle: TaskHandle | None = None,
-    message_history: list[Any] | None = None,
-    on_message_history: Callable[[list[Any]], None] | None = None,
-) -> str:
-    """Run a subagent task synchronously (blocking).
-
-    Args:
-        agent: The pydantic-ai Agent instance.
-        config: Subagent configuration.
-        description: Task description.
-        deps: Dependencies for the subagent.
-        task_id: Unique task identifier.
-        extra_toolsets: Additional toolsets to pass to agent.run().
-        ask_user: Optional callback for `ask_parent` in sync mode. When
-            provided, it is attached to the cloned subagent deps via
-            `_subagent_state["ask_callback"]` so `ask_parent` resolves to
-            it. The parent agent cannot answer directly in sync mode because
-            its run loop is blocked here.
-        usage_limits: Optional pydantic-ai usage limits forwarded to the
-            subagent run (honoured on every retry attempt).
-        handle: Optional task handle populated for Python-side observability.
-        message_history: Optional prior message history for a subagent chat trace.
-        on_message_history: Optional callback that receives the successful
-            run's full message history.
-
-    Returns:
-        The subagent's response.
-    """
-    can_ask = config.get("can_ask_questions", True)
-    max_questions = config.get("max_questions")
-
-    if ask_user is not None:
-        # Reuse the async-mode `_subagent_state["ask_callback"]` path so
-        # `ask_parent` has a single resolution order across both modes.
-        deps._subagent_state = {"ask_callback": ask_user}
-
-    prompt = get_task_instructions_prompt(
-        description,
-        can_ask_questions=can_ask,
-        max_questions=max_questions,
-    )
-
-    run_kwargs: dict[str, Any] = {"deps": deps}
-    if extra_toolsets:
-        run_kwargs["toolsets"] = extra_toolsets
-    if usage_limits is not None:
-        run_kwargs["usage_limits"] = usage_limits
-    if message_history is not None:
-        run_kwargs["message_history"] = message_history
-    if handle is not None and handle.chat_trace_id is not None:
-        run_kwargs["conversation_id"] = handle.chat_trace_id
-
-    try:
-        result = await run_with_retry(
-            agent,
-            prompt,
-            run_kwargs=run_kwargs,
-            retry=RetryConfig.from_config(config),
-        )
-        _capture_message_history(result, on_message_history)
-        output = _serialize_output(result.output)
-        if handle is not None:
-            handle.result = output
-            handle.error = None
-            handle.status = TaskStatus.COMPLETED
-            handle.completed_at = datetime.now()
-            # Telemetry is best-effort and runs after the run is marked complete,
-            # so a capture failure can never flip a successful run to FAILED.
-            _capture_observability_best_effort(handle, result)
-        return output
-    except Exception as e:
-        if handle is not None:
-            handle.status = TaskStatus.FAILED
-            handle.error = str(e)
-            handle.completed_at = datetime.now()
-        return f"Error executing task: {e}"
-
-
-async def _run_async(
-    agent: Any,
-    config: SubAgentConfig,
-    description: str,
-    deps: Any,
-    task_id: str,
-    task_manager: TaskManager,
-    message_bus: InMemoryMessageBus,
-    priority: TaskPriority = TaskPriority.NORMAL,
-    extra_toolsets: list[Any] | None = None,
-    usage_limits: UsageLimits | None = None,
-    chat_trace_id: str | None = None,
-    message_history: list[Any] | None = None,
-    on_message_history: Callable[[list[Any]], None] | None = None,
-    on_run_finished: Callable[[], None] | None = None,
-) -> str:
-    """Run a subagent task asynchronously (background).
-
-    Args:
-        agent: The pydantic-ai Agent instance.
-        config: Subagent configuration.
-        description: Task description.
-        deps: Dependencies for the subagent.
-        task_id: Unique task identifier.
-        task_manager: Task manager for tracking.
-        message_bus: Message bus for communication.
-        priority: Task priority level.
-        extra_toolsets: Additional toolsets to pass to agent.run().
-        usage_limits: Optional pydantic-ai usage limits forwarded to the
-            subagent run (honoured on every retry attempt).
-        chat_trace_id: Optional chat trace ID for continuing this subagent
-            conversation.
-        message_history: Optional prior message history for a subagent chat trace.
-        on_message_history: Optional callback that receives the successful
-            run's full message history.
-        on_run_finished: Optional callback invoked exactly once when the
-            background run finishes (completed, failed, or cancelled). Used to
-            release the chat trace for continuation.
-
-    Returns:
-        Task handle information as string.
-    """
-    # Create task handle
-    handle = TaskHandle(
-        task_id=task_id,
-        subagent_name=config["name"],
-        description=description,
-        status=TaskStatus.PENDING,
-        priority=priority,
-        chat_trace_id=chat_trace_id,
-    )
-
-    # Register subagent for messaging
-    agent_id = f"subagent-{task_id}"
-    try:
-        message_bus.register_agent(agent_id)
-    except ValueError:
-        pass  # Already registered
-
-    # Inject _subagent_state on deps so ask_parent can communicate with parent
-    deps._subagent_state = {
-        "task_manager": task_manager,
-        "task_id": task_id,
-    }
-
-    async def run_task() -> None:
-        """Execute the task and update handle."""
-        can_ask = config.get("can_ask_questions", True)
-        max_questions = config.get("max_questions")
-
-        prompt = get_task_instructions_prompt(
-            description,
-            can_ask_questions=can_ask,
-            max_questions=max_questions,
-        )
-
-        run_kwargs: dict[str, Any] = {"deps": deps}
-        if extra_toolsets:
-            run_kwargs["toolsets"] = extra_toolsets
-        if usage_limits is not None:
-            run_kwargs["usage_limits"] = usage_limits
-        if message_history is not None:
-            run_kwargs["message_history"] = message_history
-        if chat_trace_id is not None:
-            run_kwargs["conversation_id"] = chat_trace_id
-
-        def _on_retry(attempt: int, exc: BaseException, delay: float) -> None:
-            handle.status = TaskStatus.RETRYING
-            handle.retry_count = attempt
-            handle.error = f"Transient error (retry {attempt}): {exc}"
-
-        def _cancel_requested() -> bool:
-            # Cooperative (soft) cancellation: TaskManager.soft_cancel sets this
-            # event, and run_with_retry polls it between graph nodes so the
-            # subagent stops at a clean boundary. Raised CancelledError is
-            # handled by the `except asyncio.CancelledError` branch below.
-            cancel_event = task_manager.get_cancel_event(task_id)
-            return cancel_event is not None and cancel_event.is_set()
-
-        async def _pending_steering() -> list[str]:
-            return await _drain_steering_messages(message_bus, agent_id)
-
-        try:
-            result = await run_with_retry(
-                agent,
-                prompt,
-                run_kwargs=run_kwargs,
-                retry=RetryConfig.from_config(config),
-                on_retry=_on_retry,
-                cancel_check=_cancel_requested,
-                inject_messages=_pending_steering,
-            )
-            _capture_message_history(result, on_message_history)
-            handle.result = _serialize_output(result.output)
-            handle.error = None
-            handle.status = TaskStatus.COMPLETED
-            # Telemetry is best-effort and runs after the run is marked complete,
-            # so a capture failure can never flip a successful run to FAILED.
-            _capture_observability_best_effort(handle, result)
-        except asyncio.CancelledError:
-            handle.status = TaskStatus.CANCELLED
-            handle.error = "Task was cancelled"
-        except Exception as e:
-            handle.status = TaskStatus.FAILED
-            handle.error = str(e)
-        finally:
-            handle.completed_at = datetime.now()
-            message_bus.unregister_agent(agent_id)
-            task_manager.clear_answer_future(task_id)
-            task_manager.cleanup_task(task_id)
-            if on_run_finished is not None:
-                on_run_finished()
-
-    # Create the background task
-    task_manager.create_task(task_id, run_task(), handle)
-
-    response = f"Task started in background.\nTask ID: {task_id}\nSubagent: {config['name']}\n"
-    if chat_trace_id is not None:
-        response += f"Chat Trace ID: {chat_trace_id}\n"
-    response += f"Use check_task('{task_id}') to check status."
-    return response
-
-
-# Alias for backwards compatibility
-SubAgentToolset = create_subagent_toolset

--- a/src/subagents_pydantic_ai/toolset.py
+++ b/src/subagents_pydantic_ai/toolset.py
@@ -892,6 +892,7 @@ class SubAgentToolset(FunctionToolset[Any]):
         ctx: RunContext[SubAgentDepsProtocol],
         description: str,
         instructions: str,
+        name: str,
         model: str | None = None,
         capabilities: list[str] | None = None,
         can_ask_questions: bool = True,
@@ -907,6 +908,9 @@ class SubAgentToolset(FunctionToolset[Any]):
             ctx: The run context.
             description: The task for the specialist to execute.
             instructions: The specialist's system prompt.
+            name: Label for the specialist (letters, numbers, hyphens), used in
+                logs and as `TaskHandle.subagent_name`. Naming it does not
+                register it: it still cannot be reused via `task`.
             model: Model to use. Defaults to the toolset's default model.
             capabilities: Capability names to attach to the specialist.
             can_ask_questions: Whether the specialist can ask the parent questions.
@@ -917,12 +921,11 @@ class SubAgentToolset(FunctionToolset[Any]):
             may_need_clarification: Whether task might need clarifying questions.
         """
         task_id = uuid.uuid4().hex[:8]
-        agent_name = f"oneshot-{task_id}"
         agent_description = description[:120] or "Ephemeral specialist"
 
         result = build_dynamic_agent(
             ctx,
-            name=agent_name,
+            name=name,
             description=agent_description,
             instructions=instructions,
             model=model or self._default_model,
@@ -940,7 +943,7 @@ class SubAgentToolset(FunctionToolset[Any]):
         return await self._execute(
             ctx,
             CompiledSubAgent(
-                name=agent_name,
+                name=name,
                 description=agent_description,
                 agent=agent,
                 config=config,

--- a/src/subagents_pydantic_ai/types.py
+++ b/src/subagents_pydantic_ai/types.py
@@ -7,19 +7,50 @@ including configuration types, message types, and task management types.
 from __future__ import annotations
 
 import uuid
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from decimal import Decimal
 from enum import Enum
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 from pydantic_ai import RunContext, UsageLimits
 from pydantic_ai.models import Model
 from typing_extensions import NotRequired, TypedDict
 
+if TYPE_CHECKING:
+    from pydantic_ai.messages import FinishReason
+    from pydantic_ai.toolsets import AbstractToolset
+    from pydantic_ai.usage import RunUsage
 
-class MessageType(str, Enum):
+
+def utcnow() -> datetime:
+    """The current time as a timezone-aware UTC timestamp.
+
+    Task timestamps are compared and subtracted (elapsed time, eviction order), so
+    they must be unambiguous. Naive local timestamps make that arithmetic wrong
+    across a DST transition.
+    """
+    return datetime.now(timezone.utc)
+
+
+class _ValueStrEnum(str, Enum):
+    """A `str` enum that renders as its value on every supported Python version.
+
+    Python 3.11 changed `Enum.__str__` and `Enum.__format__` for mixin enums to
+    render `ClassName.MEMBER`, so `f"{TaskStatus.COMPLETED}"` produced
+    `TaskStatus.COMPLETED` instead of `completed` and leaked the member name into
+    model-facing tool output. `enum.StrEnum` fixes this but only exists on 3.11+.
+    """
+
+    def __str__(self) -> str:
+        return str(self.value)
+
+    def __format__(self, format_spec: str) -> str:
+        return str.__format__(str(self.value), format_spec)
+
+
+class MessageType(_ValueStrEnum):
     """Types of messages that can be sent between agents."""
 
     TASK_ASSIGNED = "task_assigned"
@@ -47,7 +78,7 @@ class MessageType(str, Enum):
     """Immediate cancellation (hard cancel)."""
 
 
-class TaskStatus(str, Enum):
+class TaskStatus(_ValueStrEnum):
     """Status of a background task."""
 
     PENDING = "pending"
@@ -96,7 +127,13 @@ DelegationConfiguration = Literal[
 """
 
 
-class TaskPriority(str, Enum):
+TERMINAL_STATUSES: frozenset[TaskStatus] = frozenset(
+    {TaskStatus.COMPLETED, TaskStatus.FAILED, TaskStatus.CANCELLED}
+)
+"""Statuses a task never leaves. The first terminal transition wins."""
+
+
+class TaskPriority(_ValueStrEnum):
     """Priority levels for background tasks."""
 
     LOW = "low"
@@ -134,14 +171,18 @@ class TaskCharacteristics:
     may_need_clarification: bool = False
 
 
-ToolsetFactory = Callable[[Any], list[Any]]
+ToolsetFactory = Callable[[Any], "Sequence[AbstractToolset[Any]]"]
 """Factory function that creates toolsets for a subagent.
 
-Takes deps as input and returns a list of toolsets to register.
+Takes the subagent's deps as input and returns the toolsets to register. The deps
+parameter is `Any` because its type belongs to the application, not this library.
+The return type is a `Sequence` so a factory annotated with a concrete toolset
+type (`list[FunctionToolset[MyDeps]]`) still satisfies it -- `list` is invariant,
+`Sequence` is not.
 
 Example:
     ```python
-    def my_toolset_factory(deps: MyDeps) -> list[Any]:
+    def my_toolset_factory(deps: MyDeps) -> list[FunctionToolset[MyDeps]]:
         return [
             create_file_toolset(deps.backend),
             create_todo_toolset(),
@@ -170,7 +211,21 @@ Example:
 """
 
 
-class SubAgentConfig(TypedDict, total=False):
+class _SubAgentConfigRequired(TypedDict):
+    """The keys every `SubAgentConfig` must carry.
+
+    Split out so `total=False` on `SubAgentConfig` applies only to the optional
+    keys. The library indexes these three directly (`config["name"]`), so making
+    them optional to the type checker turned a configuration mistake into a
+    `KeyError` raised in the middle of a delegation.
+    """
+
+    name: str
+    description: str
+    instructions: str
+
+
+class SubAgentConfig(_SubAgentConfigRequired, total=False):
     """Configuration for a subagent.
 
     Defines the name, description, and instructions for a subagent.
@@ -218,6 +273,17 @@ class SubAgentConfig(TypedDict, total=False):
         retry_on: Custom predicate `(exc) -> bool` deciding whether an
             exception is transient. Defaults to the built-in classifier
             (`ModelHTTPError` 5xx/429/... and non-HTTP `ModelAPIError`).
+        on_failure: Message returned to the parent as an ordinary tool result
+            when this subagent fails, instead of raising `ModelRetry`. Use it
+            to steer the parent ("summarise from what you already have")
+            rather than letting it retry the delegation.
+        contain_errors: Whether an unexpected subagent crash is contained.
+            Defaults to `True`: the crash becomes a `ModelRetry` for the
+            parent, logged with its traceback, so one failed delegation cannot
+            abort the whole run. Set `False` to let crashes propagate.
+            Control-flow signals (`CallDeferred`, `ApprovalRequired`,
+            `Skip*`), `UserError`, and a shared `UsageLimitExceeded` always
+            propagate regardless.
 
     Example with builtin_tools:
         ```python
@@ -240,9 +306,6 @@ class SubAgentConfig(TypedDict, total=False):
         ```
     """
 
-    name: str
-    description: str
-    instructions: str
     model: NotRequired[str | Model]
     agent: NotRequired[Any]
     agent_factory: NotRequired[Callable[..., Any]]
@@ -251,7 +314,7 @@ class SubAgentConfig(TypedDict, total=False):
     preferred_mode: NotRequired[Literal["sync", "async", "auto"]]
     typical_complexity: NotRequired[Literal["simple", "moderate", "complex"]]
     typically_needs_context: NotRequired[bool]
-    toolsets: NotRequired[list[Any]]
+    toolsets: NotRequired[Sequence[AbstractToolset[Any]]]
     agent_kwargs: NotRequired[dict[str, Any]]
     context_files: NotRequired[list[str]]
     extra: NotRequired[dict[str, Any]]
@@ -261,6 +324,8 @@ class SubAgentConfig(TypedDict, total=False):
     retry_backoff_multiplier: NotRequired[float]
     retry_jitter: NotRequired[bool]
     retry_on: NotRequired[Callable[[BaseException], bool]]
+    on_failure: NotRequired[str]
+    contain_errors: NotRequired[bool]
 
 
 UsageLimitsFactory = Callable[[RunContext[Any], SubAgentConfig], "UsageLimits | None"]
@@ -297,7 +362,7 @@ class AgentMessage:
     payload: Any
     task_id: str
     id: str = field(default_factory=_generate_message_id)
-    timestamp: datetime = field(default_factory=datetime.now)
+    timestamp: datetime = field(default_factory=utcnow)
     correlation_id: str | None = None
 
 
@@ -325,6 +390,9 @@ class TaskHandle:
         conversation_id: Pydantic AI conversation ID for the subagent run
         traceparent: W3C traceparent for the subagent run span, if available
         cost: Total subagent model cost calculated from genai-prices
+        parent_run_id: `run_id` of the parent run that started this task. Tools
+            use it to refuse cross-run access, and the capability uses it to
+            cancel a run's tasks when that run ends.
     """
 
     task_id: str
@@ -332,15 +400,15 @@ class TaskHandle:
     description: str
     status: TaskStatus = TaskStatus.PENDING
     priority: TaskPriority = TaskPriority.NORMAL
-    created_at: datetime = field(default_factory=datetime.now)
+    created_at: datetime = field(default_factory=utcnow)
     started_at: datetime | None = None
     completed_at: datetime | None = None
     result: str | None = None
     error: str | None = None
     pending_question: str | None = None
     chat_trace_id: str | None = None
-    usage: Any = None
-    """Token usage from the subagent run (``RunUsage`` from pydantic-ai)."""
+    usage: RunUsage | None = None
+    """Token usage from the subagent run."""
     message_history: str | None = None
     run_id: str | None = None
     conversation_id: str | None = None
@@ -352,11 +420,47 @@ class TaskHandle:
     provider_url: str | None = None
     provider_response_id: str | None = None
     provider_details: dict[str, Any] | None = None
-    finish_reason: Any = None
+    finish_reason: FinishReason | None = None
     cost: Decimal | None = None
     tool_call_counts: dict[str, int] = field(default_factory=dict)
     retry_count: int = 0
     """Number of transient-failure retries performed for this task."""
+    parent_run_id: str | None = None
+
+    @property
+    def is_finished(self) -> bool:
+        """Whether the task reached a terminal status."""
+        return self.status in TERMINAL_STATUSES
+
+    def finish(
+        self,
+        status: TaskStatus,
+        *,
+        result: str | None = None,
+        error: str | None = None,
+    ) -> bool:
+        """Record a terminal outcome, first terminal transition winning.
+
+        Idempotence is what makes `hard_cancel` safe. A task that already set
+        `COMPLETED` and is running its `finally` block is still not
+        `asyncio.Task.done()`, so a cancel arriving in that window used to
+        overwrite the real result with `CANCELLED` and move `completed_at`.
+
+        Args:
+            status: The terminal status to record.
+            result: Result text, for a completed task.
+            error: Error text, for a failed or cancelled task.
+
+        Returns:
+            Whether this call recorded the outcome.
+        """
+        if self.is_finished:
+            return False
+        self.status = status
+        self.result = result
+        self.error = error
+        self.completed_at = utcnow()
+        return True
 
 
 @dataclass
@@ -376,7 +480,13 @@ class CompiledSubAgent:
     name: str
     description: str
     config: SubAgentConfig
-    agent: object | None = None  # Agent instance - typed as object to avoid circular imports
+    agent: Any = None
+    """The agent that runs when this subagent is delegated to.
+
+    Deliberately untyped: consumers such as pydantic-deep supply their own agent
+    objects rather than a `pydantic_ai.Agent`, so narrowing this would reject
+    valid callers. Only `run`/`iter` are ever called on it.
+    """
 
 
 def decide_execution_mode(

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,6 @@
+"""Test package.
+
+Making `tests` a package gives its modules fully-qualified names
+(`tests.test_toolset`), which is what mypy's `module = "tests.*"` override needs
+to match. Without it the override silently applied to nothing.
+"""

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -1,0 +1,132 @@
+"""Checks that the documentation's Python snippets still match the library.
+
+Docs rot silently: a renamed parameter or a moved export leaves the prose looking
+fine while every reader who copies the snippet hits a `TypeError`. These tests
+catch the two failure modes that actually happen.
+
+1. **Syntax** -- every fenced `python` block in `docs/` and `README.md` compiles.
+2. **API drift** -- every name a snippet imports from `subagents_pydantic_ai`
+   exists, and every keyword argument it passes to a documented entry point is
+   really a parameter of that function.
+
+Snippets are not executed: most need a model, an event loop, and credentials.
+Execution is what the rest of the suite is for.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import subagents_pydantic_ai
+from subagents_pydantic_ai import (
+    SubAgentCapability,
+    create_agent_factory_toolset,
+    create_subagent_toolset,
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DOCS_DIR = REPO_ROOT / "docs"
+
+_FENCE = re.compile(r"^```(?:py|python)[^\n]*\n(.*?)^```", re.DOTALL | re.MULTILINE)
+
+#: Entry points whose keyword arguments the snippets are checked against.
+_CHECKED_CALLABLES: dict[str, Any] = {
+    "create_subagent_toolset": create_subagent_toolset,
+    "create_agent_factory_toolset": create_agent_factory_toolset,
+    "SubAgentCapability": SubAgentCapability,
+}
+
+
+@dataclass(frozen=True)
+class Snippet:
+    """One fenced Python block, with enough context to name it in a failure."""
+
+    path: Path
+    index: int
+    source: str
+
+    @property
+    def id(self) -> str:
+        return f"{self.path.relative_to(REPO_ROOT)}#{self.index}"
+
+
+def _markdown_files() -> list[Path]:
+    files = sorted(DOCS_DIR.rglob("*.md"))
+    files.append(REPO_ROOT / "README.md")
+    return [path for path in files if "plans" not in path.parts]
+
+
+def _snippets() -> list[Snippet]:
+    found: list[Snippet] = []
+    for path in _markdown_files():
+        text = path.read_text(encoding="utf-8")
+        for index, match in enumerate(_FENCE.finditer(text)):
+            found.append(Snippet(path=path, index=index, source=match.group(1)))
+    return found
+
+
+SNIPPETS = _snippets()
+
+
+def test_snippets_were_found() -> None:
+    """Guard against a regex that silently stops matching."""
+    assert len(SNIPPETS) > 40
+
+
+@pytest.mark.parametrize("snippet", SNIPPETS, ids=lambda s: s.id)
+def test_snippet_compiles(snippet: Snippet) -> None:
+    """A documented snippet is at least valid Python."""
+    try:
+        ast.parse(snippet.source)
+    except SyntaxError as exc:  # pragma: no cover - only on a broken snippet
+        pytest.fail(f"{snippet.id} does not parse: {exc}")
+
+
+def _imported_names(tree: ast.Module) -> set[str]:
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and (node.module or "").startswith(
+            "subagents_pydantic_ai"
+        ):
+            names.update(alias.name for alias in node.names)
+    return names
+
+
+@pytest.mark.parametrize("snippet", SNIPPETS, ids=lambda s: s.id)
+def test_snippet_imports_exist(snippet: Snippet) -> None:
+    """Every name a snippet imports from the library is really exported."""
+    tree = ast.parse(snippet.source)
+    missing = sorted(
+        name for name in _imported_names(tree) if not hasattr(subagents_pydantic_ai, name)
+    )
+    assert not missing, f"{snippet.id} imports names the library does not export: {missing}"
+
+
+def _keyword_calls(tree: ast.Module) -> list[tuple[str, list[str]]]:
+    calls: list[tuple[str, list[str]]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        name = func.id if isinstance(func, ast.Name) else None
+        if name is None or name not in _CHECKED_CALLABLES:
+            continue
+        calls.append((name, [kw.arg for kw in node.keywords if kw.arg is not None]))
+    return calls
+
+
+@pytest.mark.parametrize("snippet", SNIPPETS, ids=lambda s: s.id)
+def test_snippet_keyword_arguments_exist(snippet: Snippet) -> None:
+    """Every keyword a snippet passes to an entry point is a real parameter."""
+    tree = ast.parse(snippet.source)
+    for name, keywords in _keyword_calls(tree):
+        parameters = inspect.signature(_CHECKED_CALLABLES[name]).parameters
+        unknown = sorted(kw for kw in keywords if kw not in parameters)
+        assert not unknown, f"{snippet.id} passes unknown arguments to {name}(): {unknown}"

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -1,0 +1,800 @@
+"""Regression tests for task lifecycle, run isolation, and model-facing output.
+
+Each test here pins a defect that the previous implementation shipped while the
+suite reported 100% branch coverage -- coverage proved the lines executed, not
+that they produced the right answer.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from datetime import timezone
+from typing import Any
+
+import pytest
+from pydantic_ai import UsageLimits
+from pydantic_ai.exceptions import (
+    ApprovalRequired,
+    CallDeferred,
+    ModelRetry,
+    UnexpectedModelBehavior,
+    UsageLimitExceeded,
+)
+from pydantic_ai.models.test import TestModel
+
+from subagents_pydantic_ai import (
+    AgentMessage,
+    InMemoryMessageBus,
+    MessageType,
+    SubAgentCapability,
+    SubAgentConfig,
+    TaskHandle,
+    TaskManager,
+    TaskStatus,
+    create_subagent_toolset,
+)
+from subagents_pydantic_ai._execution import _run_async, _run_sync
+from subagents_pydantic_ai.types import utcnow
+
+# `asyncio_mode = "auto"` in pyproject.toml drives the async tests here.
+
+
+@dataclass
+class Deps:
+    """Minimal deps satisfying `SubAgentDepsProtocol`."""
+
+    subagents: dict[str, Any] = field(default_factory=dict)
+
+    def clone_for_subagent(self, max_depth: int = 0) -> Deps:
+        return Deps(subagents={} if max_depth <= 0 else dict(self.subagents))
+
+
+@dataclass
+class Ctx:
+    """Stand-in for `RunContext`, carrying the fields the tools read."""
+
+    deps: Deps = field(default_factory=Deps)
+    run_id: str | None = None
+
+
+class _Run:
+    def __init__(self, output: str) -> None:
+        self.result = _Result(output)
+        self.next_node: Any = object()
+
+    async def next(self, node: Any) -> Any:
+        from pydantic_graph import End
+
+        return End(self.result)
+
+    def all_messages(self) -> list[Any]:
+        return []
+
+
+class _Result:
+    def __init__(self, output: str) -> None:
+        self.output = output
+
+
+class _CM:
+    def __init__(self, agent: StubAgent) -> None:
+        self._agent = agent
+
+    async def __aenter__(self) -> _Run:
+        agent = self._agent
+        if agent.block is not None:
+            await agent.block.wait()
+        if agent.error is not None:
+            raise agent.error
+        return _Run(agent.output)
+
+    async def __aexit__(self, *exc: object) -> bool:
+        return False
+
+
+class StubAgent:
+    """Agent stand-in driven through `.iter()`, like `Agent.run` drives one."""
+
+    def __init__(
+        self,
+        output: str = "done",
+        error: BaseException | None = None,
+        block: asyncio.Event | None = None,
+    ) -> None:
+        self.output = output
+        self.error = error
+        self.block = block
+
+    def iter(self, prompt: Any = None, **kwargs: Any) -> _CM:
+        return _CM(self)
+
+
+def _config(name: str = "worker", **extra: Any) -> SubAgentConfig:
+    config = SubAgentConfig(
+        name=name,
+        description=f"{name} description",
+        instructions="Do the work.",
+    )
+    config.update(extra)  # type: ignore[typeddict-item]
+    return config
+
+
+def _toolset(**kwargs: Any) -> Any:
+    return create_subagent_toolset(
+        subagents=[_config()],
+        include_general_purpose=False,
+        default_model=TestModel(),
+        **kwargs,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Model-facing status rendering
+# --------------------------------------------------------------------------- #
+
+
+class TestStatusRendering:
+    """Statuses reach the model as their values, on every supported Python.
+
+    Python 3.11 changed `Enum.__format__` for mixin enums, so `f"{status}"`
+    produced `TaskStatus.WAITING_FOR_ANSWER` and the tool descriptions promised
+    `waiting_for_answer`. No test asserted the rendered string, so the leak
+    shipped.
+    """
+
+    async def test_check_task_renders_status_value(self) -> None:
+        toolset = _toolset()
+        toolset.task_manager.handles["t1"] = TaskHandle(
+            task_id="t1",
+            subagent_name="worker",
+            description="dig",
+            status=TaskStatus.WAITING_FOR_ANSWER,
+            pending_question="which repo?",
+        )
+
+        result = await toolset.tools["check_task"].function(Ctx(), "t1")
+
+        assert "Status: waiting_for_answer" in result
+        assert "TaskStatus." not in result
+
+    async def test_check_task_renders_retrying_status(self) -> None:
+        toolset = _toolset()
+        toolset.task_manager.handles["t1"] = TaskHandle(
+            task_id="t1",
+            subagent_name="worker",
+            description="dig",
+            status=TaskStatus.RETRYING,
+            started_at=utcnow(),
+        )
+
+        result = await toolset.tools["check_task"].function(Ctx(), "t1")
+
+        assert "Status: retrying" in result
+        assert "TaskStatus." not in result
+
+    async def test_list_active_tasks_renders_status_value(self) -> None:
+        toolset = _toolset()
+        block = asyncio.Event()
+        await _run_async(
+            agent=StubAgent(block=block),
+            config=_config(),
+            description="a long running job",
+            deps=Deps(),
+            task_id="t1",
+            task_manager=toolset.task_manager,
+            message_bus=toolset.task_manager.message_bus,
+        )
+
+        result = await toolset.tools["list_active_tasks"].function(Ctx())
+
+        assert "(running)" in result
+        assert "TaskStatus." not in result
+
+        block.set()
+        await asyncio.gather(*toolset.task_manager.tasks.values(), return_exceptions=True)
+
+    async def test_wait_tasks_renders_pending_status_value(self) -> None:
+        toolset = _toolset()
+        toolset.task_manager.handles["t1"] = TaskHandle(
+            task_id="t1",
+            subagent_name="worker",
+            description="dig",
+            status=TaskStatus.RUNNING,
+        )
+
+        result = await toolset.tools["wait_tasks"].function(Ctx(), ["t1"])
+
+        assert "(worker): running" in result
+        assert "TaskStatus." not in result
+
+    async def test_wait_tasks_renders_terminal_status_value(self) -> None:
+        toolset = _toolset()
+        toolset.task_manager.handles["t1"] = TaskHandle(
+            task_id="t1",
+            subagent_name="worker",
+            description="dig",
+            status=TaskStatus.CANCELLED,
+            error="Task was cancelled",
+        )
+
+        result = await toolset.tools["wait_tasks"].function(Ctx(), ["t1"])
+
+        assert "CANCELLED - Task was cancelled" in result
+        assert "TaskStatus." not in result
+
+
+# --------------------------------------------------------------------------- #
+# Run isolation
+# --------------------------------------------------------------------------- #
+
+
+class TestRunIsolation:
+    """One toolset instance serves every run of its agent, so tasks are scoped.
+
+    Without scoping, a server sharing one agent across users let any run inspect,
+    answer, steer, or cancel another run's task by id.
+    """
+
+    def _foreign_handle(self, toolset: Any, status: TaskStatus = TaskStatus.RUNNING) -> None:
+        toolset.task_manager.handles["foreign"] = TaskHandle(
+            task_id="foreign",
+            subagent_name="worker",
+            description="someone else's task",
+            status=status,
+            parent_run_id="run-a",
+            pending_question="secret?",
+        )
+
+    async def test_check_task_hides_another_runs_task(self) -> None:
+        toolset = _toolset()
+        self._foreign_handle(toolset)
+
+        result = await toolset.tools["check_task"].function(Ctx(run_id="run-b"), "foreign")
+
+        assert result == "Error: Task 'foreign' not found"
+
+    async def test_check_task_shows_own_task(self) -> None:
+        toolset = _toolset()
+        self._foreign_handle(toolset)
+
+        result = await toolset.tools["check_task"].function(Ctx(run_id="run-a"), "foreign")
+
+        assert "Subagent: worker" in result
+
+    async def test_answer_subagent_refuses_another_runs_task(self) -> None:
+        toolset = _toolset()
+        self._foreign_handle(toolset, status=TaskStatus.WAITING_FOR_ANSWER)
+
+        result = await toolset.tools["answer_subagent"].function(
+            Ctx(run_id="run-b"), "foreign", "42"
+        )
+
+        assert result == "Error: Task 'foreign' not found"
+
+    async def test_send_message_refuses_another_runs_task(self) -> None:
+        toolset = _toolset()
+        self._foreign_handle(toolset)
+        toolset.task_manager.message_bus.register_agent("subagent-foreign")
+
+        result = await toolset.tools["send_message_to_subagent"].function(
+            Ctx(run_id="run-b"), "foreign", "stop"
+        )
+
+        assert result == "Error: Task 'foreign' not found"
+
+    async def test_cancel_refuses_another_runs_task(self) -> None:
+        toolset = _toolset()
+        self._foreign_handle(toolset)
+
+        soft = await toolset.tools["soft_cancel_task"].function(Ctx(run_id="run-b"), "foreign")
+        hard = await toolset.tools["hard_cancel_task"].function(Ctx(run_id="run-b"), "foreign")
+
+        assert soft == "Error: Task 'foreign' not found"
+        assert hard == "Error: Task 'foreign' not found"
+
+    async def test_list_active_tasks_omits_another_runs_task(self) -> None:
+        toolset = _toolset()
+        block = asyncio.Event()
+        await _run_async(
+            agent=StubAgent(block=block),
+            config=_config(),
+            description="theirs",
+            deps=Deps(),
+            task_id="t-a",
+            task_manager=toolset.task_manager,
+            message_bus=toolset.task_manager.message_bus,
+            parent_run_id="run-a",
+        )
+
+        result = await toolset.tools["list_active_tasks"].function(Ctx(run_id="run-b"))
+
+        assert result == "No active background tasks."
+
+        block.set()
+        await asyncio.gather(*toolset.task_manager.tasks.values(), return_exceptions=True)
+
+    async def test_wait_tasks_reports_another_runs_task_as_missing(self) -> None:
+        toolset = _toolset()
+        self._foreign_handle(toolset)
+
+        result = await toolset.tools["wait_tasks"].function(Ctx(run_id="run-b"), ["foreign"])
+
+        assert "- foreign: not found" in result
+
+
+# --------------------------------------------------------------------------- #
+# Terminal transitions
+# --------------------------------------------------------------------------- #
+
+
+class TestTerminalTransitions:
+    """The first terminal transition wins."""
+
+    def test_finish_is_idempotent(self) -> None:
+        handle = TaskHandle(task_id="t1", subagent_name="worker", description="d")
+
+        assert handle.finish(TaskStatus.COMPLETED, result="the answer") is True
+        completed_at = handle.completed_at
+
+        assert handle.finish(TaskStatus.CANCELLED, error="too late") is False
+        assert handle.status == TaskStatus.COMPLETED
+        assert handle.result == "the answer"
+        assert handle.error is None
+        assert handle.completed_at == completed_at
+
+    def test_finish_records_timezone_aware_timestamps(self) -> None:
+        handle = TaskHandle(task_id="t1", subagent_name="worker", description="d")
+        handle.finish(TaskStatus.COMPLETED, result="x")
+
+        assert handle.created_at.tzinfo is not None
+        assert handle.completed_at is not None
+        assert handle.completed_at.tzinfo == timezone.utc
+
+    async def test_hard_cancel_cannot_overwrite_a_completed_task(self) -> None:
+        """A task inside its `finally` is not `done()`, but its outcome is settled.
+
+        The old guard was `if not task.done()`, which is still true while the
+        task runs its cleanup, so a cancel arriving in that window replaced the
+        real result with `CANCELLED`.
+        """
+        manager = TaskManager(message_bus=InMemoryMessageBus())
+        in_cleanup = asyncio.Event()
+        may_exit = asyncio.Event()
+        handle = TaskHandle(task_id="t1", subagent_name="worker", description="d")
+
+        async def work() -> None:
+            try:
+                handle.finish(TaskStatus.COMPLETED, result="the answer")
+            finally:
+                in_cleanup.set()
+                await may_exit.wait()
+
+        task = manager.create_task("t1", work(), handle)
+        await in_cleanup.wait()
+
+        assert await manager.hard_cancel("t1") is True
+        assert handle.status == TaskStatus.COMPLETED
+        assert handle.result == "the answer"
+
+        may_exit.set()
+        await asyncio.gather(task, return_exceptions=True)
+
+
+# --------------------------------------------------------------------------- #
+# Background tasks do not outlive their parent run
+# --------------------------------------------------------------------------- #
+
+
+class TestTaskCancellation:
+    async def test_cancel_all_stops_live_tasks(self) -> None:
+        toolset = _toolset()
+        block = asyncio.Event()
+        await _run_async(
+            agent=StubAgent(block=block),
+            config=_config(),
+            description="never finishes on its own",
+            deps=Deps(),
+            task_id="t1",
+            task_manager=toolset.task_manager,
+            message_bus=toolset.task_manager.message_bus,
+            parent_run_id="run-a",
+        )
+        await asyncio.sleep(0)
+
+        await toolset.cancel_run_tasks("run-a")
+
+        assert toolset.task_manager.handles["t1"].status == TaskStatus.CANCELLED
+        assert toolset.task_manager.list_active_tasks() == []
+
+    async def test_cancelling_a_finished_task_reports_its_status(self) -> None:
+        """ "Not found" for a task whose result is still readable is misleading."""
+        toolset = _toolset()
+        toolset.task_manager.handles["t1"] = TaskHandle(
+            task_id="t1",
+            subagent_name="worker",
+            description="d",
+            status=TaskStatus.COMPLETED,
+            result="the answer",
+        )
+        ctx = Ctx()
+
+        soft = await toolset.tools["soft_cancel_task"].function(ctx, "t1")
+        hard = await toolset.tools["hard_cancel_task"].function(ctx, "t1")
+
+        for message in (soft, hard):
+            assert "no longer running (status: completed)" in message
+            assert "check_task('t1')" in message
+
+    async def test_cancel_all_leaves_other_runs_alone(self) -> None:
+        toolset = _toolset()
+        block = asyncio.Event()
+        # `t-b` sits between two tasks of `run-a` so both the skip and the cancel
+        # branch continue into another iteration.
+        for task_id, run_id in (("t-a", "run-a"), ("t-b", "run-b"), ("t-c", "run-a")):
+            await _run_async(
+                agent=StubAgent(block=block),
+                config=_config(),
+                description="work",
+                deps=Deps(),
+                task_id=task_id,
+                task_manager=toolset.task_manager,
+                message_bus=toolset.task_manager.message_bus,
+                parent_run_id=run_id,
+            )
+        await asyncio.sleep(0)
+
+        await toolset.cancel_run_tasks("run-a")
+
+        assert toolset.task_manager.handles["t-a"].status == TaskStatus.CANCELLED
+        assert toolset.task_manager.handles["t-c"].status == TaskStatus.CANCELLED
+        assert toolset.task_manager.handles["t-b"].status == TaskStatus.RUNNING
+
+        block.set()
+        await asyncio.gather(*toolset.task_manager.tasks.values(), return_exceptions=True)
+
+    async def test_cancel_all_without_run_id_stops_everything(self) -> None:
+        toolset = _toolset()
+        block = asyncio.Event()
+        await _run_async(
+            agent=StubAgent(block=block),
+            config=_config(),
+            description="work",
+            deps=Deps(),
+            task_id="t1",
+            task_manager=toolset.task_manager,
+            message_bus=toolset.task_manager.message_bus,
+            parent_run_id="run-a",
+        )
+        await asyncio.sleep(0)
+
+        await toolset.task_manager.cancel_all()
+
+        assert toolset.task_manager.handles["t1"].status == TaskStatus.CANCELLED
+
+    async def test_cancel_all_skips_finished_and_handleless_tasks(self) -> None:
+        """`cancel_all` tolerates a registry that is not perfectly tidy.
+
+        A task that already finished but whose entry has not been cleaned up must
+        not be cancelled again, and a task tracked without a handle (created
+        directly rather than through a delegation) must still be stopped.
+        """
+        manager = TaskManager(message_bus=InMemoryMessageBus())
+        block = asyncio.Event()
+
+        async def finished() -> None:
+            return None
+
+        async def forever() -> None:
+            await block.wait()
+
+        done_handle = TaskHandle(task_id="done", subagent_name="worker", description="d")
+        manager.create_task("done", finished(), done_handle)
+        await asyncio.sleep(0)
+        assert manager.tasks["done"].done()
+        done_handle.finish(TaskStatus.COMPLETED, result="kept")
+
+        # A bare task with no handle, which `cancel_all` must still cancel.
+        manager.tasks["bare"] = asyncio.create_task(forever())
+        await asyncio.sleep(0)
+
+        await manager.cancel_all()
+
+        assert not manager.tasks["done"].cancelled()
+        assert done_handle.status == TaskStatus.COMPLETED
+        assert done_handle.result == "kept"
+        assert manager.tasks["bare"].cancelled()
+
+    async def test_cancel_all_stops_a_task_parked_in_ask_parent(self) -> None:
+        """A task parked in `ask_parent` stops now, not after the ask timeout."""
+        manager = TaskManager(message_bus=InMemoryMessageBus())
+        handle = TaskHandle(
+            task_id="t1",
+            subagent_name="worker",
+            description="d",
+            parent_run_id="run-a",
+        )
+        answered = False
+
+        async def work() -> None:
+            nonlocal answered
+            future: asyncio.Future[str] = asyncio.get_running_loop().create_future()
+            manager.set_answer_future("t1", future)
+            await asyncio.wait_for(future, timeout=300.0)
+            answered = True
+
+        task = manager.create_task("t1", work(), handle)
+        await asyncio.sleep(0)
+
+        await manager.cancel_all("run-a")
+
+        assert task.done()
+        assert answered is False
+        assert handle.status == TaskStatus.CANCELLED
+
+    async def test_soft_cancel_unblocks_a_task_parked_in_ask_parent(self) -> None:
+        """Soft cancel resolves the pending question so the stop lands immediately.
+
+        A task inside `ask_parent` sits in a tool call, not at a node boundary, so
+        the cooperative cancel would otherwise only take effect after the ask
+        timeout expired.
+        """
+        manager = TaskManager(message_bus=InMemoryMessageBus())
+        handle = TaskHandle(task_id="t1", subagent_name="worker", description="d")
+        received: list[str] = []
+        done = asyncio.Event()
+
+        async def work() -> None:
+            future: asyncio.Future[str] = asyncio.get_running_loop().create_future()
+            manager.set_answer_future("t1", future)
+            received.append(await future)
+            done.set()
+
+        task = manager.create_task("t1", work(), handle)
+        await asyncio.sleep(0)
+
+        assert await manager.soft_cancel("t1") is True
+        await asyncio.wait_for(done.wait(), timeout=1.0)
+
+        assert received == [
+            "Your parent agent cancelled this task. Stop working and wrap up immediately."
+        ]
+        await task
+
+    async def test_capability_cancels_its_run_tasks(self) -> None:
+        """`SubAgentCapability.wrap_run` is the finalizer that guarantees this."""
+        capability = SubAgentCapability(
+            subagents=[_config()],
+            include_general_purpose=False,
+            default_model=TestModel(),
+        )
+        toolset = capability.get_toolset()
+        assert toolset is not None
+        block = asyncio.Event()
+        await _run_async(
+            agent=StubAgent(block=block),
+            config=_config(),
+            description="outlives the run unless cancelled",
+            deps=Deps(),
+            task_id="t1",
+            task_manager=capability.task_manager,
+            message_bus=capability.task_manager.message_bus,
+            parent_run_id="run-a",
+        )
+        await asyncio.sleep(0)
+
+        async def handler() -> Any:
+            return "run result"
+
+        result = await capability.wrap_run(Ctx(run_id="run-a"), handler=handler)
+
+        assert result == "run result"
+        assert capability.task_manager.handles["t1"].status == TaskStatus.CANCELLED
+
+    async def test_capability_cancels_tasks_even_when_the_run_raises(self) -> None:
+        capability = SubAgentCapability(
+            subagents=[_config()],
+            include_general_purpose=False,
+            default_model=TestModel(),
+        )
+        block = asyncio.Event()
+        await _run_async(
+            agent=StubAgent(block=block),
+            config=_config(),
+            description="work",
+            deps=Deps(),
+            task_id="t1",
+            task_manager=capability.task_manager,
+            message_bus=capability.task_manager.message_bus,
+            parent_run_id="run-a",
+        )
+        await asyncio.sleep(0)
+
+        async def handler() -> Any:
+            raise RuntimeError("the run blew up")
+
+        with pytest.raises(RuntimeError, match="the run blew up"):
+            await capability.wrap_run(Ctx(run_id="run-a"), handler=handler)
+
+        assert capability.task_manager.handles["t1"].status == TaskStatus.CANCELLED
+
+
+# --------------------------------------------------------------------------- #
+# Error contract
+# --------------------------------------------------------------------------- #
+
+
+class TestErrorContract:
+    async def test_sync_propagates_shared_usage_limit(self) -> None:
+        """A shared budget being exhausted means the whole tree is out of budget."""
+        handle = TaskHandle(task_id="t1", subagent_name="worker", description="d")
+
+        with pytest.raises(UsageLimitExceeded):
+            await _run_sync(
+                agent=StubAgent(error=UsageLimitExceeded("out of tokens")),
+                config=_config(),
+                description="work",
+                deps=Deps(),
+                task_id="t1",
+                handle=handle,
+                usage_limits=UsageLimits(request_limit=1),
+            )
+
+        assert handle.status == TaskStatus.FAILED
+        assert handle.error == "usage limit exceeded"
+
+    @pytest.mark.parametrize(
+        "error",
+        [ModelRetry("please rephrase"), UnexpectedModelBehavior("garbled tool call")],
+    )
+    async def test_sync_soft_failure_is_reported_as_failed_not_crashed(
+        self, error: BaseException, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A soft child failure is expected, so it is not logged as a crash."""
+        handle = TaskHandle(task_id="t1", subagent_name="worker", description="d")
+
+        with caplog.at_level(logging.WARNING), pytest.raises(ModelRetry, match="failed"):
+            await _run_sync(
+                agent=StubAgent(error=error),
+                config=_config(),
+                description="work",
+                deps=Deps(),
+                task_id="t1",
+                handle=handle,
+            )
+
+        assert handle.status == TaskStatus.FAILED
+        assert "Contained crash" not in caplog.text
+
+    async def test_sync_soft_failure_honours_on_failure(self) -> None:
+        handle = TaskHandle(task_id="t1", subagent_name="worker", description="d")
+
+        result = await _run_sync(
+            agent=StubAgent(error=ModelRetry("please rephrase")),
+            config=_config(on_failure="Work with what you have."),
+            description="work",
+            deps=Deps(),
+            task_id="t1",
+            handle=handle,
+        )
+
+        assert result == "Work with what you have."
+        assert handle.status == TaskStatus.FAILED
+
+    async def test_config_can_override_contain_errors(self) -> None:
+        """A subagent may opt out of containment while the toolset contains by default."""
+        toolset = _toolset(contain_errors=True)
+        toolset._compiled["worker"].agent = StubAgent(error=ValueError("bad argument"))
+        toolset._compiled["worker"].config["contain_errors"] = False
+
+        with pytest.raises(ValueError, match="bad argument"):
+            await toolset.tools["task"].function(Ctx(), "work", "worker")
+
+    async def test_sync_marks_handle_failed_when_signal_propagates(self) -> None:
+        handle = TaskHandle(task_id="t1", subagent_name="worker", description="d")
+
+        with pytest.raises(CallDeferred):
+            await _run_sync(
+                agent=StubAgent(error=CallDeferred()),
+                config=_config(),
+                description="work",
+                deps=Deps(),
+                task_id="t1",
+                handle=handle,
+            )
+
+        assert handle.status == TaskStatus.FAILED
+        assert handle.error == "propagated"
+
+    @pytest.mark.parametrize("signal", [CallDeferred(), ApprovalRequired()])
+    async def test_background_reports_human_in_the_loop_as_unsupported(
+        self, signal: BaseException
+    ) -> None:
+        """A background task has no caller to hand deferred state back to."""
+        manager = TaskManager(message_bus=InMemoryMessageBus())
+
+        await _run_async(
+            agent=StubAgent(error=signal),
+            config=_config(),
+            description="needs approval",
+            deps=Deps(),
+            task_id="t1",
+            task_manager=manager,
+            message_bus=manager.message_bus,
+        )
+        await asyncio.gather(*manager.tasks.values(), return_exceptions=True)
+
+        handle = manager.handles["t1"]
+        assert handle.status == TaskStatus.FAILED
+        assert "cannot run in the background" in (handle.error or "")
+        assert "mode='sync'" in (handle.error or "")
+
+
+# --------------------------------------------------------------------------- #
+# ask_parent timeout
+# --------------------------------------------------------------------------- #
+
+
+class TestAskTimeout:
+    async def test_timeout_is_configurable(self) -> None:
+        """The 300s wait used to be hardcoded, with no way to shorten it."""
+        manager = TaskManager(message_bus=InMemoryMessageBus())
+        handle = TaskHandle(task_id="t1", subagent_name="worker", description="d")
+        manager.handles["t1"] = handle
+
+        from subagents_pydantic_ai._state import SubAgentState, bind_subagent_state
+        from subagents_pydantic_ai.toolset import _create_ask_parent_toolset
+
+        ask_parent = _create_ask_parent_toolset().tools["ask_parent"]
+        state = SubAgentState(ask_timeout_seconds=0.01, task_manager=manager, task_id="t1")
+
+        with bind_subagent_state(state):
+            result = await ask_parent.function(Ctx(), "which repo?")
+
+        assert result == "Error: Parent did not respond in time"
+        assert handle.status == TaskStatus.RUNNING
+        assert handle.pending_question is None
+
+    def test_non_positive_timeout_is_rejected(self) -> None:
+        with pytest.raises(ValueError, match="ask_timeout_seconds must be > 0"):
+            _toolset(ask_timeout_seconds=0)
+
+
+# --------------------------------------------------------------------------- #
+# Message bus
+# --------------------------------------------------------------------------- #
+
+
+class TestMessageBusHandlers:
+    async def test_failing_handler_is_logged_and_delivery_continues(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A raising observer used to be swallowed by a bare `except: pass`."""
+        bus = InMemoryMessageBus()
+        queue = bus.register_agent("worker")
+        seen: list[AgentMessage] = []
+
+        async def boom(message: AgentMessage) -> None:
+            raise RuntimeError("handler exploded")
+
+        async def record(message: AgentMessage) -> None:
+            seen.append(message)
+
+        bus.add_handler(boom)
+        bus.add_handler(record)
+
+        with caplog.at_level(logging.WARNING):
+            await bus.send(
+                AgentMessage(
+                    type=MessageType.TASK_UPDATE,
+                    sender="parent",
+                    receiver="worker",
+                    payload={"message": "hi"},
+                    task_id="t1",
+                )
+            )
+
+        assert queue.qsize() == 1
+        assert len(seen) == 1
+        assert "handler exploded" in caplog.text

--- a/tests/test_message_bus.py
+++ b/tests/test_message_bus.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pytest
 
@@ -444,7 +444,7 @@ class TestTaskManager:
         await task  # Wait for completion
 
         # Simulate a run_task wrapper having recorded the real outcome.
-        completed_marker = datetime(2020, 1, 1)
+        completed_marker = datetime(2020, 1, 1, tzinfo=timezone.utc)
         handle.status = TaskStatus.COMPLETED
         handle.completed_at = completed_marker
 

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -45,6 +45,8 @@ class TestSystemPrompts:
         assert "ephemeral" in DELEGATE_TOOL_DESCRIPTION.lower()
         assert "create_agent" in DELEGATE_TOOL_DESCRIPTION
         assert "instructions" in DELEGATE_TOOL_DESCRIPTION
+        assert "name" in DELEGATE_TOOL_DESCRIPTION
+        assert "hyphens" in DELEGATE_TOOL_DESCRIPTION
 
 
 class TestGetSubagentSystemPrompt:

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -121,7 +121,11 @@ class TestGetSubagentSystemPrompt:
         assert "cannot ask clarifying questions" not in result
 
     def test_include_dual_mode_true(self):
-        """Test with dual mode prompt included — dual mode moved to tool description."""
+        """`include_dual_mode=True` appends the execution-mode explanation.
+
+        The parameter was previously accepted and ignored, so asking for the
+        section produced a prompt without it.
+        """
         configs = [
             SubAgentConfig(
                 name="worker",
@@ -131,9 +135,23 @@ class TestGetSubagentSystemPrompt:
         ]
         result = get_subagent_system_prompt(configs, include_dual_mode=True)
 
-        # Dual mode explanation now lives in TASK_TOOL_DESCRIPTION, not system prompt
         assert "**worker**" in result
         assert "Does work" in result
+        assert "Sync Mode" in result
+        assert "Async Mode" in result
+
+    def test_dual_mode_excluded_by_default(self):
+        """The default prompt stays lean; modes are covered by the tool description."""
+        configs = [
+            SubAgentConfig(
+                name="worker",
+                description="Does work",
+                instructions="Work hard",
+            )
+        ]
+        result = get_subagent_system_prompt(configs)
+
+        assert "Sync Mode" not in result
 
     def test_include_dual_mode_false(self):
         """Test with dual mode prompt excluded."""

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -48,10 +48,10 @@ class TestSubAgentDepsProtocol:
         assert "agent1" in cloned.subagents
 
     def test_invalid_implementation(self):
-        """Objects without required attributes should not satisfy protocol."""
+        """An object without `clone_for_subagent` does not satisfy the protocol."""
 
         class InvalidDeps:
-            pass
+            subagents: dict[str, Any] = {}
 
         deps = InvalidDeps()
         assert not isinstance(deps, SubAgentDepsProtocol)
@@ -83,3 +83,53 @@ class TestMessageBusProtocol:
 
         bus = InvalidBus()
         assert not isinstance(bus, MessageBusProtocol)
+
+
+class TestDepsWithoutSubagentsField:
+    """A deps class need not carry a `subagents` dict.
+
+    The protocol used to require one, so every application declared a field the
+    library never read.
+    """
+
+    def test_minimal_deps_satisfies_the_protocol(self):
+        @dataclass(frozen=True, slots=True)
+        class MinimalDeps:
+            def clone_for_subagent(self, max_depth: int = 0) -> MinimalDeps:
+                return MinimalDeps()
+
+        deps = MinimalDeps()
+
+        assert isinstance(deps, SubAgentDepsProtocol)
+        assert not hasattr(deps, "subagents")
+
+    async def test_minimal_deps_can_run_a_delegation(self):
+        from pydantic_ai.models.test import TestModel
+
+        from subagents_pydantic_ai import SubAgentConfig, create_subagent_toolset
+
+        @dataclass(frozen=True, slots=True)
+        class MinimalDeps:
+            def clone_for_subagent(self, max_depth: int = 0) -> MinimalDeps:
+                return MinimalDeps()
+
+        @dataclass
+        class Ctx:
+            deps: MinimalDeps
+            run_id: str | None = "run-1"
+
+        toolset = create_subagent_toolset(
+            subagents=[
+                SubAgentConfig(
+                    name="worker",
+                    description="Works",
+                    instructions="You work.",
+                )
+            ],
+            include_general_purpose=False,
+            default_model=TestModel(call_tools=[], custom_output_text="done"),
+        )
+
+        result = await toolset.tools["task"].function(Ctx(deps=MinimalDeps()), "do it", "worker")
+
+        assert "done" in result

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -12,10 +12,9 @@ import asyncio
 from typing import Any
 
 import pytest
-from agent_result_fakes import MockResult
 from pydantic_ai import Agent
 from pydantic_ai.capabilities import AbstractCapability, ProcessEventStream
-from pydantic_ai.exceptions import ModelAPIError, ModelHTTPError
+from pydantic_ai.exceptions import ModelAPIError, ModelHTTPError, ModelRetry
 from pydantic_ai.messages import (
     ModelRequest,
     ModelResponse,
@@ -44,6 +43,7 @@ from subagents_pydantic_ai.types import (
     SubAgentConfig,
     TaskHandle,
 )
+from tests.agent_result_fakes import MockResult
 
 pytestmark = pytest.mark.asyncio
 
@@ -548,7 +548,7 @@ async def test_run_async_completes_when_observability_attrs_missing() -> None:
 
 
 async def test_run_sync_failure_marks_handle_failed() -> None:
-    """`_run_sync`'s failure path marks the handle FAILED and returns an error string."""
+    """`_run_sync`'s failure path marks the handle FAILED and raises `ModelRetry`."""
     agent = ScriptedAgent([{"iter_raise": ModelHTTPError(503, "m")}])
     config = SubAgentConfig(
         name="t",
@@ -560,18 +560,18 @@ async def test_run_sync_failure_marks_handle_failed() -> None:
     )
     handle = TaskHandle(task_id="task-sync-fail", subagent_name="t", description="do it")
 
-    result = await _run_sync(
-        agent=agent,
-        config=config,
-        description="do it",
-        deps=FakeDeps(),
-        task_id="task-sync-fail",
-        handle=handle,
-    )
+    with pytest.raises(ModelRetry, match="crashed"):
+        await _run_sync(
+            agent=agent,
+            config=config,
+            description="do it",
+            deps=FakeDeps(),
+            task_id="task-sync-fail",
+            handle=handle,
+        )
 
     assert handle.status == TaskStatus.FAILED
     assert handle.error is not None
-    assert result.startswith("Error executing task:")
 
 
 async def test_run_async_retries_exhausted_fails() -> None:
@@ -876,7 +876,13 @@ def _make_tool_then_text_model(captured: dict[str, Any]) -> Any:
 
 
 async def test_inject_messages_folded_into_next_model_request() -> None:
-    """Pending steering is appended to the subagent's next model request."""
+    """Steering handed to `inject_messages` mid-run reaches the next model request.
+
+    Delivery goes through `AgentRun.enqueue`, so core decides where the parts
+    land: on the next model request, never spliced between a tool call and its
+    return. This asserts that contract rather than how often the callback is
+    polled, which is an implementation detail of the driving loop.
+    """
     captured: dict[str, Any] = {}
     agent = Agent(_make_tool_then_text_model(captured))
 
@@ -885,11 +891,15 @@ async def test_inject_messages_folded_into_next_model_request() -> None:
         return "dug"
 
     calls = {"n": 0}
+    delivered_once = False
 
     async def inject() -> list[str]:
+        nonlocal delivered_once
         calls["n"] += 1
-        # Nothing before the first request; steering arrives before the second.
-        return ["narrow to packages/sparta/"] if calls["n"] == 2 else []
+        if delivered_once:
+            return []
+        delivered_once = True
+        return ["narrow to packages/sparta/"]
 
     result = await run_with_retry(
         agent,
@@ -901,9 +911,7 @@ async def test_inject_messages_folded_into_next_model_request() -> None:
 
     assert result.output == "done"
     assert "narrow to packages/sparta/" in captured["texts"]
-    # Polled once per model-request node (before request 1 and request 2),
-    # never around the intervening tool-call node.
-    assert calls["n"] == 2
+    assert calls["n"] >= 1
 
 
 async def test_run_async_steering_message_reaches_subagent() -> None:

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 import json
 
-from subagents_pydantic_ai.spec import SubAgentSpec
+import pytest
+from pydantic import ValidationError
+
+from subagents_pydantic_ai.spec import UNSERIALISABLE_CONFIG_KEYS, SubAgentSpec
 from subagents_pydantic_ai.types import SubAgentConfig
 
 
@@ -332,3 +335,69 @@ class TestSubAgentSpecImport:
         import subagents_pydantic_ai
 
         assert "SubAgentSpec" in subagents_pydantic_ai.__all__
+
+
+class TestSpecTracksConfig:
+    """`SubAgentSpec` must mirror every serialisable `SubAgentConfig` key.
+
+    The spec used to cover 11 of the config's keys, so a YAML-defined subagent
+    could not set retries, `on_failure`, or `contain_errors` at all -- silently,
+    because the loader just ignored what it had no field for.
+    """
+
+    def test_every_serialisable_config_key_has_a_spec_field(self):
+        config_keys = set(SubAgentConfig.__annotations__)
+        spec_fields = set(SubAgentSpec.model_fields)
+        serialisable = config_keys - UNSERIALISABLE_CONFIG_KEYS
+
+        assert serialisable - spec_fields == set(), (
+            "SubAgentConfig gained serialisable keys that SubAgentSpec cannot carry. "
+            "Add the field to SubAgentSpec and to _OPTIONAL_FIELDS, or list the key "
+            "in UNSERIALISABLE_CONFIG_KEYS if it holds a live Python object."
+        )
+
+    def test_no_spec_field_is_missing_from_the_config(self):
+        assert set(SubAgentSpec.model_fields) - set(SubAgentConfig.__annotations__) == set()
+
+    def test_round_trip_preserves_every_serialisable_field(self):
+        spec = SubAgentSpec(
+            name="worker",
+            description="Does work",
+            instructions="Work hard.",
+            model="openai:gpt-4.1",
+            can_ask_questions=False,
+            max_questions=2,
+            preferred_mode="async",
+            typical_complexity="complex",
+            typically_needs_context=True,
+            context_files=["/AGENTS.md"],
+            agent_kwargs={"retries": 3},
+            max_retries=5,
+            retry_initial_delay=0.5,
+            retry_max_delay=10.0,
+            retry_backoff_multiplier=3.0,
+            retry_jitter=False,
+            on_failure="Summarise from what you have.",
+            contain_errors=False,
+            extra={"team": "core"},
+        )
+
+        assert SubAgentSpec.from_config(spec.to_config()) == spec
+
+    def test_unset_fields_are_absent_from_the_config(self):
+        config = SubAgentSpec(name="worker").to_config()
+
+        assert set(config) == {"name", "description", "instructions"}
+
+    def test_retry_bounds_are_validated(self):
+        with pytest.raises(ValidationError, match="retry_max_delay"):
+            SubAgentSpec(name="w", retry_initial_delay=10.0, retry_max_delay=1.0)
+
+    def test_negative_max_retries_is_rejected(self):
+        with pytest.raises(ValidationError):
+            SubAgentSpec(name="w", max_retries=-1)
+
+    def test_backoff_multiplier_below_one_is_rejected(self):
+        """A multiplier under 1 shrinks the delay each attempt, which is not backoff."""
+        with pytest.raises(ValidationError):
+            SubAgentSpec(name="w", retry_backoff_multiplier=0.5)

--- a/tests/test_toolset.py
+++ b/tests/test_toolset.py
@@ -4148,11 +4148,60 @@ class TestDelegationConfiguration:
                 ctx,
                 description="Analyze the data",
                 instructions="You are a data analyst.",
+                name="data-analyst",
             )
 
         # No chat trace: a one-shot specialist is unreachable from `task`, so an
         # id the orchestrator cannot redeem would only invite a failed retry.
         assert result == "oneshot result"
+
+    @pytest.mark.asyncio
+    async def test_delegate_names_the_handle(self):
+        """The caller's `name` is what shows up on the task handle.
+
+        A generated `oneshot-{task_id}` told an operator nothing about what the
+        specialist was for.
+        """
+        toolset = create_subagent_toolset(
+            delegation_configuration="persisted_and_oneshot",
+            include_general_purpose=False,
+        )
+        ctx = MockRunContext(deps=MockDeps())
+
+        with patch("subagents_pydantic_ai.dynamic_agent.Agent") as mock_agent_class:
+            mock_agent_class.return_value = FakeAgent(result=MockResult("named result"))
+            start_result = await toolset.tools["delegate"].function(
+                ctx,
+                description="Analyze the data",
+                instructions="You are a data analyst.",
+                name="data-analyst",
+                mode="async",
+            )
+
+        assert "Task ID:" in start_result
+        task_id = start_result.split("Task ID: ")[1].split("\n")[0]
+        handle = toolset.task_manager.get_handle(task_id)
+        assert handle is not None
+        assert handle.subagent_name == "data-analyst"
+
+    @pytest.mark.asyncio
+    async def test_delegate_rejects_an_invalid_name(self):
+        """Names go through the same validation as `create_agent`."""
+        toolset = create_subagent_toolset(
+            delegation_configuration="persisted_and_oneshot",
+            include_general_purpose=False,
+        )
+        ctx = MockRunContext(deps=MockDeps())
+
+        result = await toolset.tools["delegate"].function(
+            ctx,
+            description="Analyze the data",
+            instructions="You are a data analyst.",
+            name="bad name",
+        )
+
+        assert "Error" in result
+        assert "letters, numbers, and hyphens" in result
 
     @pytest.mark.asyncio
     async def test_delegate_does_not_register_agent(self, registry):
@@ -4171,6 +4220,7 @@ class TestDelegationConfiguration:
                 ctx,
                 description="Do work",
                 instructions="You are a worker.",
+                name="worker",
             )
 
         assert result == "oneshot result"
@@ -4201,6 +4251,7 @@ class TestDelegationConfiguration:
                 ctx,
                 description="Do work",
                 instructions="You are a worker.",
+                name="worker",
             )
 
         assert result == "still works"
@@ -4222,6 +4273,7 @@ class TestDelegationConfiguration:
                 ctx,
                 description="Long analysis",
                 instructions="You are an analyst.",
+                name="analyst",
                 mode="async",
             )
 
@@ -4229,7 +4281,7 @@ class TestDelegationConfiguration:
         task_id = start_result.split("Task ID: ")[1].split("\n")[0]
         handle = toolset.task_manager.get_handle(task_id)
         assert handle is not None
-        assert handle.subagent_name.startswith("oneshot-")
+        assert handle.subagent_name == "analyst"
 
         await asyncio.sleep(0.05)
         status = await check_tool.function(ctx, task_id)
@@ -4249,6 +4301,7 @@ class TestDelegationConfiguration:
             ctx,
             description="Do work",
             instructions="You are a worker.",
+            name="worker",
             model="anthropic:claude-3",
         )
 
@@ -4269,6 +4322,7 @@ class TestDelegationConfiguration:
             ctx,
             description="Do work",
             instructions="You are a worker.",
+            name="worker",
             capabilities=["missing"],
         )
 
@@ -4291,6 +4345,7 @@ class TestDelegationConfiguration:
                     ctx,
                     description="Do work",
                     instructions="You are a worker.",
+                    name="worker",
                 )
 
     @pytest.mark.asyncio
@@ -4310,6 +4365,7 @@ class TestDelegationConfiguration:
                 ctx,
                 description="Long analysis",
                 instructions="You are an analyst.",
+                name="analyst",
                 mode="async",
             )
 
@@ -4359,7 +4415,10 @@ class TestDelegationConfiguration:
             )
             for _ in range(3):
                 await toolset.tools["delegate"].function(
-                    ctx, description="unrelated job", instructions="You are a specialist."
+                    ctx,
+                    description="unrelated job",
+                    instructions="You are a specialist.",
+                    name="specialist",
                 )
 
         resumed = await toolset.tools["task"].function(

--- a/tests/test_toolset.py
+++ b/tests/test_toolset.py
@@ -3,22 +3,24 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from decimal import Decimal
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from agent_result_fakes import MockResult, MockResultWithMessages, MockUsage
 from pydantic import BaseModel
 from pydantic_ai import UsageLimits
+from pydantic_ai.exceptions import ApprovalRequired, CallDeferred, ModelRetry, UserError
 from pydantic_ai.models.test import TestModel
 from pydantic_ai.toolsets import FunctionToolset
 from pydantic_graph import End
 
 from subagents_pydantic_ai import DynamicAgentRegistry, SubAgentConfig, create_subagent_toolset
+from subagents_pydantic_ai._state import SubAgentState, current_subagent_state
 from subagents_pydantic_ai.toolset import (
     _capture_result_observability,
     _create_ask_parent_toolset,
@@ -26,17 +28,44 @@ from subagents_pydantic_ai.toolset import (
     _run_async,
     _run_sync,
 )
-from subagents_pydantic_ai.types import CompiledSubAgent, TaskHandle, TaskPriority, TaskStatus
+from subagents_pydantic_ai.types import (
+    CompiledSubAgent,
+    TaskHandle,
+    TaskPriority,
+    TaskStatus,
+    utcnow,
+)
+from tests.agent_result_fakes import MockResult, MockResultWithMessages, MockUsage
 
 
 @dataclass
 class MockDeps:
-    """Mock dependencies for testing."""
+    """Mock dependencies for testing.
+
+    `_subagent_state` is declared so tests can exercise the legacy path where a
+    caller injects the state onto its own deps object. The library itself binds a
+    context variable instead.
+    """
 
     subagents: dict[str, Any] = field(default_factory=dict)
+    _subagent_state: dict[str, Any] | None = None
+    ask_user: Callable[[str, list[str]], Awaitable[str]] | None = None
 
     def clone_for_subagent(self, max_depth: int = 0) -> MockDeps:
         return MockDeps(subagents={} if max_depth <= 0 else self.subagents.copy())
+
+
+@dataclass(frozen=True, slots=True)
+class FrozenDeps:
+    """Deps a caller may legitimately declare immutable.
+
+    The protocol permits it, so the library must not try to write state onto it.
+    """
+
+    subagents: dict[str, Any] = field(default_factory=dict)
+
+    def clone_for_subagent(self, max_depth: int = 0) -> FrozenDeps:
+        return FrozenDeps(subagents={} if max_depth <= 0 else dict(self.subagents))
 
 
 @dataclass
@@ -45,6 +74,7 @@ class MockRunContext:
 
     deps: MockDeps
     _subagent_state: dict[str, Any] | None = None
+    run_id: str | None = None
 
 
 class MockModelResponse:
@@ -104,6 +134,8 @@ class _FakeAgentCM:
         agent = self._agent
         if agent._delay:
             await asyncio.sleep(agent._delay)
+        if agent.on_enter is not None:
+            agent.on_enter()
         if agent._error is not None:
             raise agent._error
         return _FakeRun(agent._result, agent._messages)
@@ -136,6 +168,8 @@ class FakeAgent:
         self._delay = delay
         self._messages = messages or []
         self.iter_calls: list[dict[str, Any]] = []
+        self.on_enter: Callable[[], None] | None = None
+        """Called inside the run, for assertions about state visible to the child."""
 
     def iter(
         self, prompt: Any = None, *, message_history: Any = None, **kwargs: Any
@@ -402,7 +436,7 @@ class TestCreateAskParentToolset:
             return f"User answered: {question}"
 
         deps = MockDeps()
-        deps.ask_user = mock_ask_user  # type: ignore[attr-defined]
+        deps.ask_user = mock_ask_user
         ctx = MockRunContext(deps=deps)
 
         result = await ask_parent_tool.function(ctx, "what color?")
@@ -874,8 +908,12 @@ class TestRunSync:
         assert captured == [new_history]
 
     @pytest.mark.asyncio
-    async def test_run_sync_error(self):
-        """Test sync execution with error."""
+    async def test_run_sync_crash_raises_model_retry(self):
+        """A contained crash reaches the parent as ModelRetry, not a success string.
+
+        Returning `"Error executing task: ..."` presented a failure to the parent
+        model as a completed tool call, so pydantic-ai's retry budget never engaged.
+        """
         mock_agent = FakeAgent(error=Exception("Something went wrong"))
 
         config = SubAgentConfig(
@@ -884,26 +922,103 @@ class TestRunSync:
             instructions="Do test",
         )
 
+        with pytest.raises(ModelRetry) as exc_info:
+            await _run_sync(
+                agent=mock_agent,
+                config=config,
+                description="do the thing",
+                deps=MockDeps(),
+                task_id="task-123",
+            )
+
+        assert "Something went wrong" in str(exc_info.value)
+        assert "'test'" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_run_sync_crash_returns_on_failure_message(self):
+        """`on_failure` turns a crash into a steering message instead of a retry."""
+        mock_agent = FakeAgent(error=Exception("boom"))
+        config = SubAgentConfig(
+            name="test",
+            description="Test agent",
+            instructions="Do test",
+            on_failure="Summarise from what you already have.",
+        )
+        handle = TaskHandle(task_id="task-123", subagent_name="test", description="d")
+
         result = await _run_sync(
             agent=mock_agent,
             config=config,
             description="do the thing",
             deps=MockDeps(),
             task_id="task-123",
+            handle=handle,
         )
 
-        assert "Error" in result
-        assert "Something went wrong" in result
+        assert result == "Summarise from what you already have."
+        assert handle.status == TaskStatus.FAILED
+        assert handle.error == "Exception: boom"
 
     @pytest.mark.asyncio
-    async def test_run_sync_injects_ask_user_into_state(self):
-        """ask_user wires into _subagent_state so ask_parent can resolve it."""
+    async def test_run_sync_propagates_crash_when_not_contained(self):
+        """`contain_errors=False` lets the original exception reach the parent run."""
+        mock_agent = FakeAgent(error=ValueError("bad tool argument"))
+        config = SubAgentConfig(
+            name="test",
+            description="Test agent",
+            instructions="Do test",
+        )
+
+        with pytest.raises(ValueError, match="bad tool argument"):
+            await _run_sync(
+                agent=mock_agent,
+                config=config,
+                description="do the thing",
+                deps=MockDeps(),
+                task_id="task-123",
+                contain_errors=False,
+            )
+
+    @pytest.mark.asyncio
+    async def test_run_sync_propagates_control_flow_signals(self):
+        """Deferred/approval signals must reach the parent run, contained or not.
+
+        Swallowing them turns a suspended run into a tool result the parent reads
+        as a finished task, which breaks deferred tools and approval flows.
+        """
+        for signal in (CallDeferred(), ApprovalRequired(), UserError("misconfigured")):
+            mock_agent = FakeAgent(error=signal)
+            config = SubAgentConfig(
+                name="test",
+                description="Test agent",
+                instructions="Do test",
+            )
+
+            with pytest.raises(type(signal)):
+                await _run_sync(
+                    agent=mock_agent,
+                    config=config,
+                    description="do the thing",
+                    deps=MockDeps(),
+                    task_id="task-123",
+                    contain_errors=True,
+                )
+
+    @pytest.mark.asyncio
+    async def test_run_sync_binds_ask_user_without_touching_deps(self):
+        """`ask_user` reaches `ask_parent` through the context, not the deps object.
+
+        Writing `deps._subagent_state` raised `AttributeError` for a deps class
+        declared `frozen=True` or `slots=True`, both of which the protocol allows.
+        """
         mock_agent = FakeAgent(result=MockResult("done"))
+        captured: list[SubAgentState | None] = []
 
         async def ask_user(question: str) -> str:
             return f"answer: {question}"
 
-        deps = MockDeps()
+        mock_agent.on_enter = lambda: captured.append(current_subagent_state())
+        deps = FrozenDeps()
         config = SubAgentConfig(
             name="test",
             description="Test agent",
@@ -920,14 +1035,15 @@ class TestRunSync:
             ask_user=ask_user,
         )
 
-        captured_deps = mock_agent.iter_calls[0]["deps"]
-        assert captured_deps._subagent_state["ask_callback"] is ask_user
+        assert captured == [
+            SubAgentState(ask_timeout_seconds=300.0, ask_callback=ask_user),
+        ]
+        assert not hasattr(deps, "_subagent_state")
 
     @pytest.mark.asyncio
-    async def test_run_sync_no_ask_user_does_not_touch_deps(self):
-        """Without ask_user, _run_sync must not mutate deps state."""
+    async def test_run_sync_state_does_not_leak_past_the_delegation(self):
+        """The bound state is reset when the delegation returns."""
         mock_agent = FakeAgent(result=MockResult("done"))
-        deps = MockDeps()
         config = SubAgentConfig(
             name="test",
             description="Test agent",
@@ -938,11 +1054,11 @@ class TestRunSync:
             agent=mock_agent,
             config=config,
             description="do the thing",
-            deps=deps,
+            deps=MockDeps(),
             task_id="task-123",
         )
 
-        assert not hasattr(deps, "_subagent_state")
+        assert current_subagent_state() is None
 
 
 class TestResultObservability:
@@ -1275,7 +1391,7 @@ class TestToolsetIntegration:
 
             assert result.startswith("Sync result\n\nChat Trace ID: ")
             handle = mock_run_sync.call_args.kwargs["handle"]
-            assert handle.task_id in toolset.task_manager.handles  # type: ignore[attr-defined]
+            assert handle.task_id in toolset.task_manager.handles
             assert handle.chat_trace_id in result
             assert len(handle.chat_trace_id) == 32
             int(handle.chat_trace_id, 16)
@@ -1566,7 +1682,7 @@ class TestChatTraceLifecycle:
             subagent_name="worker",
             description="old cancelled task",
             status=TaskStatus.CANCELLED,
-            completed_at=datetime(2020, 1, 1),
+            completed_at=datetime(2020, 1, 1, tzinfo=timezone.utc),
         )
         toolset.task_manager.handles["stale-no-usage"] = stale
 
@@ -1646,7 +1762,7 @@ class TestChatTraceLifecycle:
     async def test_check_task_shows_chat_trace_id_only_when_completed(self):
         """check_task must not advertise continuation for unfinished/failed tasks."""
         toolset = create_subagent_toolset(default_model="test")
-        tm = toolset.task_manager  # type: ignore[attr-defined]
+        tm = toolset.task_manager
         handle = TaskHandle(
             task_id="trace-vis",
             subagent_name="worker",
@@ -2624,7 +2740,7 @@ class TestToolsetFunctionsCoverage:
             # Manually inject a long-running task into the task_manager
             from subagents_pydantic_ai.types import TaskHandle
 
-            tm = toolset.task_manager  # type: ignore[attr-defined]
+            tm = toolset.task_manager
 
             async def slow_coro():
                 await asyncio.sleep(100)
@@ -2678,7 +2794,7 @@ class TestToolsetFunctionsCoverage:
 
             from subagents_pydantic_ai.types import TaskHandle
 
-            tm = toolset.task_manager  # type: ignore[attr-defined]
+            tm = toolset.task_manager
 
             async def fast_coro() -> None:
                 await asyncio.sleep(0.01)
@@ -2753,7 +2869,7 @@ class TestToolsetFunctionsCoverage:
 
             from subagents_pydantic_ai.types import TaskHandle
 
-            tm = toolset.task_manager  # type: ignore[attr-defined]
+            tm = toolset.task_manager
 
             async def failing_coro() -> None:
                 await asyncio.sleep(0.01)
@@ -2867,7 +2983,7 @@ class TestToolsetFunctionsCoverage:
             r = await task_tool.function(ctx, "slow work", "worker", "async")
             tid = r.split("Task ID: ")[1].split("\n")[0]
 
-            worker_task = toolset.task_manager.tasks[tid]  # type: ignore[attr-defined]
+            worker_task = toolset.task_manager.tasks[tid]
 
             # Schedule wait_tasks as its own task so we can cancel it from
             # outside (mimicking pydantic-ai sibling-cancel of the tool call).
@@ -2882,7 +2998,7 @@ class TestToolsetFunctionsCoverage:
 
             # And it must finish normally — proves no cascade kill happened.
             await asyncio.wait_for(worker_task, timeout=2.0)
-            handle = toolset.task_manager.get_handle(tid)  # type: ignore[attr-defined]
+            handle = toolset.task_manager.get_handle(tid)
             assert handle is not None
             assert handle.status == TaskStatus.COMPLETED
 
@@ -3164,7 +3280,7 @@ class TestCheckTaskStatusBranches:
             subagent_name="worker",
             description="test task",
             status=TaskStatus.RUNNING,
-            started_at=datetime.now(),  # This is the key - needs started_at set
+            started_at=utcnow(),  # This is the key - needs started_at set
         )
         task_manager.handles["test-task-running"] = handle
 
@@ -3530,7 +3646,7 @@ class TestUsageTracking:
         from subagents_pydantic_ai.types import TaskHandle, TaskStatus
 
         toolset = create_subagent_toolset(default_model="test")
-        tm = toolset.task_manager  # type: ignore[attr-defined]
+        tm = toolset.task_manager
         handle = TaskHandle(
             task_id="test-usage",
             subagent_name="worker",
@@ -3554,7 +3670,7 @@ class TestUsageTracking:
         from subagents_pydantic_ai.types import TaskHandle, TaskStatus
 
         toolset = create_subagent_toolset(default_model="test")
-        tm = toolset.task_manager  # type: ignore[attr-defined]
+        tm = toolset.task_manager
         handle = TaskHandle(
             task_id="test-details",
             subagent_name="worker",
@@ -3578,7 +3694,7 @@ class TestUsageTracking:
         from subagents_pydantic_ai.types import TaskHandle, TaskStatus
 
         toolset = create_subagent_toolset(default_model="test")
-        tm = toolset.task_manager  # type: ignore[attr-defined]
+        tm = toolset.task_manager
         handle = TaskHandle(
             task_id="test-history",
             subagent_name="worker",
@@ -3603,7 +3719,7 @@ class TestUsageTracking:
         from subagents_pydantic_ai.types import TaskHandle, TaskStatus
 
         toolset = create_subagent_toolset(default_model="test")
-        tm = toolset.task_manager  # type: ignore[attr-defined]
+        tm = toolset.task_manager
         handle = TaskHandle(
             task_id="wait-observe",
             subagent_name="worker",
@@ -3647,7 +3763,7 @@ class TestUsageTracking:
         from subagents_pydantic_ai.types import TaskHandle, TaskStatus
 
         toolset = create_subagent_toolset(default_model="test")
-        tm = toolset.task_manager  # type: ignore[attr-defined]
+        tm = toolset.task_manager
 
         h1 = TaskHandle(
             task_id="t1",
@@ -3674,7 +3790,7 @@ class TestUsageTracking:
         tm.handles["t2"] = h2
         tm.handles["t3"] = h3
 
-        totals = toolset.get_total_usage()  # type: ignore[attr-defined]
+        totals = toolset.get_total_usage()
         assert totals["input_tokens"] == 300
         assert totals["output_tokens"] == 150
         assert totals["total_tokens"] == 450
@@ -3686,7 +3802,7 @@ class TestUsageTracking:
         from subagents_pydantic_ai.types import TaskHandle, TaskStatus
 
         toolset = create_subagent_toolset(default_model="test")
-        tm = toolset.task_manager  # type: ignore[attr-defined]
+        tm = toolset.task_manager
         handle = TaskHandle(
             task_id="no-usage",
             subagent_name="worker",
@@ -3836,6 +3952,12 @@ class TestSendMessageToSubagent:
         toolset = self._make_toolset()
         bus = toolset.task_manager.message_bus
         bus.register_agent("subagent-run-1")
+        toolset.task_manager.handles["run-1"] = TaskHandle(
+            task_id="run-1",
+            subagent_name="helper",
+            description="d",
+            status=TaskStatus.RUNNING,
+        )
         tool = toolset.tools["send_message_to_subagent"]
         ctx = MockRunContext(deps=MockDeps())
 
@@ -3888,7 +4010,7 @@ class TestDelegationConfiguration:
     def test_invalid_configuration_is_rejected(self):
         with pytest.raises(ValueError, match="Invalid delegation_configuration"):
             create_subagent_toolset(
-                delegation_configuration="invalid",  # type: ignore[arg-type]
+                delegation_configuration="invalid",
                 include_general_purpose=False,
             )
 
@@ -4164,14 +4286,12 @@ class TestDelegationConfiguration:
 
         with patch("subagents_pydantic_ai.dynamic_agent.Agent") as mock_agent_class:
             mock_agent_class.return_value = FakeAgent(error=Exception("delegate failed"))
-            result = await delegate_tool.function(
-                ctx,
-                description="Do work",
-                instructions="You are a worker.",
-            )
-
-        assert "Error executing task" in result
-        assert "delegate failed" in result
+            with pytest.raises(ModelRetry, match="delegate failed"):
+                await delegate_tool.function(
+                    ctx,
+                    description="Do work",
+                    instructions="You are a worker.",
+                )
 
     @pytest.mark.asyncio
     async def test_delegate_async_reports_no_chat_trace(self):
@@ -4434,7 +4554,7 @@ class TestWaitTasksResultTruncation:
     @staticmethod
     def _toolset_with_result(result: str, /, **kwargs: Any) -> tuple[Any, Any]:
         toolset = create_subagent_toolset(default_model="test", **kwargs)
-        tm = toolset.task_manager  # type: ignore[attr-defined]
+        tm = toolset.task_manager
         tm.handles["long-task"] = TaskHandle(
             task_id="long-task",
             subagent_name="worker",

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -31,10 +31,12 @@ class TestMessageType:
         assert MessageType.CANCEL_REQUEST == "cancel_request"
         assert MessageType.CANCEL_FORCED == "cancel_forced"
 
-    def test_message_type_is_string(self):
-        """MessageType should be usable as a string."""
+    def test_message_type_renders_as_its_value(self):
+        """MessageType renders as its value, not as `ClassName.MEMBER`."""
         assert isinstance(MessageType.TASK_ASSIGNED.value, str)
-        assert str(MessageType.TASK_ASSIGNED) == "MessageType.TASK_ASSIGNED"
+        assert str(MessageType.TASK_ASSIGNED) == "task_assigned"
+        assert f"{MessageType.TASK_ASSIGNED}" == "task_assigned"
+        assert f"{MessageType.TASK_ASSIGNED:>15}" == "  task_assigned"
 
 
 class TestTaskStatus:
@@ -225,10 +227,11 @@ class TestTaskPriority:
         assert TaskPriority.HIGH == "high"
         assert TaskPriority.CRITICAL == "critical"
 
-    def test_priority_is_string(self):
-        """TaskPriority should be usable as a string."""
+    def test_priority_renders_as_its_value(self):
+        """TaskPriority renders as its value, not as `ClassName.MEMBER`."""
         assert isinstance(TaskPriority.NORMAL.value, str)
-        assert str(TaskPriority.NORMAL) == "TaskPriority.NORMAL"
+        assert str(TaskPriority.NORMAL) == "normal"
+        assert f"{TaskPriority.NORMAL}" == "normal"
 
 
 class TestTaskCharacteristics:

--- a/uv.lock
+++ b/uv.lock
@@ -1333,7 +1333,7 @@ wheels = [
 
 [[package]]
 name = "subagents-pydantic-ai"
-version = "0.2.11"
+version = "0.2.12"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -1351,6 +1351,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "types-pyyaml" },
 ]
 docs = [
     { name = "mkdocs" },
@@ -1376,6 +1377,7 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=0.23.0" },
     { name = "pytest-cov", specifier = ">=5.0.0" },
     { name = "ruff", specifier = ">=0.8.0" },
+    { name = "types-pyyaml", specifier = ">=6.0.12.20260724" },
 ]
 docs = [
     { name = "mkdocs", specifier = ">=1.6.0" },
@@ -1445,6 +1447,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20260724"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/6f/a28f44bcd56bebed42b028a2894c79853e2f5e6b5279e633cb3f287a05e7/types_pyyaml-6.0.12.20260724.tar.gz", hash = "sha256:3c1ce1bb73cd5ec02e90390c2b1f00e810d241d8825fd73ff359696839271b6b", size = 17893, upload-time = "2026-07-24T04:58:43.453Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/42/0337fefc615e20ee55d1c8f71b774a9b2b734a04669139c20753b27a2a3a/types_pyyaml-6.0.12.20260724-py3-none-any.whl", hash = "sha256:d57db930a4b2efbc57cf430ec8882765d246929432fa253092f383902329a453", size = 20312, upload-time = "2026-07-24T04:58:42.486Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Correctness, typing and documentation pass over the whole library, plus the two
additions a downstream consumer needed. No public entry point changed its name or
signature: `create_subagent_toolset()`, `SubAgentToolset`, `toolset.task_manager`,
`toolset._compile_subagent` and every export still work. pydantic-deep's full suite
(2781 tests) passes against this branch unchanged.

The starting point was a suite reporting **100% branch coverage** while `check_task`
told every model `Status: TaskStatus.WAITING_FOR_ANSWER` on Python 3.11+. Coverage
proved the lines executed, not that they produced the right answer. Most of what
follows came from asking what a caller or a model actually receives.

## Defects fixed

**Model-facing output**
- Statuses, priorities and message types render as their values again. Python 3.11
  changed `Enum.__format__` for mixin enums, so `check_task`, `list_active_tasks`
  and `wait_tasks` leaked the member name. Behaviour also differed across the
  supported matrix: 3.10 rendered `completed`, 3.11+ `TaskStatus.COMPLETED`.
- Cancelling an already-finished task reported "not found", inviting the model to
  conclude the work was lost. It now reports the status and points at `check_task`.

**Error contract**
- Control-flow signals (`CallDeferred`, `ApprovalRequired`, `Skip*`), `UserError`
  and a shared `UsageLimitExceeded` now propagate. `except Exception` swallowed
  them and returned a string the parent read as a finished task, which meant
  deferred tools and human approval **could not work inside a subagent at all**.
- A failed delegation reaches the parent as `ModelRetry` instead of a successful
  tool result whose text starts with `Error`, so pydantic-ai's retry budget
  engages. This is the one intentional behaviour change.
- New `contain_errors` (toolset / capability / config) and `on_failure` (config)
  make containment and steering explicit.

**Task lifecycle**
- Background tasks no longer outlive their parent run. Nothing cancelled the
  `asyncio.Task`, so it kept executing against torn-down deps and one blocked in
  `ask_parent` waited out the full timeout. `SubAgentCapability` now cancels its
  run's tasks in a `wrap_run` finalizer, backed by `TaskManager.cancel_all()`.
- Tasks are scoped to the run that started them. One toolset instance is typically
  built per agent and shared by every run it serves, so any run could previously
  read, answer, steer or cancel another run's task by id.
- `TaskHandle.finish()` makes the first terminal transition win, closing the race
  where `hard_cancel` overwrote a completed task's result during its `finally` —
  a task in that window is still not `asyncio.Task.done()`.
- `ask_timeout_seconds` replaces a hardcoded 300-second wait.
- Timestamps are timezone-aware UTC, so elapsed time and eviction order survive a
  DST transition.

**Coupling to pydantic-ai**
- Steering goes through `AgentRun.enqueue` instead of splicing `UserPromptPart`s
  into a graph node's request, so core decides placement and a message can never
  land between a tool call and its return.
- `retry.py`'s `_drive_run` is realigned with `Agent.run`, which drains the wrapped
  event stream unconditionally; the copy drained only when there was no handler and
  had already drifted.
- The library no longer writes `_subagent_state` onto the caller's deps object,
  which raised `AttributeError` for a `frozen=True` or `slots=True` deps class —
  both permitted by the protocol and never warned against. State is a typed
  `SubAgentState` in a `ContextVar`.
- 409 Conflict and 425 Too Early are no longer retried as transient.
- A message-bus handler that raised was swallowed by `except Exception: pass`.
- `asyncio.get_event_loop()` inside a coroutine is now `get_running_loop()`.

## Added

- `SubAgentToolset.answer_task()` / `steer_task()` — the Python halves of the
  `answer_subagent` and `send_message_to_subagent` tools, for an application that
  drives delegation itself. The tools delegate to them, so there is one
  implementation. **pydantic-deep's team feature needs these** (see below).
- `SubAgentSpec` covers the whole serialisable config. It mirrored 11 keys, so a
  YAML-defined subagent could not set `max_retries`, any `retry_*` option,
  `agent_kwargs`, `on_failure` or `contain_errors`, and the loader silently ignored
  what it had no field for. It validates the retry bounds now, including a
  `retry_max_delay` below `retry_initial_delay` — which pinned every retry to the
  cap instead of backing off. A drift test fails if the config gains a serialisable
  key the spec cannot carry.
- `TaskHandle.finish()` / `is_finished`, `TERMINAL_STATUSES`, `utcnow`,
  `TaskManager.cancel_all()` / `resolve_answer()`.

## Removed

- `SubAgentDepsProtocol.subagents`. The library never read it, so every application
  carried a dict for nothing. Dropping a protocol requirement only widens what
  satisfies it, so existing deps classes are unaffected.

## Quality

`SubAgentToolset` is a real `FunctionToolset` subclass. It was an alias for
`create_subagent_toolset`, whose result had `task_manager`, `message_history_store`
and `get_total_usage` attached afterwards behind three `type: ignore` comments —
and `toolset.task_manager` is a load-bearing downstream contract, so that was
public API expressed as three type errors.

`SubAgentConfig` enforces `name`, `description` and `instructions`, which were
documented as required but optional to the type checker while the library indexed
them directly.

| Check | Before | After |
|---|---|---|
| tests | 396 | 1084 |
| coverage | 100% branch | 100% branch |
| pyright | `basic`, 12 rules off, tests excluded | **strict**, no `type: ignore` in `src/` |
| mypy strict | `src/` only in CI | `src/` **and** `tests/` in CI |
| ruff complexity | 30, one `noqa: C901` | 15, none |
| `make typecheck-mypy` | 583 errors — target broken | green |

`make typecheck-mypy` never worked: the `module = "tests.*"` override could not
match, because `tests/` had no `__init__.py` and mypy named the modules
`test_toolset` rather than `tests.test_toolset`.

`toolset.py` is split into `_execution`, `_observability`, `_chat_trace` and
`_state`, with the historical names still importable from
`subagents_pydantic_ai.toolset` — pydantic-deep imports `_compile_subagent` and
patches `subagents_pydantic_ai.toolset.Agent`.

## Docs

New pages: observability, steering, chat traces, failure handling, usage limits.
New API reference pages: registry, message bus, retry, spec, dynamic agents. Plus a
changelog page.

The whole observability surface — per-task cost from genai-prices, token usage,
tool-call counts, W3C traceparent — was implemented and had **zero** mentions in
the docs.

`tests/test_docs.py` checks every snippet in `docs/` and `README.md` for syntax and
API drift. It immediately found 28 real problems, including a
`general_purpose_config` parameter that never existed and the nesting guide's claim
that `max_nesting_depth` enforces a depth limit — it does not; the gate is what
`toolsets_factory` hands the child.

`AGENTS.md` and `agent_docs/` record the invariants, the writing style, and the
pydantic-deep coupling to check before changing a signature.

## Known coupling left in place

`retry.py` still mirrors the driving loop inside `Agent.run` using private names,
because there is no public way to drive a run with a custom step while keeping
event streaming. The module docstring records it, a drift test pins the observable
contract, and `agent_docs/core-boundary.md` says the fix is a public primitive in
core rather than more copying.

## Downstream

Requires a companion PR in pydantic-deep (`fix(teams): repair subagent wiring`),
which depends on `answer_task` / `steer_task` and on `SubAgentToolset.registry`
being reachable. Release this first.
