### PR TITLE
fix: close the eight defects found in the 2026-08-01 audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,66 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.13] - 2026-08-01
+
+Findings from a full-repo audit. Every defect here sat in a place the tooling
+could not see: a disagreement between two call sites that each read fine alone, or
+documentation describing behaviour the code did not implement.
+
+### Fixed
+
+- **Any run could cancel another run's live background task.** `soft_cancel_task`
+  and `hard_cancel_task` guarded with `handle is None and task_id not in tasks` —
+  and a foreign task that is actually running satisfies exactly that, so the guard
+  fell through and the cancel went ahead. `check_task` hid the same task correctly,
+  so one tenant on a shared agent could kill another tenant's work with an id it
+  read out of tool output. A handle scoped to another run now reads exactly like a
+  missing one. The existing isolation test passed against the defect because its
+  fixture registered no `asyncio.Task`; the new test starts a real background
+  delegation and asserts the task survives.
+- **`check_task` told the model a cancelled task was still running.** `CANCELLED`
+  and `RETRYING` fell through to an elapsed-time line computed from `started_at`,
+  so a task cancelled two hours ago reported `Running for: 7200.0s` and never said
+  why it stopped. Both statuses now report their outcome.
+- **A retried attempt got a fresh usage allowance.** `run_with_retry` forwarded
+  `usage_limits` into every attempt but no `usage`, so `Agent.iter` built a new
+  `RunUsage` each time while the replayed history genuinely re-spent the tokens —
+  with the default `max_retries=3` the real ceiling was 4× what the caller
+  configured. Attempts now share one tally, which is what
+  `docs/advanced/usage-limits.md` already promised.
+- **`retry_count` was always 0 for sync delegations.** `_run_sync` passed no
+  `on_retry`, and `sync` is the default mode for both `task` and `delegate`, so the
+  handle field documented for spotting a flaky gateway reported nothing from the
+  path most delegations take.
+- **`SubAgentCapability` could not reach `ask_user`.** It forwarded 15 of
+  `create_subagent_toolset`'s parameters and silently dropped `ask_user`,
+  `max_chat_traces`, and `max_task_handles`. `ask_user` is the only channel a
+  sync-mode subagent has for `ask_parent`, so the advertised question feature was
+  off by construction on the primary entry point — and the error text pointed at a
+  remedy the capability did not accept. All three are now fields, and a parity test
+  fails if the toolset grows an argument the capability cannot reach.
+- **`max_agents=0` meant unlimited.** `DynamicAgentRegistry.register` tested
+  `if self.max_agents and ...`, reading `0` as falsy. It now tests `is not None`, so
+  `0` rejects every registration and `None` stays unlimited. `max_agents`,
+  `max_chat_traces`, and `max_task_handles` are validated at construction:
+  `max_agents >= 0`, and the two stores `>= 1` since a store that cannot hold one
+  entry evicts everything before it can be read back.
+- **`validate_agent_name` enforced a wider rule than it stated.** `str.isalnum` is
+  Unicode-aware, so Cyrillic and fullwidth-digit names passed an allow-list the
+  model was told read "letters, numbers, and hyphens", while `café` was rejected
+  only over a combining accent. It is an explicit ASCII match now.
+- **Sync and async recorded different errors for the same exhausted budget.**
+  `handle.error` was `usage limit exceeded` in sync mode and
+  `UsageLimitExceeded: ...` in background mode, so telemetry had to know how a
+  delegation had been dispatched. Both modes now write `usage limit exceeded: ...`.
+
+### Changed
+
+- `docs/advanced/errors.md` no longer claims a per-task usage budget is a soft
+  outcome, or distinguishes a "shared" `UsageLimitExceeded`: the library never
+  hands a child run the parent's tally, so every subagent budget is its own. It now
+  states what actually differs — sync propagates, background contains.
+
 ## [0.2.12] - 2026-08-01
 
 Correctness, typing, and documentation pass over the whole library. Every public

