### PR TITLE
fix: close the eight defects found re-auditing 0.2.13

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,9 +53,10 @@ has its own sub-agent capability worth comparing against.
 ## Coding standards
 
 - Python 3.10+, supported through 3.13.
-- **pyright strict** and **mypy strict**, over `src/` and `tests/`. No
-  `# type: ignore` in `src/`. The per-rule exemptions in `pyproject.toml` each carry
-  a comment saying why.
+- **pyright strict** and **mypy strict**, over `src/` and `tests/`. Exactly one
+  `# type: ignore` in `src/` (`spec.py`, writing a dynamic `TypedDict` key) -- adding
+  a second needs a reason in review. The per-rule exemptions in `pyproject.toml`
+  each carry a comment saying why.
 - **ruff**: line-length 100, double quotes, `max-complexity = 15`, no per-function
   `noqa`. If a function trips the ceiling, split it.
 - **100% branch coverage** is the merge gate. Coverage is necessary, not

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,69 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.14] - 2026-08-01
+
+A re-audit of 0.2.13, verifying each of that release's fixes and then sweeping the
+areas the audit behind it had listed as uncovered. The fixes in 0.2.13 were all
+correct; they had been applied to the sites the report named rather than to the
+class of defect, and the class was still open elsewhere.
+
+Three entries change observable behaviour, in each case to match what the docs
+already promised: `can_ask_questions=False` now removes `ask_parent`,
+`max_questions` is enforced, and a `chat_trace_id` from another run is refused.
+Code relying on the old behaviour was relying on a defect, but it is worth knowing
+about before upgrading.
+
+### Fixed
+
+- **`can_ask_questions=False` did not disable `ask_parent`.** The flag was honoured
+  when `_execute` injects the tool for a runtime specialist and ignored when
+  `_compile_subagent` builds a configured subagent, so the tool was attached
+  regardless. In background mode that is a stall, not a cosmetic issue: the
+  subagent parks the task in `WAITING_FOR_ANSWER` for the full
+  `ask_timeout_seconds` (300 s by default) while the parent's own instructions
+  describe that subagent as one that *cannot ask clarifying questions*, so nothing
+  ever calls `answer_subagent`. The tool is now attached only when the flag allows
+  it.
+- **Any run could resume any other run's chat trace.** Task handles record
+  `parent_run_id` and every tool that takes a `task_id` is scoped, but traces were
+  keyed by `(subagent_name, chat_trace_id)` with no owner at all — so a run passing
+  an id it had seen got the other run's whole conversation replayed into its
+  subagent's `message_history`. `ChatTraceStore` now records the claiming run, and a
+  foreign trace reads exactly like an unknown one. The check runs before the
+  "already has a running task" branch, which would otherwise confirm the id exists.
+  A trace claimed without a `run_id` stays open, matching `_handle_for`.
+- **`wait_tasks` awaited another run's live task.** It filtered its listing through
+  `_handle_for` and built the set it awaited from `task_manager.tasks` directly, so
+  a foreign id blocked the caller for the whole `timeout` and then reported "not
+  found". The wall-clock difference against a genuinely unknown id (which returns
+  instantly) was an existence oracle over foreign task ids. The isolation test
+  missed it for the same reason the 0.2.13 cancel defect shipped: its fixture
+  registers a handle with no `asyncio.Task`, so the await never happened.
+- **The unknown-subagent error enumerated every run's dynamic agents.** One registry
+  is shared by every run of an agent, and `create_agent` names are model-authored
+  and describe the work, so the list told one tenant what the others were doing. The
+  error names the configured subagents and says dynamic agents exist without naming
+  them. The registry itself stays shared — a persistent agent is meant to outlive
+  one run.
+- **`wait_tasks` counted a missing task as still running.** `still running` was
+  `total - finished`, so the same message said `not found` and `1 still running`
+  about one id and the orchestrator kept polling something that will never resolve.
+  Missing ids are now counted and reported separately.
+- **`max_questions` was prompt text, documented as a limit.** It reached the
+  subagent only as a sentence in its task prompt, which a model is free to ignore —
+  and each ignored question costs up to `ask_timeout_seconds`. It is now a counter
+  on the delegation: past the limit, `ask_parent` returns immediately without
+  waiting for the parent. The budget is per delegation, so a task continuing a chat
+  trace gets a full allowance.
+- **`check_task`'s tool description named four of seven statuses.** 0.2.13 added the
+  `cancelled` and `retrying` renderings without updating the description that
+  enumerated the statuses a model should expect. It now describes what each terminal
+  state returns instead of listing values that drift.
+- **`typing-extensions` was imported but not declared.** `types.py` imports it at
+  module scope for `NotRequired`/`TypedDict`; it was only present transitively via
+  `pydantic`. Now a direct dependency.
+
 ## [0.2.13] - 2026-08-01
 
 Findings from a full-repo audit. Every defect here sat in a place the tooling

--- a/agent_docs/delegation-contracts.md
+++ b/agent_docs/delegation-contracts.md
@@ -46,8 +46,27 @@ serves. Handles record `parent_run_id`, and `_handle_for` refuses ids from anoth
 run. Any new tool that takes a `task_id` must go through it; a direct
 `task_manager.get_handle` lookup reintroduces cross-run access.
 
+Scoping the *output* is not enough. `wait_tasks` filtered its listing correctly and
+built the set it awaited straight off `task_manager.tasks`, so a foreign id still
+blocked the caller for the full timeout -- which is also an existence oracle,
+because a genuinely unknown id returns instantly. Anything that waits on, cancels,
+or otherwise touches a task must be scoped, not only what gets rendered.
+
 `TaskManager.handles` stays globally readable on purpose -- external monitoring
 depends on it.