--- a/docs/advanced/errors.md
+++ b/docs/advanced/errors.md
@@ -31,7 +31,7 @@ agent = Agent(
 |---|---|
 | Control-flow signal (`CallDeferred`, `ApprovalRequired`, `Skip*`) | Propagates unchanged |
 | `UserError` | Propagates unchanged |
-| Shared `UsageLimitExceeded` | Propagates unchanged |
+| `UsageLimitExceeded` | Propagates unchanged from a sync delegation |
 | Anything else | `ModelRetry`, or the subagent's `on_failure` message |
 
 ### Control-flow signals propagate
@@ -53,11 +53,19 @@ bug you need to see.
     `mode="sync"` instead. Approval and deferred tools need synchronous
     delegation.
 
-### Usage limits depend on whose budget it was
+### Usage limits stop the parent run
 
-A `UsageLimitExceeded` on a budget shared with the parent means the whole agent
-tree is out of budget, so it propagates. See [Usage limits](usage-limits.md) for
-per-task budgets, which are a soft outcome instead.
+A `UsageLimitExceeded` from a sync delegation propagates. Every subagent budget is
+its own -- the library never hands a child run the parent's usage tally -- but a
+subagent that ran out of budget is still the parent's problem: reporting it as one
+delegation's bad luck lets the parent keep fanning out into an empty wallet. See
+[Usage limits](usage-limits.md).
+
+A background delegation contains it, like every other failure in background mode:
+the tool result (the task id) went back to the parent long ago, so the only outcome
+left to deliver is a status transition. Both modes record the same
+`usage limit exceeded: ...` marker on `handle.error`, so telemetry does not have to
+know which mode a delegation ran in.
 
 ### Everything else becomes a retry
 

--- a/docs/advanced/questions.md
+++ b/docs/advanced/questions.md
@@ -100,14 +100,14 @@ If sync mode is used without an `ask_user` callback, `ask_parent` returns a
 configuration error to the subagent. Either provide the callback, drop
 `can_ask_questions` on that subagent, or switch to async mode.
 
-!!! warning "`SubAgentCapability` does not wire `ask_user`"
-    [`SubAgentCapability`][subagents_pydantic_ai.capability.SubAgentCapability]
-    builds its toolset without passing an `ask_user` callback, so sync-mode
-    questions (`can_ask_questions=True`) cannot be answered through the
-    capability. If you need sync-mode `ask_parent`, build the toolset directly
-    with [`create_subagent_toolset`][subagents_pydantic_ai.toolset.create_subagent_toolset]
-    and pass `ask_user=...` (or use async mode, where the parent answers via
-    `answer_subagent`).
+[`SubAgentCapability`][subagents_pydantic_ai.capability.SubAgentCapability] takes
+the same argument and forwards it:
+
+```python
+from subagents_pydantic_ai import SubAgentCapability
+
+cap = SubAgentCapability(subagents=subagents, ask_user=ask_user)
+```
 
 ### Async Mode
 

--- a/docs/advanced/usage-limits.md
+++ b/docs/advanced/usage-limits.md
@@ -1,8 +1,8 @@
 # Usage limits
 
 A fan-out of subagents can burn a lot of tokens before the parent notices. Usage
-limits put a ceiling on every delegated run, either one shared budget or a fresh
-one per task.
+limits put a ceiling on every delegated run, either the same ceiling everywhere
+or one computed per task.
 
 ```python
 from pydantic_ai import Agent, UsageLimits
@@ -66,17 +66,18 @@ def limits_for(ctx: RunContext[MyDeps], config: SubAgentConfig) -> UsageLimits |
 
 ## What happens when a limit is hit
 
-`UsageLimitExceeded` propagates to the parent run rather than being contained. A
-budget shared with the parent means the whole agent tree is out of budget, and
-quietly reporting that as one subagent's bad luck would let the parent keep
-delegating into an empty wallet.
+`UsageLimitExceeded` from a sync delegation propagates to the parent run rather
+than being contained. Quietly reporting an exhausted budget as one subagent's bad
+luck would let the parent keep delegating into an empty wallet. A background
+delegation has no caller left to raise into, so it records the failure on the
+handle instead -- see [Failure handling](errors.md).
 
-The task handle records `failed`, so your telemetry sees which delegation hit the
-ceiling:
+Either way the task handle records `failed`, so your telemetry sees which
+delegation hit the ceiling:
 
 ```python
 for handle in toolset.task_manager.list_handles():
-    if handle.error == "usage limit exceeded":
+    if handle.error is not None and handle.error.startswith("usage limit exceeded"):
         print(f"{handle.subagent_name} ran out of budget")
 ```
 

--- a/docs/concepts/capability.md
+++ b/docs/concepts/capability.md
@@ -118,16 +118,12 @@ When you pass `SubAgentCapability` to an agent, pydantic-ai calls:
    listing available subagents with their descriptions (via
    [`get_subagent_system_prompt`][subagents_pydantic_ai.prompts.get_subagent_system_prompt])
 
-!!! warning "Sync-mode questions are not supported via the capability"
-    `SubAgentCapability` builds its toolset without an `ask_user` callback (see
-    [`capability.py`][subagents_pydantic_ai.capability.SubAgentCapability]). A
-    subagent that calls `ask_parent` in **sync** mode therefore gets a
-    configuration error. To support sync-mode questions
-    (`can_ask_questions=True`), build the toolset directly with
-    [`create_subagent_toolset`][subagents_pydantic_ai.toolset.create_subagent_toolset]
-    and pass `ask_user=...`. In **async** mode the parent answers via
-    `answer_subagent`, which works with the capability. See
-    [Parent-Child Questions](../advanced/questions.md).
+!!! note "Sync-mode questions need `ask_user`"
+    In **sync** mode the parent's run loop is blocked inside the delegation, so a
+    subagent's `ask_parent` cannot be answered with `answer_subagent`. Pass
+    `ask_user=...` to the capability to give it a channel; without one, a subagent
+    that asks gets a configuration error back. In **async** mode the parent answers
+    via `answer_subagent`. See [Parent-Child Questions](../advanced/questions.md).
 
 ## Observability
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -91,7 +91,7 @@ agent = Agent("openai:gpt-4.1", toolsets=[toolset])
 | [**Steering**](advanced/steering.md) | Redirect a running task without losing its progress |
 | [**Cancellation**](advanced/cancellation.md) | Cooperative (clean boundary) or immediate |
 | [**Retries**](advanced/retries.md) | Transient gateway failures resume from accumulated history |
-| [**Usage limits**](advanced/usage-limits.md) | One shared budget, or a fresh budget per task |
+| [**Usage limits**](advanced/usage-limits.md) | One ceiling for every delegation, or one computed per task |
 | [**Observability**](concepts/observability.md) | Per-task cost, tokens, tool-call counts, traceparent |
 | [**Dynamic agents**](advanced/dynamic-agents.md) | Create specialists at runtime, reusable or one-shot |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "subagents-pydantic-ai"
-version = "0.2.12"
+version = "0.2.13"
 description = "Subagent toolset for pydantic-ai with dual-mode execution and dynamic agent creation"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/subagents_pydantic_ai/_execution.py
+++ b/src/subagents_pydantic_ai/_execution.py
@@ -12,8 +12,10 @@ needs:
   they always propagate.
 - **`UserError`** is a setup mistake no retry can fix. Reporting it to the model as
   a task failure hides it, so it always propagates.
-- **`UsageLimitExceeded`** on a budget shared with the parent means the whole agent
-  tree is out of budget, so it propagates too.
+- **`UsageLimitExceeded`** means a delegation ran out of budget. Every subagent
+  budget is its own -- a child run never gets the parent's usage tally -- but
+  containing it would let the parent keep fanning out into an empty wallet, so it
+  propagates too.
 - **Everything else** is a failure the parent can react to. It reaches the parent as
   `ModelRetry`, which engages pydantic-ai's retry budget, rather than as a normal
   tool result whose text happens to start with `Error`.
@@ -50,7 +52,7 @@ from subagents_pydantic_ai._observability import (
 from subagents_pydantic_ai._state import SubAgentState, bind_subagent_state
 from subagents_pydantic_ai.message_bus import InMemoryMessageBus, TaskManager
 from subagents_pydantic_ai.prompts import get_task_instructions_prompt
-from subagents_pydantic_ai.retry import RetryConfig, run_with_retry
+from subagents_pydantic_ai.retry import OnRetryCallback, RetryConfig, run_with_retry
 from subagents_pydantic_ai.types import (
     AskUserCallback,
     MessageType,
@@ -78,6 +80,13 @@ _ALWAYS_PROPAGATE: tuple[type[Exception], ...] = (
 
 Containing the first five breaks the agent graph -- they are deferred/approval
 control flow, not failures. `UserError` is a configuration bug that no retry fixes.
+"""
+
+_USAGE_LIMIT_MARKER = "usage limit exceeded"
+"""Prefix both modes record on `handle.error` when a budget runs out.
+
+Sync propagates the exception and background mode contains it, but telemetry
+should not have to know which mode a delegation ran in to spot the same outcome.
 """
 
 _HUMAN_IN_THE_LOOP: tuple[type[Exception], ...] = (CallDeferred, ApprovalRequired)
@@ -154,7 +163,7 @@ async def _run_sync(
 
     Raises:
         ModelRetry: When the subagent failed and no `on_failure` message is set.
-        Exception: Control-flow signals, `UserError`, a shared `UsageLimitExceeded`,
+        Exception: Control-flow signals, `UserError`, `UsageLimitExceeded`,
             and -- when `contain_errors` is false -- any other subagent exception.
     """
     prompt = _task_prompt(config, description)
@@ -174,12 +183,13 @@ async def _run_sync(
                 prompt,
                 run_kwargs=run_kwargs,
                 retry=RetryConfig.from_config(config),
+                on_retry=_retry_recorder(handle),
             )
     except _ALWAYS_PROPAGATE:
         _fail(handle, "propagated")
         raise
-    except UsageLimitExceeded:
-        _fail(handle, "usage limit exceeded")
+    except UsageLimitExceeded as exc:
+        _fail(handle, f"{_USAGE_LIMIT_MARKER}: {exc}")
         raise
     except (ModelRetry, UnexpectedModelBehavior) as exc:
         return _degrade(handle, config, task_id, exc, crashed=False)
@@ -197,6 +207,24 @@ async def _run_sync(
         # can never flip a successful run to FAILED.
         capture_observability(handle, result)
     return output
+
+
+def _retry_recorder(handle: TaskHandle | None) -> OnRetryCallback | None:
+    """Record each transient retry on the handle, or `None` when there is no handle.
+
+    Both execution modes need this: `retry_count` is documented without a mode
+    qualifier, and `sync` is the default, so leaving it out there reported zero
+    retries for the path most delegations take.
+    """
+    if handle is None:
+        return None
+
+    def on_retry(attempt: int, exc: BaseException, delay: float) -> None:
+        handle.status = TaskStatus.RETRYING
+        handle.retry_count = attempt
+        handle.error = f"Transient error (retry {attempt}): {exc}"
+
+    return on_retry
 
 
 def _fail(handle: TaskHandle | None, error: str) -> None:
@@ -305,11 +333,6 @@ async def _run_async(
     )
 
     async def run_task() -> None:
-        def on_retry(attempt: int, exc: BaseException, delay: float) -> None:
-            handle.status = TaskStatus.RETRYING
-            handle.retry_count = attempt
-            handle.error = f"Transient error (retry {attempt}): {exc}"
-
         def cancel_requested() -> bool:
             # Cooperative cancellation: `soft_cancel` sets this event and the run
             # loop polls it between graph nodes, so the subagent stops at a clean
@@ -327,7 +350,7 @@ async def _run_async(
                     prompt,
                     run_kwargs=run_kwargs,
                     retry=RetryConfig.from_config(config),
-                    on_retry=on_retry,
+                    on_retry=_retry_recorder(handle),
                     cancel_check=cancel_requested,
                     inject_messages=pending_steering,
                 )
@@ -337,6 +360,8 @@ async def _run_async(
         except asyncio.CancelledError:
             handle.finish(TaskStatus.CANCELLED, error="Task was cancelled")
             raise
+        except UsageLimitExceeded as exc:
+            handle.finish(TaskStatus.FAILED, error=f"{_USAGE_LIMIT_MARKER}: {exc}")
         except _HUMAN_IN_THE_LOOP as exc:
             handle.finish(
                 TaskStatus.FAILED,

--- a/src/subagents_pydantic_ai/capability.py
+++ b/src/subagents_pydantic_ai/capability.py
@@ -40,6 +40,7 @@ from subagents_pydantic_ai.prompts import get_subagent_system_prompt
 from subagents_pydantic_ai.registry import DynamicAgentRegistry
 from subagents_pydantic_ai.toolset import SubAgentToolset, create_subagent_toolset
 from subagents_pydantic_ai.types import (
+    AskUserCallback,
     DelegationConfiguration,
     SubAgentConfig,
     ToolsetFactory,
@@ -93,10 +94,17 @@ class SubAgentCapability(AbstractCapability[Any]):
         max_agents: Maximum number of persistent dynamic agents, applied to the
             registry the toolset creates for `create_agent`. Ignored when
             `registry` is set — that registry keeps its own `max_agents`.
+        max_chat_traces: Maximum number of subagent conversations kept for
+            `chat_trace_id` continuation, least-recently-used evicted first.
+        max_task_handles: Maximum number of finished task handles retained for
+            status queries. Evicted usage still counts toward `get_total_usage()`.
         max_result_chars: Character budget for a completed task's result in the
             `wait_tasks` listing. Truncated results carry an explicit marker
             pointing at `check_task`, which always returns the full text. Pass
             `None` to never truncate.
+        ask_user: Callback backing `ask_parent`. Required for a sync-mode subagent
+            to ask its parent anything: the parent's run loop is blocked inside the
+            delegation, so `answer_subagent` cannot be reached until it returns.
 
     Raises:
         ValueError: From `create_subagent_toolset` when the configuration is
@@ -118,7 +126,10 @@ class SubAgentCapability(AbstractCapability[Any]):
     capabilities_map: dict[str, CapabilityFactory] | None = None
     default_agent_factory: AgentFactory | None = None
     max_agents: int = 10
+    max_chat_traces: int = 100
+    max_task_handles: int = 500
     max_result_chars: int | None = 2000
+    ask_user: AskUserCallback | None = None
     ask_timeout_seconds: float = DEFAULT_ASK_TIMEOUT_SECONDS
     contain_errors: bool = True
     _toolset: SubAgentToolset = field(init=False, repr=False)
@@ -140,7 +151,10 @@ class SubAgentCapability(AbstractCapability[Any]):
             capabilities_map=self.capabilities_map,
             default_agent_factory=self.default_agent_factory,
             max_agents=self.max_agents,
+            max_chat_traces=self.max_chat_traces,
+            max_task_handles=self.max_task_handles,
             max_result_chars=self.max_result_chars,
+            ask_user=self.ask_user,
             ask_timeout_seconds=self.ask_timeout_seconds,
             contain_errors=self.contain_errors,
         )

--- a/src/subagents_pydantic_ai/dynamic_agent.py
+++ b/src/subagents_pydantic_ai/dynamic_agent.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from collections.abc import Callable
 from typing import Any
 
@@ -26,9 +27,17 @@ collide on the tool name.
 """
 
 
+_AGENT_NAME_PATTERN = re.compile(r"[A-Za-z0-9-]+")
+"""ASCII only, matching what the `create_agent` tool descriptions promise the model.
+
+`str.isalnum` is Unicode-aware, so it admitted Cyrillic and fullwidth digits while
+rejecting `café` — an allow-list a model can silently exceed is not one.
+"""
+
+
 def validate_agent_name(name: str) -> str | None:
     """Return an error message when the agent name is invalid."""
-    if not name or not all(c.isalnum() or c == "-" for c in name):
+    if not _AGENT_NAME_PATTERN.fullmatch(name):
         return "Error: Name must contain only letters, numbers, and hyphens"
     return None
 

--- a/src/subagents_pydantic_ai/registry.py
+++ b/src/subagents_pydantic_ai/registry.py
@@ -22,7 +22,8 @@ class DynamicAgentRegistry:
     Attributes:
         agents: Dictionary mapping agent names to Agent instances.
         configs: Dictionary mapping agent names to their configurations.
-        max_agents: Maximum number of agents allowed (optional limit).
+        max_agents: Maximum number of agents allowed. `None` means unlimited; `0`
+            rejects every registration.
 
     Example:
         ```python
@@ -66,7 +67,9 @@ class DynamicAgentRegistry:
         if name in self.agents:
             raise ValueError(f"Agent '{name}' already exists")
 
-        if self.max_agents and len(self.agents) >= self.max_agents:
+        # `is not None`, not truthiness: `max_agents=0` is the obvious way to write
+        # "no dynamic agents" and must not read as "unlimited". `None` is unlimited.
+        if self.max_agents is not None and len(self.agents) >= self.max_agents:
             raise ValueError(
                 f"Maximum number of agents ({self.max_agents}) reached. "
                 f"Remove an agent before creating a new one."

--- a/src/subagents_pydantic_ai/retry.py
+++ b/src/subagents_pydantic_ai/retry.py
@@ -3,7 +3,9 @@
 Wraps a subagent's execution so transient failures (gateway 5xx, rate
 limits, connection drops from proxies such as LiteLLM) are retried with
 exponential backoff. Each retry resumes with the full accumulated message
-history, so partial progress (model turns, tool calls) is not lost.
+history, so partial progress (model turns, tool calls) is not lost. All
+attempts share one `RunUsage`, so a configured `usage_limits` caps the
+whole delegation rather than being granted again per attempt.
 
 The retry path deliberately uses :meth:`Agent.iter` rather than
 `capture_run_messages()` to recover the failed run's messages, because
@@ -47,6 +49,7 @@ from typing import Any
 
 from pydantic_ai import _agent_graph
 from pydantic_ai.exceptions import ModelAPIError, ModelHTTPError
+from pydantic_ai.usage import RunUsage
 from pydantic_graph import End
 
 from subagents_pydantic_ai.types import SubAgentConfig
@@ -277,7 +280,8 @@ async def run_with_retry(
             inside `message_history`.
         run_kwargs: Extra kwargs forwarded to `agent.run`/`agent.iter`
             (`deps`, `toolsets`, ...). A caller-supplied
-            `message_history` is honoured as the starting history.
+            `message_history` is honoured as the starting history, and a
+            caller-supplied `usage` as the tally every attempt adds to.
         retry: The resolved retry policy.
         on_retry: Optional callback invoked before each retry sleep with
             `(attempt, exc, delay)`. May be sync or async.
@@ -322,12 +326,21 @@ async def run_with_retry(
         return await agent.run(user_prompt, **run_kwargs)
 
     message_history = run_kwargs.pop("message_history", None)
+    # One tally across every attempt. `Agent.iter` builds a fresh `RunUsage` when
+    # `usage` is `None`, so without this each attempt starts counting from zero
+    # while the replayed history genuinely re-spends the tokens -- and a
+    # `usage_limits` ceiling would be granted again per attempt, multiplying the
+    # caller's budget by `max_retries + 1`.
+    caller_usage: RunUsage | None = run_kwargs.pop("usage", None)
+    run_usage = caller_usage if caller_usage is not None else RunUsage()
     prompt = user_prompt
     attempt = 0
     while True:
         run = None
         try:
-            async with agent.iter(prompt, message_history=message_history, **run_kwargs) as run:
+            async with agent.iter(
+                prompt, message_history=message_history, usage=run_usage, **run_kwargs
+            ) as run:
                 await _drive_run(agent, run, handler, cancel_check, inject_messages)
             return run.result
         except Exception as exc:

--- a/src/subagents_pydantic_ai/toolset.py
+++ b/src/subagents_pydantic_ai/toolset.py
@@ -268,7 +268,8 @@ def _create_ask_parent_toolset() -> FunctionToolset[Any]:
 
         return (
             "Error: Cannot ask parent - no communication channel configured. "
-            "In sync mode, pass `ask_user=...` to create_subagent_toolset(), "
+            "In sync mode, pass `ask_user=...` to create_subagent_toolset() or "
+            "SubAgentCapability(), "
             "or use mode='async' so the parent can respond via answer_subagent()."
         )
 
@@ -339,6 +340,9 @@ class SubAgentToolset(FunctionToolset[Any]):
             default_agent_factory=default_agent_factory,
             max_result_chars=max_result_chars,
             ask_timeout_seconds=ask_timeout_seconds,
+            max_agents=max_agents,
+            max_chat_traces=max_chat_traces,
+            max_task_handles=max_task_handles,
         )
 
         self._descriptions = descriptions or {}
@@ -385,6 +389,9 @@ class SubAgentToolset(FunctionToolset[Any]):
         default_agent_factory: AgentFactory | None,
         max_result_chars: int | None,
         ask_timeout_seconds: float,
+        max_agents: int,
+        max_chat_traces: int,
+        max_task_handles: int,
     ) -> None:
         """Reject a configuration that contradicts itself.
 
@@ -439,6 +446,19 @@ class SubAgentToolset(FunctionToolset[Any]):
 
         if ask_timeout_seconds <= 0:
             raise ValueError(f"ask_timeout_seconds must be > 0, got {ask_timeout_seconds}")
+
+        # A store that cannot hold one entry is not a small store, it is a broken
+        # one: every save is evicted before it can be read back, so continuing a
+        # chat trace or checking a finished task always fails.
+        for name, bound in (
+            ("max_chat_traces", max_chat_traces),
+            ("max_task_handles", max_task_handles),
+        ):
+            if bound < 1:
+                raise ValueError(f"{name} must be >= 1, got {bound}")
+
+        if max_agents < 0:
+            raise ValueError(f"max_agents must be >= 0, got {max_agents}")
 
     @property
     def _expose_create_agent(self) -> bool:
@@ -579,6 +599,22 @@ class SubAgentToolset(FunctionToolset[Any]):
         if handle.parent_run_id is not None and handle.parent_run_id != ctx.run_id:
             return None
         return handle
+
+    def _cancel_reads_as_missing(self, task_id: str, handle: TaskHandle | None) -> bool:
+        """Whether a cancel for `task_id` must read as "not found" to this run.
+
+        `handle` is the run-scoped lookup, so `None` means the id is either unknown
+        or owned by another run -- and the two have to be indistinguishable. Task
+        ids are short and appear in tool output, so admitting a foreign id here
+        lets one run kill another run's work. A task with no handle at all has no
+        owner to compare against and stays cancellable.
+        """
+        if handle is not None:
+            return False
+        return (
+            self.task_manager.get_handle(task_id) is not None
+            or task_id not in self.task_manager.tasks
+        )
 
     async def cancel_run_tasks(self, run_id: str | None) -> None:
         """Cancel every background task started by `run_id` and await its cleanup."""
@@ -991,6 +1027,13 @@ class SubAgentToolset(FunctionToolset[Any]):
             status_info.append(f"Error: {handle.error}")
         elif handle.status == TaskStatus.WAITING_FOR_ANSWER:
             status_info.append(f"Question: {handle.pending_question}")
+        elif handle.is_finished:
+            # CANCELLED. Every terminal status has to report its outcome here;
+            # falling through to the elapsed-time line would tell the model a
+            # finished task is still running, and hide why it stopped.
+            status_info.append(f"Outcome: {handle.error}")
+        elif handle.status == TaskStatus.RETRYING:
+            status_info.append(f"Retry {handle.retry_count}: {handle.error}")
         elif handle.started_at:
             elapsed = (utcnow() - handle.started_at).total_seconds()
             status_info.append(f"Running for: {elapsed:.1f}s")
@@ -1147,7 +1190,7 @@ class SubAgentToolset(FunctionToolset[Any]):
             task_id: The task to cancel.
         """
         handle = self._handle_for(ctx, task_id)
-        if handle is None and task_id not in self.task_manager.tasks:
+        if self._cancel_reads_as_missing(task_id, handle):
             return f"Error: Task '{task_id}' not found"
         if await self.task_manager.soft_cancel(task_id):
             return f"Cancellation requested for task '{task_id}'"
@@ -1165,7 +1208,7 @@ class SubAgentToolset(FunctionToolset[Any]):
             task_id: The task to cancel.
         """
         handle = self._handle_for(ctx, task_id)
-        if handle is None and task_id not in self.task_manager.tasks:
+        if self._cancel_reads_as_missing(task_id, handle):
             return f"Error: Task '{task_id}' not found"
         if await self.task_manager.hard_cancel(task_id):
             return f"Task '{task_id}' has been cancelled"
@@ -1262,8 +1305,9 @@ def create_subagent_toolset(
             Do not attach an `ask_parent` toolset in the factory; the toolset
             injects it at run time when needed.
         max_agents: Maximum number of persistent dynamic agents, applied to the
-            registry this toolset creates for `create_agent`. Ignored when
-            `registry` is passed — that registry keeps its own `max_agents`.
+            registry this toolset creates for `create_agent`. `0` rejects every
+            `create_agent` call. Ignored when `registry` is passed — that registry
+            keeps its own `max_agents`.
         max_chat_traces: Maximum number of chat traces (subagent conversations)
             whose message history is kept in memory for continuation via
             `chat_trace_id`. Least-recently-used traces are evicted past this
@@ -1284,16 +1328,17 @@ def create_subagent_toolset(
         contain_errors: Whether an unexpected subagent crash is converted into a
             `ModelRetry` for the parent instead of aborting the parent run.
             Defaults to `True`. Control-flow signals (`CallDeferred`,
-            `ApprovalRequired`, `Skip*`), `UserError`, and a shared
-            `UsageLimitExceeded` always propagate. Individual subagents can
+            `ApprovalRequired`, `Skip*`), `UserError`, and `UsageLimitExceeded`
+            always propagate. Individual subagents can
             override this with `SubAgentConfig["contain_errors"]`.
 
     Returns:
         A `SubAgentToolset` configured with the subagent management tools.
 
     Raises:
-        ValueError: If `max_result_chars` is negative; if `ask_timeout_seconds` is
-            not positive; if `delegation_configuration` is invalid; if
+        ValueError: If `max_result_chars` or `max_agents` is negative; if
+            `ask_timeout_seconds` is not positive; if `max_chat_traces` or
+            `max_task_handles` is below 1; if `delegation_configuration` is invalid; if
             `"oneshot_only"` is combined with `subagents` or a `registry`, neither
             of which is reachable without `task`; or if a mode exposing neither
             `create_agent` nor `delegate` is given `allowed_models`,

--- a/src/subagents_pydantic_ai/types.py
+++ b/src/subagents_pydantic_ai/types.py
@@ -282,8 +282,8 @@ class SubAgentConfig(_SubAgentConfigRequired, total=False):
             parent, logged with its traceback, so one failed delegation cannot
             abort the whole run. Set `False` to let crashes propagate.
             Control-flow signals (`CallDeferred`, `ApprovalRequired`,
-            `Skip*`), `UserError`, and a shared `UsageLimitExceeded` always
-            propagate regardless.
+            `Skip*`), `UserError`, and `UsageLimitExceeded` always propagate
+            regardless.
 
     Example with builtin_tools:
         ```python

--- a/tests/test_capability.py
+++ b/tests/test_capability.py
@@ -10,7 +10,19 @@ import pytest
 from pydantic_ai import Agent, UsageLimits
 from pydantic_ai.models.test import TestModel
 
-from subagents_pydantic_ai import DynamicAgentRegistry, SubAgentCapability, SubAgentConfig
+from subagents_pydantic_ai import (
+    DynamicAgentRegistry,
+    SubAgentCapability,
+    SubAgentConfig,
+    create_subagent_toolset,
+)
+
+_CAPABILITY_OWNED_ARGUMENTS = frozenset({"id"})
+"""Toolset arguments the capability sets itself rather than exposing.
+
+`id` is fixed to `"subagents"` so the capability's toolset is addressable by a
+stable name.
+"""
 
 _MODEL = TestModel()
 
@@ -226,3 +238,45 @@ class TestSubAgentCapabilityIntegration:
         assert "task" in tool_names
         assert "check_task" in tool_names
         assert "list_active_tasks" in tool_names
+
+
+class TestCapabilityTracksToolset:
+    """`SubAgentCapability` must forward every `create_subagent_toolset` argument.
+
+    It used to omit three. `ask_user` was the one that bit: it is the only channel
+    a sync-mode subagent has for `ask_parent`, and sync is the default mode, so the
+    documented "a subagent can ask its parent" feature was off by construction on
+    the primary entry point -- and the error text told the user to pass an argument
+    the capability did not accept.
+    """
+
+    def test_every_toolset_argument_is_reachable(self):
+        import inspect
+
+        toolset_args = set(inspect.signature(create_subagent_toolset).parameters)
+        capability_fields = {
+            name for name in SubAgentCapability.__dataclass_fields__ if not name.startswith("_")
+        }
+
+        assert toolset_args - capability_fields - _CAPABILITY_OWNED_ARGUMENTS == set(), (
+            "create_subagent_toolset gained an argument SubAgentCapability cannot "
+            "reach. Add a field and forward it in __post_init__, or list it in "
+            "_CAPABILITY_OWNED_ARGUMENTS if the capability must own its value."
+        )
+
+    def test_ask_user_is_forwarded(self):
+        """A sync-mode subagent's only route to its parent has to survive the hop."""
+
+        async def ask(question: str) -> str:
+            return "42"
+
+        cap = _cap(ask_user=ask)
+
+        assert cap.get_toolset()._ask_user is ask
+
+    def test_memory_bounds_are_forwarded(self):
+        cap = _cap(max_chat_traces=7, max_task_handles=9)
+        toolset = cap.get_toolset()
+
+        assert toolset._chat_traces._max_traces == 7
+        assert toolset._max_task_handles == 9

--- a/tests/test_dynamic_agent.py
+++ b/tests/test_dynamic_agent.py
@@ -37,6 +37,16 @@ class TestDynamicAgentValidation:
         assert validate_agent_name("") is not None
         assert validate_agent_name("bad name") is not None
 
+    @pytest.mark.parametrize("name", ["агент", "１２３", "café", "agent⁵"])
+    def test_validate_agent_name_is_ascii_only(self, name: str):
+        """The rule the `create_agent` tool descriptions state, actually enforced.
+
+        `str.isalnum` is Unicode-aware, so Cyrillic and fullwidth-digit names sailed
+        through an allow-list the model was told read "letters, numbers, and
+        hyphens", while `café` was rejected only over a combining accent.
+        """
+        assert validate_agent_name(name) is not None
+
     def test_validate_model(self):
         assert validate_model("openai:gpt-4", ["openai:gpt-4"]) is None
         assert validate_model("anthropic:claude", ["openai:gpt-4"]) is not None

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -174,6 +174,48 @@ class TestStatusRendering:
         assert "Status: retrying" in result
         assert "TaskStatus." not in result
 
+    async def test_check_task_reports_a_retry_instead_of_elapsed_time(self) -> None:
+        """`RETRYING` used to fall through to the elapsed line, hiding the error."""
+        toolset = _toolset()
+        toolset.task_manager.handles["t1"] = TaskHandle(
+            task_id="t1",
+            subagent_name="worker",
+            description="dig",
+            status=TaskStatus.RETRYING,
+            started_at=utcnow(),
+            retry_count=2,
+            error="Transient error (retry 2): 503",
+        )
+
+        result = await toolset.tools["check_task"].function(Ctx(), "t1")
+
+        assert "Retry 2: Transient error (retry 2): 503" in result
+        assert "Running for:" not in result
+
+    async def test_check_task_reports_a_cancellation_instead_of_elapsed_time(self) -> None:
+        """A cancelled task used to report a running-time that grew forever.
+
+        The elapsed line read `utcnow() - started_at`, so a task cancelled hours
+        ago told the orchestrating model it was still running, and never said why
+        it stopped.
+        """
+        toolset = _toolset()
+        handle = TaskHandle(
+            task_id="t1",
+            subagent_name="worker",
+            description="dig",
+            status=TaskStatus.RUNNING,
+            started_at=utcnow(),
+        )
+        handle.finish(TaskStatus.CANCELLED, error="Task was cancelled")
+        toolset.task_manager.handles["t1"] = handle
+
+        result = await toolset.tools["check_task"].function(Ctx(), "t1")
+
+        assert "Status: cancelled" in result
+        assert "Outcome: Task was cancelled" in result
+        assert "Running for:" not in result
+
     async def test_list_active_tasks_renders_status_value(self) -> None:
         toolset = _toolset()
         block = asyncio.Event()
@@ -293,6 +335,85 @@ class TestRunIsolation:
 
         assert soft == "Error: Task 'foreign' not found"
         assert hard == "Error: Task 'foreign' not found"
+
+    async def test_cancel_refuses_another_runs_live_task(self) -> None:
+        """The cancel tools once admitted a foreign task that was actually running.
+
+        `_foreign_handle` registers no `asyncio.Task`, so the guard those tools used
+        (`handle is None and task_id not in tasks`) short-circuited on the missing
+        task and the test above passed without ever reaching the broken case. With a
+        live task registered, the guard fell through and the cancel went ahead.
+        """
+        toolset = _toolset()
+        block = asyncio.Event()
+        await _run_async(
+            agent=StubAgent(block=block),
+            config=_config(),
+            description="theirs",
+            deps=Deps(),
+            task_id="victim",
+            task_manager=toolset.task_manager,
+            message_bus=toolset.task_manager.message_bus,
+            parent_run_id="run-a",
+        )
+
+        soft = await toolset.tools["soft_cancel_task"].function(Ctx(run_id="run-b"), "victim")
+        hard = await toolset.tools["hard_cancel_task"].function(Ctx(run_id="run-b"), "victim")
+
+        assert soft == "Error: Task 'victim' not found"
+        assert hard == "Error: Task 'victim' not found"
+        # The returned string alone passed against the broken code too: assert the
+        # task actually survived.
+        assert toolset.task_manager.handles["victim"].status == TaskStatus.RUNNING
+
+        block.set()
+        await asyncio.gather(*toolset.task_manager.tasks.values(), return_exceptions=True)
+
+    async def test_cancel_allows_own_live_task(self) -> None:
+        """Scoping a cancel must not stop the run that owns the task."""
+        toolset = _toolset()
+        block = asyncio.Event()
+        await _run_async(
+            agent=StubAgent(block=block),
+            config=_config(),
+            description="mine",
+            deps=Deps(),
+            task_id="mine",
+            task_manager=toolset.task_manager,
+            message_bus=toolset.task_manager.message_bus,
+            parent_run_id="run-a",
+        )
+
+        result = await toolset.tools["hard_cancel_task"].function(Ctx(run_id="run-a"), "mine")
+
+        assert result == "Task 'mine' has been cancelled"
+        assert toolset.task_manager.handles["mine"].status == TaskStatus.CANCELLED
+
+        block.set()
+        await asyncio.gather(*toolset.task_manager.tasks.values(), return_exceptions=True)
+
+    async def test_cancel_allows_an_unowned_task(self) -> None:
+        """A task with no handle has no owner to compare against, so it stays cancellable."""
+        toolset = _toolset()
+        block = asyncio.Event()
+        await _run_async(
+            agent=StubAgent(block=block),
+            config=_config(),
+            description="orphan",
+            deps=Deps(),
+            task_id="orphan",
+            task_manager=toolset.task_manager,
+            message_bus=toolset.task_manager.message_bus,
+            parent_run_id="run-a",
+        )
+        del toolset.task_manager.handles["orphan"]
+
+        result = await toolset.tools["soft_cancel_task"].function(Ctx(run_id="run-b"), "orphan")
+
+        assert result == "Cancellation requested for task 'orphan'"
+
+        block.set()
+        await asyncio.gather(*toolset.task_manager.tasks.values(), return_exceptions=True)
 
     async def test_list_active_tasks_omits_another_runs_task(self) -> None:
         toolset = _toolset()
@@ -626,8 +747,8 @@ class TestTaskCancellation:
 
 
 class TestErrorContract:
-    async def test_sync_propagates_shared_usage_limit(self) -> None:
-        """A shared budget being exhausted means the whole tree is out of budget."""
+    async def test_sync_propagates_usage_limit(self) -> None:
+        """Containing an exhausted budget would let the parent keep delegating."""
         handle = TaskHandle(task_id="t1", subagent_name="worker", description="d")
 
         with pytest.raises(UsageLimitExceeded):
@@ -642,7 +763,29 @@ class TestErrorContract:
             )
 
         assert handle.status == TaskStatus.FAILED