+
+## Chat traces are scoped the same way
+
+`ChatTraceStore` records the run that first claimed a trace (`mark_active`), and
+`owned_by` gates the lookup in `_execute`. A trace holds a whole subagent
+conversation, so an unscoped `chat_trace_id` was a cross-run read, not just a
+cross-run reference. The ownership check runs *before* the "already has a running
+task" branch, so that branch cannot confirm a foreign id exists. A trace claimed
+without a `run_id` stays open, matching `_handle_for`.
+
+The registry behind `create_agent` is deliberately **not** scoped -- a persistent
+agent is meant to outlive one run. The unknown-subagent error still must not
+enumerate it: those names are model-authored and describe the work.
 
 ## Terminal transitions are idempotent
 

--- a/docs/advanced/chat-traces.md
+++ b/docs/advanced/chat-traces.md
@@ -64,6 +64,12 @@ A trace belongs to one subagent and one task at a time.
 - **Only successful runs are stored.** A failed first run saves nothing, so its id
   would resume an empty conversation. Neither the result text nor `check_task`
   advertises a trace in that case.
+- **One run only.** A trace belongs to the run that started it, the same way a task
+  handle does. One toolset instance serves every run of its agent, and a trace
+  holds a whole subagent conversation, so a trace from another run reads exactly
+  like an unknown one — including while its task is still running, so the error
+  cannot be used to probe which ids exist. A trace created without a `run_id`
+  stays continuable by anyone.
 
 ## Where history lives
 

--- a/docs/advanced/questions.md
+++ b/docs/advanced/questions.md
@@ -55,7 +55,7 @@ When data is ambiguous or you need clarification:
 
 ## Question Limits
 
-Prevent infinite question loops with `max_questions`:
+Cap the questions one delegation may ask with `max_questions`:
 
 ```python
 SubAgentConfig(
@@ -67,7 +67,26 @@ SubAgentConfig(
 )
 ```
 
-If the limit is reached, the subagent should proceed with best judgment or return partial results.
+The limit is enforced, not suggested. It reaches the subagent both as a line in
+its task prompt and as a counter on the delegation: the fourth `ask_parent` call
+returns
+
+```text
+Error: question limit reached (3 for this task). Finish with the information you already have.
+```
+
+without waiting for the parent. That matters because an unanswered question costs
+the task up to `ask_timeout_seconds` (300 s by default), so a subagent that ignores
+the prompt would otherwise stall repeatedly.
+
+The budget is per delegation, not per conversation: a task continuing a chat trace
+starts with a full allowance.
+
+### Turning questions off entirely
+
+`can_ask_questions=False` removes the `ask_parent` tool from the subagent rather
+than only telling it not to ask, so there is no path by which such a subagent can
+block on a question.
 
 ## Sync vs Async Questions
 

--- a/docs/concepts/subagents.md
+++ b/docs/concepts/subagents.md
@@ -29,8 +29,8 @@ subagent = SubAgentConfig(
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `model` | `str` | Parent's model | LLM model to use |
-| `can_ask_questions` | `bool` | `True` | Enable `ask_parent` tool |
-| `max_questions` | `int` | `None` (unlimited) | Max questions per task |
+| `can_ask_questions` | `bool` | `True` | Attach the `ask_parent` tool; `False` removes it |
+| `max_questions` | `int` | `None` (unlimited) | Enforced cap on `ask_parent` calls per delegation |
 | `preferred_mode` | `str` | `"auto"` | `"sync"`, `"async"`, or `"auto"` |
 | `typical_complexity` | `str` | `"moderate"` | `"simple"`, `"moderate"`, or `"complex"` |
 | `typically_needs_context` | `bool` | `False` | Hint for auto-mode selection |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "subagents-pydantic-ai"
-version = "0.2.13"
+version = "0.2.14"
 description = "Subagent toolset for pydantic-ai with dual-mode execution and dynamic agent creation"
 readme = "README.md"
 license = { file = "LICENSE" }
@@ -29,7 +29,11 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Typing :: Typed",
 ]
-dependencies = ["pydantic>=2.0", "pydantic-ai-slim>=2.0.0"]
+dependencies = [
+    "pydantic>=2.0",
+    "pydantic-ai-slim>=2.0.0",
+    "typing-extensions>=4.15.0",
+]
 
 [project.urls]
 Homepage = "https://github.com/vstorm-co/subagents-pydantic-ai"

--- a/src/subagents_pydantic_ai/_chat_trace.py
+++ b/src/subagents_pydantic_ai/_chat_trace.py
@@ -23,24 +23,50 @@ class ChatTraceStore:
     A trace must finish before it can be continued. Two concurrent tasks on one
     trace would both save at the end, and the slower save would silently discard
     the faster one's history.
+
+    A trace also belongs to the run that started it. One toolset instance serves
+    every run of its agent, and a trace holds a whole subagent conversation, so an
+    unscoped lookup let one run replay another run's history into its own subagent
+    by passing an id it had seen. Ownership mirrors `_handle_for`: a trace claimed
+    without a `run_id` stays continuable by everyone.
     """
 
     def __init__(self, max_traces: int) -> None:
         self.history: OrderedDict[ChatTraceKey, list[Any]] = OrderedDict()
         self._max_traces = max_traces
         self._active: set[ChatTraceKey] = set()
+        self._owners: dict[ChatTraceKey, str] = {}
 
     def is_active(self, key: ChatTraceKey) -> bool:
         """Whether a task is currently running on this trace."""
         return key in self._active
 
-    def mark_active(self, key: ChatTraceKey) -> None:
-        """Claim the trace for a task that is about to start."""
+    def owned_by(self, key: ChatTraceKey, run_id: str | None) -> bool:
+        """Whether `run_id` may read this trace. Unclaimed traces are open."""
+        owner = self._owners.get(key)
+        return owner is None or owner == run_id
+
+    def mark_active(self, key: ChatTraceKey, run_id: str | None = None) -> None:
+        """Claim the trace for a task that is about to start.
+
+        Ownership is recorded here rather than on `save`, so a trace whose first run
+        is still in flight is already protected. Taking `run_id` on the same call
+        that marks the trace busy is what stops a new caller forgetting one of them.
+        """
         self._active.add(key)
+        if run_id is not None:
+            self._owners.setdefault(key, run_id)
 
     def release(self, key: ChatTraceKey) -> None:
-        """Release the trace once its task has finished."""
+        """Release the trace once its task has finished.
+
+        A trace that never saved a history has nothing left to protect -- its first
+        run failed -- so the ownership record goes with it rather than pinning an id
+        no one can use.
+        """
         self._active.discard(key)
+        if key not in self.history:
+            self._owners.pop(key, None)
 
     def __contains__(self, key: ChatTraceKey) -> bool:
         return key in self.history
@@ -61,4 +87,8 @@ class ChatTraceStore:
         self.history[key] = messages
         self.history.move_to_end(key)
         while len(self.history) > self._max_traces:
-            self.history.popitem(last=False)
+            evicted, _ = self.history.popitem(last=False)
+            # An evicted trace is unreachable, so its owner record would only leak.
+            # A trace evicted mid-run keeps its claim until `release` drops it.
+            if evicted not in self._active:
+                self._owners.pop(evicted, None)

--- a/src/subagents_pydantic_ai/_execution.py
+++ b/src/subagents_pydantic_ai/_execution.py
@@ -49,7 +49,7 @@ from subagents_pydantic_ai._observability import (
     capture_observability,
     serialize_output,
 )
-from subagents_pydantic_ai._state import SubAgentState, bind_subagent_state
+from subagents_pydantic_ai._state import QuestionBudget, SubAgentState, bind_subagent_state
 from subagents_pydantic_ai.message_bus import InMemoryMessageBus, TaskManager
 from subagents_pydantic_ai.prompts import get_task_instructions_prompt
 from subagents_pydantic_ai.retry import OnRetryCallback, RetryConfig, run_with_retry
@@ -122,6 +122,17 @@ def _task_prompt(config: SubAgentConfig, description: str) -> str:
     )
 
 
+def _question_budget(config: SubAgentConfig) -> QuestionBudget | None:
+    """The delegation's `max_questions` budget, or `None` when it is unlimited.
+
+    One budget per delegation, so a subagent continuing a chat trace gets a fresh
+    allowance rather than inheriting a spent one -- `max_questions` is documented
+    per task, not per conversation.
+    """
+    limit = config.get("max_questions")
+    return QuestionBudget(limit=limit) if limit is not None else None
+
+
 async def _run_sync(
     agent: Any,
     config: SubAgentConfig,
@@ -174,7 +185,11 @@ async def _run_sync(
         message_history=message_history,
         conversation_id=handle.chat_trace_id if handle is not None else None,
     )
-    state = SubAgentState(ask_timeout_seconds=ask_timeout_seconds, ask_callback=ask_user)
+    state = SubAgentState(
+        ask_timeout_seconds=ask_timeout_seconds,
+        ask_callback=ask_user,
+        questions=_question_budget(config),
+    )
 
     try:
         with bind_subagent_state(state):
@@ -330,6 +345,7 @@ async def _run_async(
         ask_timeout_seconds=ask_timeout_seconds,
         task_manager=task_manager,
         task_id=task_id,
+        questions=_question_budget(config),
     )
 
     async def run_task() -> None:

--- a/src/subagents_pydantic_ai/_state.py
+++ b/src/subagents_pydantic_ai/_state.py
@@ -25,6 +25,31 @@ if TYPE_CHECKING:
     from subagents_pydantic_ai.message_bus import TaskManager
 
 
+@dataclass(slots=True)
+class QuestionBudget:
+    """How many more times this delegation may call `ask_parent`.
+
+    `max_questions` used to reach the subagent only as a sentence in its prompt,
+    which a model is free to ignore -- and every ignored question costs the task up
+    to `ask_timeout_seconds`. The counter makes the documented limit real. It is
+    mutable and per-delegation, so it lives here rather than on the config.
+
+    Attributes:
+        limit: Maximum questions allowed, or `None` for unlimited.
+        asked: Questions already spent.
+    """
+
+    limit: int | None = None
+    asked: int = 0
+
+    def consume(self) -> bool:
+        """Spend one question, returning whether it was within the limit."""
+        if self.limit is not None and self.asked >= self.limit:
+            return False
+        self.asked += 1
+        return True
+
+
 @dataclass(frozen=True, slots=True)
 class SubAgentState:
     """How the subagent currently being run can reach its parent.
@@ -40,12 +65,14 @@ class SubAgentState:
         task_id: Async mode. Identifies this delegation in `task_manager`.
         ask_timeout_seconds: How long `ask_parent` waits for the parent's answer
             before giving up and telling the subagent to proceed on its own.
+        questions: This delegation's `max_questions` budget, when one is set.
     """
 
     ask_timeout_seconds: float
     ask_callback: AskUserCallback | None = None
     task_manager: TaskManager | None = None
     task_id: str | None = None
+    questions: QuestionBudget | None = None
 
 
 _SUBAGENT_STATE: ContextVar[SubAgentState | None] = ContextVar(

--- a/src/subagents_pydantic_ai/prompts.py
+++ b/src/subagents_pydantic_ai/prompts.py
@@ -131,8 +131,9 @@ CHECK_TASK_DESCRIPTION = """\
 Check the status of a background (async) task and get its result if completed.
 
 Use this after launching async tasks to see if they're done. Returns the \
-task status (running, completed, failed, waiting_for_answer) and the result \
-if available. The result is always returned in full, so call this when a \
+task's current status, plus its result when completed, its error when failed, \
+its pending question when waiting for an answer, and why it stopped when \
+cancelled. The result is always returned in full, so call this when a \
 `wait_tasks` listing showed a truncated one."""
 
 ANSWER_SUBAGENT_DESCRIPTION = """\

--- a/src/subagents_pydantic_ai/toolset.py
+++ b/src/subagents_pydantic_ai/toolset.py
@@ -191,7 +191,14 @@ def _compile_subagent(
             config=config,
         )
 