-        assert handle.error == "usage limit exceeded"
+        assert handle.error == "usage limit exceeded: out of tokens"
+
+    async def test_async_records_usage_limit_under_the_same_marker(self) -> None:
+        """A background delegation has no caller to raise into, so it records instead.
+
+        The two modes used to write different strings for the same outcome, which
+        made telemetry depend on knowing how a delegation had been dispatched.
+        """
+        toolset = _toolset()
+        await _run_async(
+            agent=StubAgent(error=UsageLimitExceeded("out of tokens")),
+            config=_config(),
+            description="work",
+            deps=Deps(),
+            task_id="t1",
+            task_manager=toolset.task_manager,
+            message_bus=toolset.task_manager.message_bus,
+        )
+        await asyncio.gather(*toolset.task_manager.tasks.values(), return_exceptions=True)
+
+        handle = toolset.task_manager.handles["t1"]
+        assert handle.status == TaskStatus.FAILED
+        assert handle.error == "usage limit exceeded: out of tokens"
 
     @pytest.mark.parametrize(
         "error",

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -247,3 +247,13 @@ class TestDynamicAgentRegistry:
             registry.register(config, MockAgent(f"agent-{i}"))
 
         assert registry.count() == 100
+
+
+class TestZeroMaxAgents:
+    def test_zero_max_agents_rejects_every_registration(self):
+        """`max_agents=0` used to read as falsy, so it imposed no cap at all."""
+        registry = DynamicAgentRegistry(max_agents=0)
+        config = SubAgentConfig(name="agent-0", description="Agent 0", instructions="Do stuff")
+
+        with pytest.raises(ValueError, match=r"Maximum number of agents \(0\) reached"):
+            registry.register(config, MockAgent("agent-0"))

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -12,9 +12,14 @@ import asyncio
 from typing import Any
 
 import pytest
-from pydantic_ai import Agent
+from pydantic_ai import Agent, UsageLimits
 from pydantic_ai.capabilities import AbstractCapability, ProcessEventStream
-from pydantic_ai.exceptions import ModelAPIError, ModelHTTPError, ModelRetry
+from pydantic_ai.exceptions import (
+    ModelAPIError,
+    ModelHTTPError,
+    ModelRetry,
+    UsageLimitExceeded,
+)
 from pydantic_ai.messages import (
     ModelRequest,
     ModelResponse,
@@ -25,6 +30,7 @@ from pydantic_ai.messages import (
 from pydantic_ai.models.function import AgentInfo, FunctionModel
 from pydantic_ai.models.test import TestModel
 from pydantic_ai.run import AgentRunResult
+from pydantic_ai.usage import RunUsage
 from pydantic_graph import End
 
 from subagents_pydantic_ai import (
@@ -975,3 +981,175 @@ async def test_run_async_steering_message_reaches_subagent() -> None:
     handle = tm.get_handle("steer-1")
     assert handle is not None
     assert handle.status == TaskStatus.COMPLETED
+
+
+# --------------------------------------------------------------------------- #
+# Usage budget across attempts
+# --------------------------------------------------------------------------- #
+
+
+def _flaky_multi_request_model() -> Any:
+    """FunctionModel spending two counted model requests either side of a 503.
+
+    Request 1 calls the `dig` tool, request 2 fails transiently, and the retried
+    attempt spends two more requests (another tool call, then the answer). Failed
+    requests are not counted against the budget, so the whole task costs three
+    counted requests -- one on the first attempt and two on the second.
+    """
+    calls = {"n": 0}
+
+    def model_fn(messages: list[Any], info: AgentInfo) -> Any:
+        calls["n"] += 1
+        if calls["n"] == 2:
+            raise ModelHTTPError(503, "gateway")
+        if calls["n"] == 4:
+            return ModelResponse(parts=[TextPart(content="done")])
+        return ModelResponse(parts=[ToolCallPart(tool_name="dig", args={})])
+
+    return FunctionModel(model_fn)
+
+
+async def test_retries_share_one_usage_budget() -> None:
+    """A retried attempt must not be granted the caller's allowance again.
+
+    `Agent.iter` builds a fresh `RunUsage` when no `usage` is passed, so every
+    attempt used to start counting from zero while the replayed history genuinely
+    re-spent the tokens -- a `request_limit` of 2 with the default `max_retries=3`
+    permitted up to 8 counted requests. With one shared tally the second attempt
+    inherits the one request already spent and stops at the ceiling.
+    """
+    agent = Agent(_flaky_multi_request_model())
+
+    @agent.tool_plain
+    def dig() -> str:
+        return "dug"
+
+    with pytest.raises(UsageLimitExceeded):
+        await run_with_retry(
+            agent,
+            "search the repo",
+            run_kwargs={"usage_limits": UsageLimits(request_limit=2)},
+            retry=RetryConfig(max_retries=1, jitter=False),
+            sleep=_no_sleep,
+        )
+
+
+async def test_caller_supplied_usage_is_the_shared_tally() -> None:
+    """A caller tracking usage itself keeps that object across every attempt."""
+    agent = Agent(TestModel(custom_output_text="done"))
+    usage = RunUsage()
+
+    result = await run_with_retry(
+        agent,
+        "go",
+        run_kwargs={"usage": usage},
+        retry=RetryConfig(max_retries=1, jitter=False),
+        sleep=_no_sleep,
+    )
+
+    assert result.output == "done"
+    assert usage.requests == 1
+
+
+# --------------------------------------------------------------------------- #
+# _run_sync integration — handle reflects retries
+# --------------------------------------------------------------------------- #
+
+
+async def test_run_sync_records_retries_on_the_handle() -> None:
+    """`retry_count` is documented without a mode qualifier, and `sync` is default.
+
+    `_run_sync` passed no `on_retry`, so every synchronous delegation reported
+    zero retries however flaky the gateway had been.
+    """
+    agent = ScriptedAgent(
+        [
+            {"iter_raise": ModelHTTPError(503, "m"), "messages": [{"x": 1}]},
+            {"result": MockResult("finished", usage=None)},
+        ]
+    )
+    config = SubAgentConfig(
+        name="t",
+        description="d",
+        instructions="i",
+        max_retries=2,
+        retry_initial_delay=0.0,
+        retry_jitter=False,
+    )
+    handle = TaskHandle(task_id="task-sr", subagent_name="t", description="d")
+
+    result = await _run_sync(
+        agent=agent,
+        config=config,
+        description="do it",
+        deps=FakeDeps(),
+        task_id="task-sr",
+        handle=handle,
+    )
+
+    assert result == "finished"
+    assert handle.status == TaskStatus.COMPLETED
+    assert handle.retry_count == 1
+    # Transient error message cleared after eventual success.
+    assert handle.error is None
+
+
+async def test_run_sync_records_retries_before_failing() -> None:
+    """An exhausted retry budget leaves the attempt count and the last error."""
+    agent = ScriptedAgent(
+        [
+            {"iter_raise": ModelHTTPError(503, "m")},
+            {"iter_raise": ModelHTTPError(503, "m")},
+        ]
+    )
+    config = SubAgentConfig(
+        name="t",
+        description="d",
+        instructions="i",
+        max_retries=1,
+        retry_initial_delay=0.0,
+        retry_jitter=False,
+    )
+    handle = TaskHandle(task_id="task-sf", subagent_name="t", description="d")
+
+    with pytest.raises(ModelRetry):
+        await _run_sync(
+            agent=agent,
+            config=config,
+            description="do it",
+            deps=FakeDeps(),
+            task_id="task-sf",
+            handle=handle,
+        )
+
+    assert handle.status == TaskStatus.FAILED
+    assert handle.retry_count == 1
+    assert "503" in str(handle.error)
+
+
+async def test_run_sync_without_a_handle_still_retries() -> None:
+    """No handle means nothing to record on, not a reason to skip the retry."""
+    agent = ScriptedAgent(
+        [
+            {"iter_raise": ModelHTTPError(503, "m")},
+            {"result": MockResult("finished", usage=None)},
+        ]
+    )
+    config = SubAgentConfig(
+        name="t",
+        description="d",
+        instructions="i",
+        max_retries=1,
+        retry_initial_delay=0.0,
+        retry_jitter=False,
+    )
+
+    result = await _run_sync(
+        agent=agent,
+        config=config,
+        description="do it",
+        deps=FakeDeps(),
+        task_id="task-nh",
+    )
+
+    assert result == "finished"

--- a/tests/test_toolset.py
+++ b/tests/test_toolset.py
@@ -4690,3 +4690,37 @@ class TestWaitTasksResultTruncation:
     def test_negative_budget_is_rejected(self):
         with pytest.raises(ValueError, match="max_result_chars must be >= 0 or None, got -1"):
             create_subagent_toolset(default_model="test", max_result_chars=-1)
+
+
+class TestMemoryBoundsValidation:
+    """The bounds arguments used to be accepted unchecked.
+
+    `max_agents=0` is the obvious way to write "no dynamic agents" and did the
+    opposite -- the registry read it as falsy and imposed no cap at all. A zero or
+    negative store bound was accepted too, evicting every entry before anything
+    could read it back.
+    """
+
+    @pytest.mark.parametrize("bound", ["max_chat_traces", "max_task_handles"])
+    @pytest.mark.parametrize("value", [0, -5])
+    def test_a_store_that_cannot_hold_an_entry_is_rejected(self, bound: str, value: int):
+        with pytest.raises(ValueError, match=f"{bound} must be >= 1, got {value}"):
+            create_subagent_toolset(default_model="test", **{bound: value})
+
+    def test_negative_max_agents_is_rejected(self):
+        with pytest.raises(ValueError, match="max_agents must be >= 0, got -1"):
+            create_subagent_toolset(default_model="test", max_agents=-1)
+
+    def test_zero_max_agents_allows_no_dynamic_agents(self):
+        """The cap that used to read as unlimited."""
+        toolset = create_subagent_toolset(
+            default_model="test",
+            max_agents=0,
+            delegation_configuration="persisted",
+        )
+
+        with pytest.raises(ValueError, match="Maximum number of agents \\(0\\) reached"):
+            toolset.registry.register(
+                SubAgentConfig(name="a", description="d", instructions="i"),
+                object(),
+            )

--- a/uv.lock
+++ b/uv.lock
@@ -1333,7 +1333,7 @@ wheels = [
 
 [[package]]
 name = "subagents-pydantic-ai"
-version = "0.2.12"
+version = "0.2.13"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
Full-repo audit of `162e8d0` turned up eight defects. All of them sat where the
tooling cannot look: two call sites that each read fine alone but disagree, or
documentation describing behaviour the code does not implement. Lint, pyright
strict, mypy strict and 100% branch coverage were green before and after.

## The one that matters

`soft_cancel_task` and `hard_cancel_task` guarded with
`handle is None and task_id not in self.task_manager.tasks`. A live task owned by
another run satisfies exactly that, so the guard fell through and the cancel went
ahead — while `check_task` correctly reported the same task as missing:

```
before: status=running  owner=run-a
check_task  as run-b -> "Error: Task 'victim' not found"
soft_cancel as run-b -> "Cancellation requested for task 'victim'"
after:  status=cancelled
```

Task ids are 8 hex chars and appear in tool output, so on a server sharing one
agent across users, one tenant could stop another's work. A handle scoped to
another run now reads exactly like a missing one; a task with no handle at all has
no owner to compare against and stays cancellable.

`tests/test_lifecycle.py::TestRunIsolation::test_cancel_refuses_another_runs_task`
passed against the defect because `_foreign_handle` registers no `asyncio.Task`,
so the guard short-circuited before reaching the broken branch. The replacement
starts a real background delegation and asserts `handle.status` is still `RUNNING`
afterwards — asserting only the returned string passed against the old code too.

## The rest

| ID | Fix |
|---|---|
| AUD-002 | `check_task` reported a forever-growing `Running for:` for `CANCELLED` and `RETRYING`; both now report their outcome |
| AUD-003 | Retries shared no usage tally, so `usage_limits` was granted again per attempt (4× the configured ceiling at the default `max_retries=3`) |
| AUD-004 | `retry_count` stayed `0` for sync delegations — the default mode |
| AUD-005 | `SubAgentCapability` could not reach `ask_user`, `max_chat_traces`, `max_task_handles` |
| AUD-006 | `errors.md` promised a per-task budget was "a soft outcome"; there is no per-task-vs-shared distinction in the code |
| AUD-007 | `max_agents=0` read as unlimited; the three bounds arguments are validated now |
| AUD-008 | `validate_agent_name` promised ASCII and enforced Unicode |

`ask_user` is the AUD-005 one that bit: it is the only channel a sync-mode
subagent has for `ask_parent`, sync is the default mode, and every docs example
uses the capability — so the advertised question feature was off by construction
on the primary entry point, and the error text named a remedy the user could not
reach. A parity test now fails when `create_subagent_toolset` grows an argument
`SubAgentCapability` does not forward.

## Verification

- `make all` — 1114 tests (28 new), 100.00% branch coverage, ruff + pyright strict
  + mypy strict clean
- `uv run mkdocs build --strict`
- pydantic-deep against this branch: 2785 passed (the capability gained fields and
  the toolset gained validation, so the cross-repo check applies)
- AUD-001, AUD-003 and AUD-004's tests were each run against the unfixed source
  and fail there