-    toolsets: list[AbstractToolset[Any]] = [_create_ask_parent_toolset()]
+    # `can_ask_questions=False` has to remove the tool, not just tell the subagent
+    # not to use it. `_execute` already honours the flag when it injects
+    # `ask_parent` at run time; leaving it out here meant a configured subagent
+    # could still park a background task in WAITING_FOR_ANSWER for the full
+    # `ask_timeout_seconds` while the parent's own instructions said it never asks.
+    toolsets: list[AbstractToolset[Any]] = []
+    if config.get("can_ask_questions", True):
+        toolsets.append(_create_ask_parent_toolset())
     toolsets.extend(config.get("toolsets") or [])
 
     agent: Agent[Any, str] = Agent(
@@ -241,6 +248,16 @@ def _create_ask_parent_toolset() -> FunctionToolset[Any]:
             ask_callback = ask_callback or legacy.get("ask_callback")
             task_manager = task_manager or legacy.get("task_manager")
             task_id = task_id or legacy.get("task_id")
+
+        budget = state.questions if state is not None else None
+        if budget is not None and not budget.consume():
+            # Spent before dispatch, so the limit also caps the no-channel case --
+            # a subagent looping on a configuration error is the loop that
+            # `max_questions` is documented to prevent.
+            return (
+                f"Error: question limit reached ({budget.limit} for this task). "
+                "Finish with the information you already have."
+            )
 
         if ask_callback is not None:
             return str(await ask_callback(question))
@@ -716,6 +733,16 @@ class SubAgentToolset(FunctionToolset[Any]):
         effective_chat_trace_id = chat_trace_id or uuid.uuid4().hex
         trace_key: ChatTraceKey = (config["name"], effective_chat_trace_id)
 
+        unknown_trace = (
+            f"Error: no saved conversation for chat_trace_id '{chat_trace_id}' "
+            f"with subagent '{config['name']}' (unknown, evicted, or its first "
+            f"run failed). Omit chat_trace_id to start a new conversation."
+        )
+        # A trace owned by another run has to read exactly like an unknown one, and
+        # be refused before the "already running" branch below -- that branch would
+        # otherwise confirm the id exists.
+        if not self._chat_traces.owned_by(trace_key, ctx.run_id):
+            return unknown_trace
         if self._chat_traces.is_active(trace_key):
             return (
                 f"Error: chat trace '{effective_chat_trace_id}' already has a running "
@@ -724,11 +751,7 @@ class SubAgentToolset(FunctionToolset[Any]):
             )
         message_history = self._chat_traces.history_for(trace_key)
         if message_history is None and chat_trace_id is not None:
-            return (
-                f"Error: no saved conversation for chat_trace_id '{chat_trace_id}' "
-                f"with subagent '{config['name']}' (unknown, evicted, or its first "
-                f"run failed). Omit chat_trace_id to start a new conversation."
-            )
+            return unknown_trace
 
         def save_message_history(messages: list[Any]) -> None:
             self._chat_traces.save(trace_key, messages)
@@ -764,7 +787,7 @@ class SubAgentToolset(FunctionToolset[Any]):
                 parent_run_id=ctx.run_id,
             )
             self.task_manager.handles[actual_task_id] = handle
-            self._chat_traces.mark_active(trace_key)
+            self._chat_traces.mark_active(trace_key, ctx.run_id)
             try:
                 result = await _run_sync(
                     agent=agent,
@@ -791,7 +814,7 @@ class SubAgentToolset(FunctionToolset[Any]):
                 return _format_chat_trace_result(result, effective_chat_trace_id)
             return result
 
-        self._chat_traces.mark_active(trace_key)
+        self._chat_traces.mark_active(trace_key, ctx.run_id)
         try:
             return await _run_async(
                 agent=agent,
@@ -907,8 +930,17 @@ class SubAgentToolset(FunctionToolset[Any]):
             subagent = registry_subagent
             inject_ask_parent = True
         else:
-            available = ", ".join([*self._compiled, *self.registry.list_agents()])
-            return f"Error: Unknown subagent '{subagent_type}'. Available: {available}"
+            # Only the configured subagents are named. The registry is shared by
+            # every run of this agent, and `create_agent` names are model-authored
+            # and describe the work ("invoice-parser-acme"), so enumerating them
+            # told one tenant what the others were doing.
+            available = ", ".join(self._compiled) or "none"
+            hint = (
+                " Agents created with create_agent are also addressable by their name."
+                if self.registry.count()
+                else ""
+            )
+            return f"Error: Unknown subagent '{subagent_type}'. Available: {available}.{hint}"
 
         return await self._execute(
             ctx,
@@ -1131,10 +1163,16 @@ class SubAgentToolset(FunctionToolset[Any]):
                 can react to the first finisher without stalling on the
                 slowest one.
         """
+        # Scoped the same way the reporting below is. An unscoped await let one run
+        # block for the full `timeout` on another run's task -- and the difference
+        # between that and an id that does not exist is an existence oracle, since
+        # both render as "not found".
         pending = [
             task
             for tid in task_ids
-            if (task := self.task_manager.tasks.get(tid)) is not None and not task.done()
+            if self._handle_for(ctx, tid) is not None
+            and (task := self.task_manager.tasks.get(tid)) is not None
+            and not task.done()
         ]
         if pending:
             # Both modes route through `asyncio.wait`. Unlike
@@ -1148,9 +1186,11 @@ class SubAgentToolset(FunctionToolset[Any]):
 
         lines: list[str] = []
         finished_count = 0
+        missing_count = 0
         for tid in task_ids:
             handle = self._handle_for(ctx, tid)
             if handle is None:
+                missing_count += 1
                 lines.append(f"- {tid}: not found")
                 continue
             if handle.status == TaskStatus.COMPLETED:
@@ -1173,8 +1213,15 @@ class SubAgentToolset(FunctionToolset[Any]):
 
         total = len(task_ids)
         header_parts = [f"mode={mode}", f"{finished_count}/{total} finished"]
-        if total - finished_count > 0:
-            header_parts.append(f"{total - finished_count} still running")
+        # A missing id is neither finished nor running. Folding it into the running
+        # count told the orchestrator, in the same message that said "not found",
+        # that the task was still going -- so it kept polling an id that never
+        # resolves.
+        running = total - finished_count - missing_count
+        if running > 0:
+            header_parts.append(f"{running} still running")
+        if missing_count > 0:
+            header_parts.append(f"{missing_count} not found")
 
         return f"Task results ({', '.join(header_parts)}):\n" + "\n\n".join(lines)
 

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -23,6 +23,7 @@ from pydantic_ai.exceptions import (
     UsageLimitExceeded,
 )
 from pydantic_ai.models.test import TestModel
+from pydantic_ai.toolsets import FunctionToolset
 
 from subagents_pydantic_ai import (
     AgentMessage,
@@ -32,11 +33,17 @@ from subagents_pydantic_ai import (
     SubAgentConfig,
     TaskHandle,
     TaskManager,
+    TaskPriority,
     TaskStatus,
     create_subagent_toolset,
 )
-from subagents_pydantic_ai._execution import _run_async, _run_sync
+from subagents_pydantic_ai._chat_trace import ChatTraceStore
+from subagents_pydantic_ai._execution import _question_budget, _run_async, _run_sync
+from subagents_pydantic_ai._state import QuestionBudget, SubAgentState, bind_subagent_state
 from subagents_pydantic_ai.types import utcnow
+
+_UNSET = object()
+"""Distinguishes "the agent was never run" from "it was handed no history"."""
 
 # `asyncio_mode = "auto"` in pyproject.toml drives the async tests here.
 
@@ -941,3 +948,372 @@ class TestMessageBusHandlers:
         assert queue.qsize() == 1
         assert len(seen) == 1
         assert "handler exploded" in caplog.text
+
+
+# --------------------------------------------------------------------------- #
+# Run isolation, part two: the stores the handle gate never covered
+# --------------------------------------------------------------------------- #
+
+
+class TestChatTraceIsolation:
+    """A chat trace belongs to the run that started it.
+
+    Handles were scoped by `parent_run_id`; traces were keyed by
+    `(subagent_name, chat_trace_id)` with no owner, so one run could pass an id it
+    had seen and have the subagent replay another run's whole conversation.
+    """
+
+    def _seeded(self) -> Any:
+        toolset = _toolset()
+        toolset._compiled["worker"].agent = _HistoryRecordingAgent()
+        toolset._chat_traces.mark_active(("worker", "TRACE-A"), "run-a")
+        toolset._chat_traces.save(("worker", "TRACE-A"), ["run-a's private conversation"])
+        toolset._chat_traces.release(("worker", "TRACE-A"))
+        return toolset
+
+    async def _resume(self, toolset: Any, run_id: str | None) -> Any:
+        return await toolset.tools["task"].function(
+            Ctx(run_id=run_id),
+            "continue",
+            "worker",
+            "sync",
+            TaskPriority.NORMAL,
+            None,
+            False,
+            False,
+            "TRACE-A",
+        )
+
+    async def test_another_run_cannot_resume_a_trace(self) -> None:
+        toolset = self._seeded()
+
+        result = await self._resume(toolset, "run-b")
+
+        assert "no saved conversation for chat_trace_id 'TRACE-A'" in result
+        # The returned string alone is not enough: assert the history never
+        # reached the subagent.
+        assert toolset._compiled["worker"].agent.seen_history is _UNSET
+
+    async def test_a_foreign_active_trace_still_reads_as_unknown(self) -> None:
+        """The 'already has a running task' branch would confirm the id exists."""
+        toolset = self._seeded()
+        toolset._chat_traces.mark_active(("worker", "TRACE-A"), "run-a")
+
+        result = await self._resume(toolset, "run-b")
+
+        assert "no saved conversation" in result
+        assert "already has a running task" not in result
+
+    async def test_the_owning_run_still_resumes(self) -> None:
+        toolset = self._seeded()
+
+        result = await self._resume(toolset, "run-a")
+
+        assert "no saved conversation" not in result
+        assert toolset._compiled["worker"].agent.seen_history == ["run-a's private conversation"]
+
+    async def test_an_unclaimed_trace_stays_open(self) -> None:
+        """Matches `_handle_for`: state with no recorded owner is visible to all."""
+        toolset = _toolset()
+        toolset._compiled["worker"].agent = _HistoryRecordingAgent()
+        toolset._chat_traces.save(("worker", "TRACE-A"), ["no owner"])
+
+        result = await self._resume(toolset, "run-b")
+
+        assert "no saved conversation" not in result
+        assert toolset._compiled["worker"].agent.seen_history == ["no owner"]
+
+
+class TestChatTraceOwnership:
+    """Ownership bookkeeping in the store itself."""
+
+    def test_the_first_claim_wins(self) -> None:
+        store = ChatTraceStore(max_traces=10)
+
+        store.mark_active(("w", "t"), "run-a")
+        store.mark_active(("w", "t"), "run-b")
+
+        assert store.owned_by(("w", "t"), "run-a") is True
+        assert store.owned_by(("w", "t"), "run-b") is False
+
+    def test_a_trace_claimed_without_a_run_id_stays_open(self) -> None:
+        store = ChatTraceStore(max_traces=10)
+
+        store.mark_active(("w", "t"), None)
+
+        assert store.owned_by(("w", "t"), "anyone") is True
+
+    def test_releasing_an_unsaved_trace_drops_its_claim(self) -> None:
+        """A first run that failed saves nothing, so the id protects nothing."""
+        store = ChatTraceStore(max_traces=10)
+        store.mark_active(("w", "t"), "run-a")
+
+        store.release(("w", "t"))
+
+        assert store.owned_by(("w", "t"), "run-b") is True
+
+    def test_releasing_a_saved_trace_keeps_its_claim(self) -> None:
+        store = ChatTraceStore(max_traces=10)
+        store.mark_active(("w", "t"), "run-a")
+        store.save(("w", "t"), ["history"])
+
+        store.release(("w", "t"))
+
+        assert store.owned_by(("w", "t"), "run-b") is False
+
+    def test_eviction_drops_the_claim(self) -> None:
+        store = ChatTraceStore(max_traces=1)
+        store.mark_active(("w", "old"), "run-a")
+        store.save(("w", "old"), ["old"])
+        store.release(("w", "old"))
+
+        store.save(("w", "new"), ["new"])
+
+        assert ("w", "old") not in store
+        assert store.owned_by(("w", "old"), "run-b") is True
+
+    def test_eviction_keeps_the_claim_of_a_running_trace(self) -> None:
+        """A trace evicted mid-run is still live; `release` drops it afterwards."""
+        store = ChatTraceStore(max_traces=1)
+        store.mark_active(("w", "old"), "run-a")
+        store.save(("w", "old"), ["old"])
+
+        store.save(("w", "new"), ["new"])
+
+        assert store.owned_by(("w", "old"), "run-b") is False
+
+
+class TestWaitTasksIsolation:
+    """`wait_tasks` reported another run's task as missing and awaited it anyway.
+
+    The existing test used a handle with no `asyncio.Task` registered, which is the
+    same fixture that hid the cancel-tool defect: with nothing in
+    `task_manager.tasks` the await never happened, so the unscoped lookup that
+    built the pending list was never exercised.
+    """
+
+    async def test_does_not_await_another_runs_live_task(self) -> None:
+        toolset = _toolset()
+        block = asyncio.Event()
+        await _run_async(
+            agent=StubAgent(block=block),
+            config=_config(),
+            description="theirs",
+            deps=Deps(),
+            task_id="victim",
+            task_manager=toolset.task_manager,
+            message_bus=toolset.task_manager.message_bus,
+            parent_run_id="run-a",
+        )
+
+        started = asyncio.get_running_loop().time()
+        result = await toolset.tools["wait_tasks"].function(Ctx(run_id="run-b"), ["victim"], 5.0)
+        elapsed = asyncio.get_running_loop().time() - started
+
+        assert "- victim: not found" in result
+        # Timing is the assertion that matters: the old code blocked for the full
+        # timeout, which is also an existence oracle over foreign task ids.
+        assert elapsed < 1.0
+
+        block.set()
+        await asyncio.gather(*toolset.task_manager.tasks.values(), return_exceptions=True)
+
+    async def test_still_awaits_its_own_task(self) -> None:
+        toolset = _toolset()
+        block = asyncio.Event()
+        await _run_async(
+            agent=StubAgent(block=block),
+            config=_config(),
+            description="mine",
+            deps=Deps(),
+            task_id="mine",
+            task_manager=toolset.task_manager,
+            message_bus=toolset.task_manager.message_bus,
+            parent_run_id="run-a",
+        )
+
+        async def unblock() -> None:
+            await asyncio.sleep(0.05)
+            block.set()
+
+        asyncio.ensure_future(unblock())
+        result = await toolset.tools["wait_tasks"].function(Ctx(run_id="run-a"), ["mine"], 5.0)
+
+        assert "1/1 finished" in result
+        assert "COMPLETED" in result
+
+    async def test_a_missing_task_is_not_counted_as_running(self) -> None:
+        """The header said "1 still running" in the same breath as "not found"."""
+        toolset = _toolset()
+
+        result = await toolset.tools["wait_tasks"].function(Ctx(run_id="run-b"), ["nosuch"], 0.0)
+
+        assert result.startswith("Task results (mode=all, 0/1 finished, 1 not found):")
+        assert "still running" not in result
+
+    async def test_running_and_missing_are_counted_separately(self) -> None:
+        toolset = _toolset()
+        block = asyncio.Event()
+        await _run_async(
+            agent=StubAgent(block=block),
+            config=_config(),
+            description="mine",
+            deps=Deps(),
+            task_id="mine",
+            task_manager=toolset.task_manager,
+            message_bus=toolset.task_manager.message_bus,
+            parent_run_id="run-a",
+        )
+
+        result = await toolset.tools["wait_tasks"].function(
+            Ctx(run_id="run-a"), ["mine", "nosuch"], 0.0
+        )
+
+        assert "0/2 finished" in result
+        assert "1 still running" in result
+        assert "1 not found" in result
+
+        block.set()
+        await asyncio.gather(*toolset.task_manager.tasks.values(), return_exceptions=True)
+
+
+# --------------------------------------------------------------------------- #
+# Question contracts
+# --------------------------------------------------------------------------- #
+
+
+class TestCanAskQuestions:
+    """`can_ask_questions=False` has to remove the tool, not just discourage it.
+
+    The flag was honoured for runtime-injected specialists and ignored when
+    compiling a configured subagent, so a background task could park in
+    WAITING_FOR_ANSWER for the full `ask_timeout_seconds` while the parent's own
+    instructions said that subagent never asks.
+    """
+
+    def _tool_names(self, toolset: Any, name: str) -> list[str]:
+        agent = toolset._compiled[name].agent
+        return [
+            tool_name
+            for sub in agent.toolsets
+            for tool_name in getattr(sub, "tools", {})
+            if getattr(sub, "id", None) == "ask_parent"
+        ]
+
+    def test_a_quiet_subagent_has_no_ask_parent(self) -> None:
+        toolset = create_subagent_toolset(
+            subagents=[_config("quiet", can_ask_questions=False)],
+            include_general_purpose=False,
+            default_model=TestModel(),
+        )
+
+        assert self._tool_names(toolset, "quiet") == []
+
+    def test_a_talkative_subagent_keeps_ask_parent(self) -> None:
+        toolset = create_subagent_toolset(
+            subagents=[_config("chatty", can_ask_questions=True)],
+            include_general_purpose=False,
+            default_model=TestModel(),
+        )
+
+        assert self._tool_names(toolset, "chatty") == ["ask_parent"]
+
+    def test_the_default_keeps_ask_parent(self) -> None:
+        toolset = _toolset()
+
+        assert self._tool_names(toolset, "worker") == ["ask_parent"]
+
+    def test_a_quiet_subagent_keeps_its_own_toolsets(self) -> None:
+        """Dropping `ask_parent` must not drop the configured toolsets with it."""
+        extra: FunctionToolset[Any] = FunctionToolset(id="extra")
+        toolset = create_subagent_toolset(
+            subagents=[_config("quiet", can_ask_questions=False, toolsets=[extra])],
+            include_general_purpose=False,
+            default_model=TestModel(),
+        )
+
+        assert extra in toolset._compiled["quiet"].agent.toolsets
+
+
+class TestQuestionBudget:
+    """`max_questions` reached the subagent only as a sentence in its prompt.
+
+    A model that ignores it asks forever, and every unanswered question costs the
+    task up to `ask_timeout_seconds`.
+    """
+
+    def _ask_parent(self, toolset: Any, name: str = "asker") -> Any:
+        agent = toolset._compiled[name].agent
+        ask = next(t for t in agent.toolsets if getattr(t, "id", None) == "ask_parent")
+        return ask.tools["ask_parent"].function
+
+    def _toolset_with_budget(self, limit: int | None) -> Any:
+        extra: dict[str, Any] = {"max_questions": limit} if limit is not None else {}
+        return create_subagent_toolset(
+            subagents=[_config("asker", **extra)],
+            include_general_purpose=False,
+            default_model=TestModel(),
+            ask_user=self._answerer,
+        )
+
+    @staticmethod
+    async def _answerer(question: str) -> str:
+        return f"answer to {question}"
+
+    async def test_questions_past_the_limit_are_refused(self) -> None:
+        toolset = self._toolset_with_budget(2)
+        ask_parent = self._ask_parent(toolset)
+        state = SubAgentState(
+            ask_timeout_seconds=1.0,
+            ask_callback=self._answerer,
+            questions=QuestionBudget(limit=2),
+        )
+
+        with bind_subagent_state(state):
+            first = await ask_parent(Ctx(), "one?")
+            second = await ask_parent(Ctx(), "two?")
+            third = await ask_parent(Ctx(), "three?")
+
+        assert first == "answer to one?"
+        assert second == "answer to two?"
+        assert third == "Error: question limit reached (2 for this task). " + (
+            "Finish with the information you already have."
+        )
+
+    async def test_no_limit_means_unlimited(self) -> None:
+        toolset = self._toolset_with_budget(None)
+        ask_parent = self._ask_parent(toolset)
+        state = SubAgentState(ask_timeout_seconds=1.0, ask_callback=self._answerer)
+
+        with bind_subagent_state(state):
+            answers = [await ask_parent(Ctx(), f"q{i}?") for i in range(5)]
+
+        assert answers == [f"answer to q{i}?" for i in range(5)]
+
+    def test_the_budget_is_built_from_the_config(self) -> None:
+        assert _question_budget(_config("a", max_questions=3)) == QuestionBudget(limit=3)
+        assert _question_budget(_config("a")) is None
+
+    def test_consume_counts_and_stops(self) -> None:
+        budget = QuestionBudget(limit=1)
+
+        assert budget.consume() is True
+        assert budget.asked == 1
+        assert budget.consume() is False
+        assert budget.asked == 1
+
+    def test_an_unlimited_budget_never_refuses(self) -> None:
+        budget = QuestionBudget()
+
+        assert all(budget.consume() for _ in range(10))
+
+
+class _HistoryRecordingAgent:
+    """Records the `message_history` it was handed, so a leak is assertable."""
+
+    def __init__(self) -> None:
+        self.seen_history: Any = _UNSET
+
+    def iter(self, prompt: Any = None, **kwargs: Any) -> Any:
+        self.seen_history = kwargs.get("message_history")
+        return _CM(StubAgent())

--- a/tests/test_toolset.py
+++ b/tests/test_toolset.py
@@ -594,8 +594,14 @@ class TestCreateSubagentToolset:
             assert "Unknown subagent" in result
 
     @pytest.mark.asyncio
-    async def test_task_unknown_subagent_with_registry(self):
-        """Test task with unknown subagent includes registry agents in error."""
+    async def test_task_unknown_subagent_does_not_enumerate_the_registry(self):
+        """The unknown-subagent error once listed every run's dynamic agents.
+
+        One registry is shared by every run of the agent, and `create_agent` names
+        are model-authored and describe the work, so enumerating them told one
+        tenant what the others were doing. The error names the configured subagents
+        and says dynamic agents exist without naming them.
+        """
         config = SubAgentConfig(
             name="helper",
             description="Helps",
@@ -604,6 +610,7 @@ class TestCreateSubagentToolset:
         registry = MagicMock()
         registry.get_compiled.return_value = None
         registry.list_agents.return_value = ["dynamic-agent"]
+        registry.count.return_value = 1
 
         with patch(
             "subagents_pydantic_ai.toolset._compile_subagent",
@@ -621,7 +628,46 @@ class TestCreateSubagentToolset:
             result = await task_tool.function(ctx, "do something", "nonexistent", "sync")
 
             assert "Unknown subagent" in result
-            assert "dynamic-agent" in result
+            assert "helper" in result
+            assert "dynamic-agent" not in result
+            assert "create_agent" in result
+
+    @pytest.mark.asyncio
+    async def test_task_unknown_subagent_without_registry_agents(self):
+        """With an empty registry the error offers no dynamic-agent hint."""
+        config = SubAgentConfig(name="helper", description="Helps", instructions="Help")
+        registry = MagicMock()
+        registry.get_compiled.return_value = None
+        registry.count.return_value = 0
+
+        with patch(
+            "subagents_pydantic_ai.toolset._compile_subagent",
+            return_value=_make_mock_compiled_subagent(config),
+        ):
+            toolset = create_subagent_toolset(
+                subagents=[config],
+                include_general_purpose=False,
+                registry=registry,
+            )
+
+            ctx = MockRunContext(deps=MockDeps())
+            result = await toolset.tools["task"].function(ctx, "do", "nonexistent", "sync")
+
+            assert result == "Error: Unknown subagent 'nonexistent'. Available: helper."
+
+    @pytest.mark.asyncio
+    async def test_task_unknown_subagent_with_no_configured_subagents(self):
+        """An empty list must not render as an empty word after 'Available:'."""
+        toolset = create_subagent_toolset(
+            subagents=None,
+            include_general_purpose=False,
+            default_model=TestModel(),
+        )
+
+        ctx = MockRunContext(deps=MockDeps())
+        result = await toolset.tools["task"].function(ctx, "do", "nonexistent", "sync")
+
+        assert result == "Error: Unknown subagent 'nonexistent'. Available: none."
 
     @pytest.mark.asyncio
     async def test_task_resolved_via_registry(self):

--- a/uv.lock
+++ b/uv.lock
@@ -1333,11 +1333,12 @@ wheels = [
 
 [[package]]
 name = "subagents-pydantic-ai"
-version = "0.2.13"
+version = "0.2.14"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },
     { name = "pydantic-ai-slim" },
+    { name = "typing-extensions" },
 ]
 
 [package.dev-dependencies]
@@ -1364,6 +1365,7 @@ docs = [
 requires-dist = [
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pydantic-ai-slim", specifier = ">=2.0.0" },
+    { name = "typing-extensions", specifier = ">=4.15.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
0.2.13's fixes were all correct — I re-ran each against the shipped code rather
than trusting the diff. What they were not was complete: each was applied to the
site the report named rather than to the class of defect, and three of these are
that class still open somewhere else.

## Run scoping stopped at task handles

`wait_tasks` filtered its listing through `_handle_for` and built the set it
awaited straight off `task_manager.tasks`:

```
run-b wait_tasks(['victim'], timeout=1.0)  -> blocked 1.00s, then "- victim: not found"
run-b wait_tasks(['nosuch'], timeout=1.0)  -> blocked 0.00s, then "- nosuch: not found"
```

Identical output, different wall-clock — an existence oracle over foreign task
ids, plus a way to stall a run on work it does not own for up to the timeout
(300s by default). `test_wait_tasks_reports_another_runs_task_as_missing` missed
it for exactly the reason the cancel defect shipped in the first place: the
fixture registers a handle with no `asyncio.Task`, so `pending` was empty and the
await never ran. The replacement starts a real background delegation and asserts
elapsed time, not the string.

Chat traces had no owner at all — keyed by `(subagent_name, chat_trace_id)`, no
`run_id` anywhere:

```
run-b task(chat_trace_id='TRACE-A')  -> 'ok\n\nChat Trace ID: TRACE-A'
history handed to the subagent       -> ["run-a's private conversation"]
```

That is a read of another run's whole conversation, a step past being able to
cancel one. `ChatTraceStore` records the claiming run now, and the ownership check
runs *before* the "already has a running task" branch — that branch would
otherwise confirm a foreign id exists. A trace claimed without a `run_id` stays
open, matching `_handle_for`.

## `can_ask_questions=False` did not disable `ask_parent`

Unrelated to isolation, and the one I would fix first. The flag is honoured at
`toolset.py:710`, where `_execute` injects the tool for a runtime specialist, and
was ignored at `toolset.py:194`, where `_compile_subagent` builds a configured
one. Two lines that have to agree.

In background mode that is a stall. `ask_parent` parks the task in
`WAITING_FOR_ANSWER` for the full `ask_timeout_seconds` — 300s by default — while
the parent's own instructions say:

```
- **quiet**: Never asks *(cannot ask clarifying questions)*
```

so nothing ever calls `answer_subagent`.

## Also fixed

- The unknown-subagent error enumerated every run's dynamic agents. `create_agent`
  names are model-authored and describe the work (`invoice-parser-acme`), so the
  list told one tenant what the others were doing. The registry itself stays
  shared — a persistent agent is meant to outlive one run, and that is documented.
- `wait_tasks` counted a missing task as still running, so one message said both
  `not found` and `1 still running` about the same id, and the orchestrator kept
  polling something that never resolves.
- `max_questions` was a sentence in the subagent's prompt, documented as a limit
  that "prevents infinite question loops". It is a per-delegation counter now: past
  the limit `ask_parent` returns immediately instead of costing another
  `ask_timeout_seconds`.
- `check_task`'s tool description named four of seven statuses — 0.2.13 added the
  `cancelled` and `retrying` renderings without updating the enumeration that
  drifts.
- `typing-extensions` is imported at module scope in `types.py` and was only
  present transitively via pydantic.

## Behaviour changes

Three, each moving the code onto what the docs already promised:
`can_ask_questions=False` removes the tool, `max_questions` is enforced, and a
`chat_trace_id` from another run is refused. Anything relying on the old behaviour
was relying on a defect, but it is worth knowing before upgrading.

## Verification

- `make lint`, `make typecheck-both`, `mkdocs build --strict` — clean
- 1139 tests, 100.00% branch coverage (1496 stmts, 388 branches, 0 missed)
- pydantic-deep: 2785 passed with `PYTHONPATH` pointed here, since
  `_compile_subagent` changed behaviour and it imports that symbol
- Each of 0.2.13's eight fixes re-verified against the running code before this
  branch was cut

Every new test asserts the observable outcome — the history handed to the
subagent, the handle's status, elapsed time — not just that a branch ran. Two of
these defects shipped under 100% coverage, both times because the fixture never
reached the case.
