### PR TITLE
fix: a suspended subagent is no longer reported as completed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,76 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-08-02
+
+Three defects found integrating the library into a platform where every agent is
+built with `output_type=[str, DeferredToolRequests]`, which made the first one the
+default path rather than an edge case.
+
+The minor bump is for the status change: a suspended delegation now reports
+`deferred` where it used to report `completed` (a real defect) or `failed` (an
+honest but wrong label). Code branching on `TaskStatus.FAILED` to detect a
+human-in-the-loop delegation needs updating.
+
+### Fixed
+
+- **A suspended subagent was reported to the parent as a completed task.**
+  `_ALWAYS_PROPAGATE` guards the exception route, but an agent whose `output_type`
+  includes `DeferredToolRequests` never raises: pydantic-ai ends its run normally
+  with the parked calls as the output, exactly as it does for a top-level run a
+  caller is expected to resume. That reached `serialize_output`, so the parent
+  agent received `{"calls": [], "approvals": [...]}` as the specialist's answer,
+  summarised it, and carried on -- with `handle.status` saying `completed` and the
+  approval surfaced nowhere. It is the outcome the module docstring says the
+  design prevents, arriving by the output instead of the exception. A deferred
+  output is now the fifth entry in the error contract: the handle is marked
+  `DEFERRED`, the parked calls are kept on `TaskHandle.deferred_requests`, and the
+  matching signal is raised (`ApprovalRequired` when anything needs approving,
+  `CallDeferred` otherwise) so the parent run suspends too. The suspended run's
+  chat trace is deliberately not saved -- continuing it would resume from a point
+  whose deferred results were never supplied.
+- **`cancel_all` waited on cancelled tasks without a bound, inside a `finally`.**
+  `SubAgentCapability.wrap_run` calls it when a run ends, and it awaited each
+  cancelled task indefinitely. A `CancelledError` can be caught, and a subagent's
+  toolset is arbitrary consumer code, so one task that swallowed the cancel held
+  the parent run's teardown open forever with nothing logged. The wait is now
+  bounded by `cancel_grace_seconds` (5 s by default, configurable on
+  `TaskManager`, `create_subagent_toolset` and `SubAgentCapability`); a task still
+  alive after it is logged with its task id and left to the event loop. The
+  suppression around the wait is also no longer able to hide an *outer*
+  cancellation for longer than the grace period, which is the case that matters:
+  the parent is usually being cancelled from outside when this runs.
+
+### Added
+
+- **`event_stream_handler` on `create_subagent_toolset` and `SubAgentCapability`.**
+  Streaming a delegation was possible but only by setting the handler on each
+  agent instance -- which a dynamically created specialist does not have, since the
+  library builds it, making "stream subagents" and "let the model create
+  specialists" quietly incompatible. The handler is now resolved per delegation,
+  so both work together. An agent supplied as `SubAgentConfig["agent"]` keeps its
+  own handler: the specific choice wins, and the toolset's is the default for
+  everything else.
+- **`event_stream_handler_factory`**, resolved per delegation from the parent run
+  context, the subagent config and the task id. The task id is the argument that
+  makes a fan-out readable -- three specialists streaming into one callback are
+  otherwise indistinguishable. Mutually exclusive with `event_stream_handler`,
+  which is refused at construction: both are callables, so nothing downstream
+  could tell them apart.
+- **`TaskStatus.DEFERRED`** and **`TaskHandle.deferred_requests`**, and
+  `DEFERRED` joins `TERMINAL_STATUSES`.
+- **`docs/advanced/streaming.md`**, which is also the first documentation that
+  streaming a subagent is possible at all.
+
+### Changed
+
+- **A human-in-the-loop delegation reports `DEFERRED`, not `FAILED`.** Both the
+  sync route (where the signal propagates) and the background route (where it
+  cannot be delivered) previously recorded `FAILED`, sending a caller looking for
+  a defect when what the delegation needs is a person to decide. The background
+  message is unchanged and still tells the model to delegate with `mode="sync"`.
+  `UserError` and the `Skip*` signals still record `FAILED`.
+
 ## [0.2.14] - 2026-08-01
 
 A re-audit of 0.2.13, verifying each of that release's fixes and then sweeping the

--- a/docs/advanced/cancellation.md
+++ b/docs/advanced/cancellation.md
@@ -177,6 +177,34 @@ If cancelled, return:
 """
 ```
 
+## When the parent run ends
+
+`SubAgentCapability` cancels every background task the run started, in a
+finalizer, so nothing outlives its parent: a delegation still working against
+deps the application has torn down is a bug, and one blocked in `ask_parent`
+waits for an answer that can never arrive.
+
+That cleanup waits for each cancelled task to unwind, but **only up to
+`cancel_grace_seconds`** (5 s by default). The bound matters because the wait
+happens in a `finally`. A `CancelledError` can be caught, and a subagent's
+toolset is arbitrary code -- an HTTP client with its own shield, a slow cleanup,
+a `contextlib.suppress` a little too wide. An unbounded wait on one of those
+never returns, so the parent run's teardown never returns either, and the
+application hangs with nothing logged.
+
+A task still alive after the grace period is logged with its task id and left to
+the event loop. A leaked task that is reported is recoverable; a `finally` that
+never finishes is not.
+
+```python
+SubAgentCapability(subagents=subagents, cancel_grace_seconds=30.0)
+```
+
+Raise it when subagents do real cleanup on the way out; lower it when a fast
+shutdown matters more than a graceful one. The guarantee either way is that every
+task is cancelled -- the setting only changes how long the parent waits to watch
+it happen.
+
 ## Next Steps
 
 - [Dynamic Agents](dynamic-agents.md) - Runtime agent creation

--- a/docs/advanced/errors.md
+++ b/docs/advanced/errors.md
@@ -25,11 +25,12 @@ agent = Agent(
 )
 ```
 
-## The four outcomes
+## The five outcomes
 
 | What happened | How it reaches the parent |
 |---|---|
 | Control-flow signal (`CallDeferred`, `ApprovalRequired`, `Skip*`) | Propagates unchanged |
+| A `DeferredToolRequests` **output** | The matching signal is raised, so it propagates too |
 | `UserError` | Propagates unchanged |
 | `UsageLimitExceeded` | Propagates unchanged from a sync delegation |
 | Anything else | `ModelRetry`, or the subagent's `on_failure` message |
@@ -46,12 +47,37 @@ so they always reach the parent run.
 retry fixes a misconfiguration. Reporting it to the model as a task failure hides a
 bug you need to see.
 
+### A deferred output is the same suspension, arriving differently
+
+A subagent whose `output_type` includes `DeferredToolRequests` does not raise. Its
+run ends normally, with the parked calls as its output -- exactly as a top-level run
+does for a caller that is expected to resume it. Nothing about that is an
+exception, so the guard above never sees it.
+
+It is treated as the suspension it is. The handle is marked `deferred`, the parked
+calls are kept on `TaskHandle.deferred_requests`, and the matching signal is raised
+so the parent run suspends too: `ApprovalRequired` when anything needs approving,
+`CallDeferred` otherwise. A parent told only that a call was deferred would resume
+it with a tool result, and nobody would ever be asked the question the child
+stopped for.
+
+```python
+handle = toolset.task_manager.get_handle(task_id)
+if handle is not None and handle.status is TaskStatus.DEFERRED:
+    assert handle.deferred_requests is not None
+    for call in handle.deferred_requests.approvals:
+        print("waiting on", call.tool_name)
+```
+
+The suspended run's chat trace is deliberately **not** saved: continuing it later
+would resume from a point whose deferred results were never supplied.
+
 !!! warning "Background mode cannot suspend"
     A background delegation returned its tool result (the task id) long before the
-    signal arrives, so there is no caller left to hand the deferred state back to.
-    The task is marked `failed` with an error saying to delegate it with
-    `mode="sync"` instead. Approval and deferred tools need synchronous
-    delegation.
+    suspension arrives, so there is no caller left to hand the deferred state back
+    to. The task is marked `deferred` with an error saying to delegate it with
+    `mode="sync"` instead, and the parked calls are still kept on the handle.
+    Approval and deferred tools need synchronous delegation.
 
 ### Usage limits stop the parent run
 

--- a/docs/advanced/streaming.md
+++ b/docs/advanced/streaming.md
@@ -1,0 +1,126 @@
+# Streaming subagent output
+
+A delegation can take a while. Without streaming, everything a specialist does
+between "task started" and its final answer is invisible -- the user watches a
+spinner, and an application that wants to show the work has nothing to show.
+
+Pass an `event_stream_handler` and every delegation's events -- model text,
+thinking, tool calls and their results -- arrive as they happen.
+
+```python
+from typing import Any
+
+from pydantic_ai import Agent, RunContext
+from subagents_pydantic_ai import SubAgentCapability, SubAgentConfig
+
+
+async def on_events(ctx: RunContext[Any], events: Any) -> None:
+    async for event in events:
+        print(event)
+
+
+agent = Agent(
+    "openai:gpt-4.1",
+    capabilities=[
+        SubAgentCapability(
+            subagents=[
+                SubAgentConfig(
+                    name="researcher",
+                    description="Researches topics",
+                    instructions="You research topics thoroughly.",
+                ),
+            ],
+            event_stream_handler=on_events,
+        )
+    ],
+)
+```
+
+The handler is pydantic-ai's own
+[`EventStreamHandler`](https://ai.pydantic.dev/agents/#streaming-all-events) --
+the same callable an `Agent` takes -- so anything already written for a top-level
+run works unchanged for a subagent.
+
+## Labelling a fan-out
+
+Three specialists streaming into one callback are indistinguishable: the events
+themselves carry nothing that says which delegation produced them. Pass a
+factory instead, and it is handed the task id.
+
+```python
+from subagents_pydantic_ai import SubAgentConfig, create_subagent_toolset
+
+
+def handler_for(ctx: RunContext[Any], config: SubAgentConfig, task_id: str) -> Any:
+    async def on_events(run_ctx: RunContext[Any], events: Any) -> None:
+        async for event in events:
+            await socket.send_json(
+                {"task_id": task_id, "subagent": config["name"], "event": repr(event)}
+            )
+
+    return on_events
+
+
+toolset = create_subagent_toolset(
+    subagents=subagents,
+    event_stream_handler_factory=handler_for,
+)
+```
+
+The factory runs once per delegation, before the subagent starts, so it can read
+anything on the parent context as well. Return `None` to run that one without
+streaming.
+
+`event_stream_handler` and `event_stream_handler_factory` are mutually exclusive:
+both are callables, so nothing downstream could tell them apart and one would
+silently win.
+
+## Which handler wins
+
+| The agent for this delegation | Toolset handler | What streams |
+|---|---|---|
+| Has its own `event_stream_handler` | set | The agent's own |
+| Has its own `event_stream_handler` | unset | The agent's own |
+| Has none | set | The toolset's |
+| Has none | unset | Nothing |
+
+An agent passed in as `SubAgentConfig["agent"]` with a handler already on it was
+configured for that one specialist deliberately, so it wins. The toolset's
+handler is the application saying "stream everything I did not configure
+individually".
+
+## Dynamically created specialists
+
+An agent the model creates through `create_agent` or `delegate` is built by this
+library, so there is no instance for an application to attach a handler to. That
+is the reason the handler is resolved per delegation rather than baked onto an
+agent at construction: a dynamic specialist streams on exactly the same terms as
+a configured one, with no extra wiring.
+
+```python
+toolset = create_subagent_toolset(
+    delegation_configuration="persisted_and_oneshot",
+    allowed_models=["openai:gpt-4o-mini"],
+    event_stream_handler_factory=handler_for,
+)
+```
+
+## Background delegations
+
+Streaming works in both execution modes. A background delegation streams while it
+runs, which means its events keep arriving after the delegating tool has already
+returned its task id -- and, if the parent finishes first, after the parent's own
+answer. An application that tears its display down when the parent run ends will
+drop the last thing a specialist said.
+
+## Retries
+
+A retried attempt streams too. The handler is resolved once and honoured on every
+attempt, so a transient failure mid-delegation does not silently stop the stream.
+See [Retries](retries.md).
+
+## Next steps
+
+- [Execution modes](execution-modes.md) -- sync, background, and `auto`
+- [Observability](../concepts/observability.md) -- what a finished delegation cost
+- [Cancellation](cancellation.md) -- stopping a task on purpose

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -166,6 +166,7 @@ nav:
     - advanced/steering.md
     - advanced/chat-traces.md
     - advanced/cancellation.md
+    - advanced/streaming.md
     - advanced/errors.md
     - advanced/retries.md
     - advanced/usage-limits.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "subagents-pydantic-ai"
-version = "0.2.14"
+version = "0.3.0"
 description = "Subagent toolset for pydantic-ai with dual-mode execution and dynamic agent creation"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/subagents_pydantic_ai/__init__.py
+++ b/src/subagents_pydantic_ai/__init__.py
@@ -9,6 +9,7 @@ subagents within pydantic-ai agents. It supports:
 - **Questions**: a subagent can ask its parent for clarification mid-task
 - **Steering**: redirect a running background task without losing its progress
 - **Cancellation**: cooperative (stops at a clean boundary) or immediate
+- **Streaming**: a delegation's events as they happen, labelled by task
 - **Retries**: transient model/gateway failures resume from accumulated history
 - **Observability**: per-task usage, cost, tool-call counts, and traceparent
 - **Dynamic agents**: create specialists at runtime, reusable or one-shot
@@ -40,6 +41,9 @@ from subagents_pydantic_ai.dynamic_agent import (
 )
 from subagents_pydantic_ai.factory import (
     create_agent_factory_toolset as create_agent_factory_toolset,
+)
+from subagents_pydantic_ai.message_bus import (
+    DEFAULT_CANCEL_GRACE_SECONDS as DEFAULT_CANCEL_GRACE_SECONDS,
 )
 from subagents_pydantic_ai.message_bus import (
     InMemoryMessageBus as InMemoryMessageBus,
@@ -135,6 +139,9 @@ from subagents_pydantic_ai.types import (
     DelegationConfiguration as DelegationConfiguration,
 )
 from subagents_pydantic_ai.types import (
+    EventStreamHandlerFactory as EventStreamHandlerFactory,
+)
+from subagents_pydantic_ai.types import (
     ExecutionMode as ExecutionMode,
 )
 from subagents_pydantic_ai.types import (
@@ -186,6 +193,7 @@ __all__ = [
     "TaskCharacteristics",
     "ExecutionMode",
     "DelegationConfiguration",
+    "EventStreamHandlerFactory",
     "ToolsetFactory",
     "AgentFactory",
     "UsageLimitsFactory",
@@ -202,6 +210,7 @@ __all__ = [
     "InMemoryMessageBus",
     "create_message_bus",
     "TaskManager",
+    "DEFAULT_CANCEL_GRACE_SECONDS",
     # Registry
     "DynamicAgentRegistry",
     # Retry

--- a/src/subagents_pydantic_ai/_execution.py
+++ b/src/subagents_pydantic_ai/_execution.py
@@ -2,7 +2,7 @@
 
 ## Error contract
 
-A delegation can fail in four distinct ways, and collapsing them into one string
+A delegation can fail in five distinct ways, and collapsing them into one string
 result -- which is what this module used to do -- loses information the parent run
 needs:
 
@@ -10,6 +10,16 @@ needs:
   pydantic-ai suspends a run for deferred tools or human approval. Catching them
   turns a suspended run into a tool result the parent reads as a finished task, so
   they always propagate.
+- **A deferred *output*** is the same suspension arriving by the other route. An
+  agent whose `output_type` includes `DeferredToolRequests` does not raise: the
+  run ends normally with the parked calls as its output, exactly as a top-level
+  run does for a caller that is expected to resume it. Nothing about that is a
+  failure, so the guard above never sees it -- and without the check in
+  `_deferred_requests` the parent is handed a serialized dataclass as the
+  subagent's answer and the handle says `completed`. It is treated as the
+  signal it is: `DEFERRED` on the handle, the parked calls kept on
+  `TaskHandle.deferred_requests`, and the matching exception raised so the
+  parent run suspends too.
 - **`UserError`** is a setup mistake no retry can fix. Reporting it to the model as
   a task failure hides it, so it always propagates.
 - **`UsageLimitExceeded`** means a delegation ran out of budget. Every subagent
@@ -31,7 +41,8 @@ import logging
 from collections.abc import Callable
 from typing import Any
 
-from pydantic_ai import UsageLimits
+from pydantic_ai import DeferredToolRequests, UsageLimits
+from pydantic_ai.agent import EventStreamHandler
 from pydantic_ai.exceptions import (
     ApprovalRequired,
     CallDeferred,
@@ -93,6 +104,62 @@ _HUMAN_IN_THE_LOOP: tuple[type[Exception], ...] = (CallDeferred, ApprovalRequire
 """Signals a background delegation cannot deliver: they need a caller to hand the
 deferred state back to, and the delegating tool returned long ago."""
 
+_SUSPENSION_ERROR = "the subagent stopped for a human decision and produced no answer"
+"""What a `DEFERRED` handle says happened, whichever route the suspension arrived by."""
+
+_BACKGROUND_SUSPENSION_ERROR = (
+    "a subagent that needs approval or defers a tool call cannot run in the "
+    "background; delegate it with mode='sync'."
+)
+"""Why a background delegation cannot suspend, whichever route it arrived by.
+
+Shared so the exception and the deferred-output branch cannot drift into two
+explanations of one rule.
+"""
+
+
+def _deferred_requests(output: object) -> DeferredToolRequests | None:
+    """The parked tool calls in a run's output, when it suspended rather than answered.
+
+    An empty `DeferredToolRequests` -- no calls and no approvals -- is not a
+    suspension. Core does not produce one, but treating it as deferred would
+    strand a delegation on nothing to decide, so it is read as an ordinary
+    output and serialized like any other.
+    """
+    if not isinstance(output, DeferredToolRequests):
+        return None
+    if not output.calls and not output.approvals:
+        return None
+    return output
+
+
+def _resolve_event_stream_handler(
+    agent: Any, configured: EventStreamHandler[Any] | None
+) -> EventStreamHandler[Any] | None:
+    """The handler for this delegation: the agent's own first, the toolset's as a default.
+
+    An agent handed over as `SubAgentConfig["agent"]` with a handler already on it
+    was configured for that one specialist deliberately, so it wins. A
+    toolset-level handler is the application saying "stream everything I did not
+    configure individually" -- it fills the gap rather than overriding the
+    specific choice, which is also the only way an agent the library builds
+    itself (a dynamic specialist) can stream at all.
+    """
+    own: EventStreamHandler[Any] | None = getattr(agent, "event_stream_handler", None)
+    return own or configured
+
+
+def _suspension_signal(deferred: DeferredToolRequests) -> Exception:
+    """The exception that reproduces a child's suspension in its parent run.
+
+    Approvals outrank deferred calls: a parent told only that a call was
+    deferred would resume it with a tool result, and nobody would ever be asked
+    the question the child stopped for.
+    """
+    if deferred.approvals:
+        return ApprovalRequired()
+    return CallDeferred()
+
 
 def _build_run_kwargs(
     deps: Any,
@@ -147,6 +214,7 @@ async def _run_sync(
     on_message_history: Callable[[list[Any]], None] | None = None,
     ask_timeout_seconds: float = DEFAULT_ASK_TIMEOUT_SECONDS,
     contain_errors: bool = True,
+    event_stream_handler: EventStreamHandler[Any] | None = None,
 ) -> str:
     """Run a subagent task synchronously, blocking until it finishes.
 
@@ -168,12 +236,16 @@ async def _run_sync(
         contain_errors: Whether a subagent crash is converted into a `ModelRetry`
             for the parent instead of propagating and aborting the parent run.
             Signals in `_ALWAYS_PROPAGATE` ignore this.
+        event_stream_handler: Streams this delegation's events. Used only when
+            the agent carries no handler of its own.
 
     Returns:
         The subagent's output, or the configured `on_failure` message.
 
     Raises:
         ModelRetry: When the subagent failed and no `on_failure` message is set.
+        ApprovalRequired: When the subagent suspended on a tool needing approval.
+        CallDeferred: When the subagent suspended on a deferred tool call.
         Exception: Control-flow signals, `UserError`, `UsageLimitExceeded`,
             and -- when `contain_errors` is false -- any other subagent exception.
     """
@@ -199,7 +271,14 @@ async def _run_sync(
                 run_kwargs=run_kwargs,
                 retry=RetryConfig.from_config(config),
                 on_retry=_retry_recorder(handle),
+                event_stream_handler=_resolve_event_stream_handler(agent, event_stream_handler),
             )
+    except _HUMAN_IN_THE_LOOP as exc:
+        # Before `_ALWAYS_PROPAGATE`, which also matches these: a suspension is
+        # not a failure, and reporting one as `FAILED` sends a caller looking for
+        # a defect instead of for the person who has to decide.
+        _suspend(handle, exc)
+        raise
     except _ALWAYS_PROPAGATE:
         _fail(handle, "propagated")
         raise
@@ -213,6 +292,15 @@ async def _run_sync(
             _fail(handle, str(exc))
             raise
         return _degrade(handle, config, task_id, exc, crashed=True)
+
+    deferred = _deferred_requests(result.output)
+    if deferred is not None:
+        signal = _suspension_signal(deferred)
+        # Deliberately not `capture_message_history`: a suspended run has not
+        # finished, and saving it would let a later `chat_trace_id` resume from a
+        # point whose deferred results were never supplied.
+        _suspend(handle, signal, deferred=deferred, result=result)
+        raise signal
 
     capture_message_history(result, on_message_history)
     output = serialize_output(result.output)
@@ -245,6 +333,32 @@ def _retry_recorder(handle: TaskHandle | None) -> OnRetryCallback | None:
 def _fail(handle: TaskHandle | None, error: str) -> None:
     if handle is not None:
         handle.finish(TaskStatus.FAILED, error=error)
+
+
+def _suspend(
+    handle: TaskHandle | None,
+    signal: Exception,
+    *,
+    deferred: DeferredToolRequests | None = None,
+    result: Any = None,
+) -> None:
+    """Record a delegation that stopped for a human instead of answering.
+
+    `deferred` is set only on the output route; the exception route carries no
+    result to read the parked calls off, which is why the two are distinguishable
+    on the handle but not in its status.
+
+    Telemetry is captured where there is a result to capture it from: the
+    suspended run still spent tokens, and a cost that only lands for delegations
+    that happened to finish is a cost report that under-reports exactly the runs
+    a human is about to make more expensive.
+    """
+    if handle is None:
+        return
+    if handle.finish(TaskStatus.DEFERRED, error=f"{type(signal).__name__}: {_SUSPENSION_ERROR}"):
+        handle.deferred_requests = deferred
+        if result is not None:
+            capture_observability(handle, result)
 
 
 def _degrade(
@@ -293,6 +407,7 @@ async def _run_async(
     on_run_finished: Callable[[], None] | None = None,
     ask_timeout_seconds: float = DEFAULT_ASK_TIMEOUT_SECONDS,
     parent_run_id: str | None = None,
+    event_stream_handler: EventStreamHandler[Any] | None = None,
 ) -> str:
     """Start a subagent task in the background and return its handle text.
 
@@ -313,6 +428,8 @@ async def _run_async(
         on_run_finished: Invoked once when the run finishes, however it finishes.
         ask_timeout_seconds: How long `ask_parent` waits for the parent's answer.
         parent_run_id: `run_id` of the parent run, so the task can be scoped to it.
+        event_stream_handler: Streams this delegation's events. Used only when
+            the agent carries no handler of its own.
 
     Returns:
         Text telling the parent the task id and how to check on it.
@@ -369,7 +486,24 @@ async def _run_async(
                     on_retry=_retry_recorder(handle),
                     cancel_check=cancel_requested,
                     inject_messages=pending_steering,
+                    event_stream_handler=_resolve_event_stream_handler(agent, event_stream_handler),
                 )
+            deferred = _deferred_requests(result.output)
+            if deferred is not None:
+                # No caller left to hand the parked calls back to, so this is as
+                # far as the delegation goes -- but the calls are kept on the
+                # handle, which is the only way an application can see what the
+                # subagent stopped on and re-run it where a human can answer.
+                if handle.finish(
+                    TaskStatus.DEFERRED,
+                    error=(
+                        f"{type(_suspension_signal(deferred)).__name__}: "
+                        f"{_BACKGROUND_SUSPENSION_ERROR}"
+                    ),
+                ):
+                    handle.deferred_requests = deferred
+                    capture_observability(handle, result)
+                return
             capture_message_history(result, on_message_history)
             if handle.finish(TaskStatus.COMPLETED, result=serialize_output(result.output)):
                 capture_observability(handle, result)
@@ -380,11 +514,8 @@ async def _run_async(
             handle.finish(TaskStatus.FAILED, error=f"{_USAGE_LIMIT_MARKER}: {exc}")
         except _HUMAN_IN_THE_LOOP as exc:
             handle.finish(
-                TaskStatus.FAILED,
-                error=(
-                    f"{type(exc).__name__}: a subagent that needs approval or defers a "
-                    f"tool call cannot run in the background; delegate it with mode='sync'."
-                ),
+                TaskStatus.DEFERRED,
+                error=f"{type(exc).__name__}: {_BACKGROUND_SUSPENSION_ERROR}",
             )
         except Exception as exc:
             logger.warning(

--- a/src/subagents_pydantic_ai/capability.py
+++ b/src/subagents_pydantic_ai/capability.py
@@ -29,19 +29,20 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from pydantic_ai import RunContext, UsageLimits
-from pydantic_ai.agent import AgentRunResult
+from pydantic_ai.agent import AgentRunResult, EventStreamHandler
 from pydantic_ai.capabilities import AbstractCapability, WrapRunHandler
 from pydantic_ai.toolsets import AbstractToolset
 
 from subagents_pydantic_ai._execution import DEFAULT_ASK_TIMEOUT_SECONDS
 from subagents_pydantic_ai.dynamic_agent import AgentFactory, CapabilityFactory
-from subagents_pydantic_ai.message_bus import TaskManager
+from subagents_pydantic_ai.message_bus import DEFAULT_CANCEL_GRACE_SECONDS, TaskManager
 from subagents_pydantic_ai.prompts import get_subagent_system_prompt
 from subagents_pydantic_ai.registry import DynamicAgentRegistry
 from subagents_pydantic_ai.toolset import SubAgentToolset, create_subagent_toolset
 from subagents_pydantic_ai.types import (
     AskUserCallback,
     DelegationConfiguration,
+    EventStreamHandlerFactory,
     SubAgentConfig,
     ToolsetFactory,
     UsageLimitsFactory,
@@ -105,12 +106,22 @@ class SubAgentCapability(AbstractCapability[Any]):
         ask_user: Callback backing `ask_parent`. Required for a sync-mode subagent
             to ask its parent anything: the parent's run loop is blocked inside the
             delegation, so `answer_subagent` cannot be reached until it returns.
+        event_stream_handler: Streams every delegation's events as they happen,
+            including for specialists created at run time. An agent supplied as
+            `SubAgentConfig["agent"]` keeps its own handler if it has one.
+        event_stream_handler_factory: The same, resolved per delegation from the
+            parent run context, the subagent config and the task id — which is
+            what lets a handler label the events of a fan-out. Mutually exclusive
+            with `event_stream_handler`.
+        cancel_grace_seconds: How long `wrap_run` waits for a cancelled
+            background task to unwind before logging it and returning.
 
     Raises:
         ValueError: From `create_subagent_toolset` when the configuration is
-            self-contradictory — an invalid `delegation_configuration`, or one
+            self-contradictory — an invalid `delegation_configuration`, one
             whose hidden tools make `subagents`, `registry`, `allowed_models`,
-            `capabilities_map`, or `default_agent_factory` unreachable.
+            `capabilities_map`, or `default_agent_factory` unreachable, or both
+            an `event_stream_handler` and an `event_stream_handler_factory`.
     """
 
     subagents: list[SubAgentConfig] | None = None
@@ -132,6 +143,9 @@ class SubAgentCapability(AbstractCapability[Any]):
     ask_user: AskUserCallback | None = None
     ask_timeout_seconds: float = DEFAULT_ASK_TIMEOUT_SECONDS
     contain_errors: bool = True
+    event_stream_handler: EventStreamHandler[Any] | None = None
+    event_stream_handler_factory: EventStreamHandlerFactory | None = None
+    cancel_grace_seconds: float = DEFAULT_CANCEL_GRACE_SECONDS
     _toolset: SubAgentToolset = field(init=False, repr=False)
 
     def __post_init__(self) -> None:
@@ -157,6 +171,9 @@ class SubAgentCapability(AbstractCapability[Any]):
             ask_user=self.ask_user,
             ask_timeout_seconds=self.ask_timeout_seconds,
             contain_errors=self.contain_errors,
+            event_stream_handler=self.event_stream_handler,
+            event_stream_handler_factory=self.event_stream_handler_factory,
+            cancel_grace_seconds=self.cancel_grace_seconds,
         )
 
     @classmethod

--- a/src/subagents_pydantic_ai/message_bus.py
+++ b/src/subagents_pydantic_ai/message_bus.py
@@ -24,6 +24,14 @@ from subagents_pydantic_ai.types import AgentMessage, MessageType, TaskHandle, T
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_CANCEL_GRACE_SECONDS = 5.0
+"""How long a cancelled background task is given to unwind before it is left behind.
+
+Long enough for a real `finally` -- closing a client, flushing a span -- and short
+enough that a subagent which ignores cancellation cannot hold a parent run's
+teardown open. See `TaskManager.cancel_all`.
+"""
+
 
 @dataclass
 class InMemoryMessageBus:
@@ -311,11 +319,14 @@ class TaskManager:
         handles: `TaskHandle` per task id, kept after the task finishes so its
             result and telemetry stay queryable.
         message_bus: Message bus used to deliver steering and cancel messages.
+        cancel_grace_seconds: How long `cancel_all` waits for a cancelled task to
+            unwind before logging it and moving on.
     """
 
     tasks: dict[str, asyncio.Task[None]] = field(default_factory=dict)
     handles: dict[str, TaskHandle] = field(default_factory=dict)
     message_bus: InMemoryMessageBus = field(default_factory=InMemoryMessageBus)
+    cancel_grace_seconds: float = DEFAULT_CANCEL_GRACE_SECONDS
     _cancel_events: dict[str, asyncio.Event] = field(default_factory=dict)
     _answer_futures: dict[str, asyncio.Future[str]] = field(default_factory=dict)
     _strong_refs: set[asyncio.Task[None]] = field(default_factory=set)
@@ -486,17 +497,28 @@ class TaskManager:
         return True
 
     async def cancel_all(self, parent_run_id: str | None = None) -> None:
-        """Cancel every live task and wait for it to finish cleaning up.
+        """Cancel every live task and wait, up to the grace period, for it to unwind.
 
         Called when a parent run ends. A background delegation that outlives its
         parent keeps working against deps the application has already torn down,
         and one blocked in `ask_parent` waits for an answer that can never come.
 
+        The wait is bounded because the caller is a `finally` block. A
+        `CancelledError` can be caught, and a subagent's toolset is arbitrary
+        consumer code -- an HTTP client with its own shield, a slow cleanup, a
+        `contextlib.suppress` a little too wide. An unbounded wait on one of
+        those never returns, so the parent run's teardown never returns either,
+        and the application hangs with nothing logged. A leaked task that is
+        reported is recoverable; a `finally` that never finishes is not.
+
+        The guarantee is therefore: every matching task is cancelled, and its
+        cleanup is awaited for at most `cancel_grace_seconds`.
+
         Args:
             parent_run_id: Only cancel tasks started by this parent run. `None`
                 cancels every live task.
         """
-        live: list[asyncio.Task[None]] = []
+        live: dict[asyncio.Task[None], str] = {}
         for task_id, task in list(self.tasks.items()):
             handle = self.handles.get(task_id)
             if parent_run_id is not None and (
@@ -507,17 +529,36 @@ class TaskManager:
                 # `cancel()` raises into whatever the task is awaiting, including a
                 # future held by `ask_parent`, so there is nothing to unblock first.
                 task.cancel()
-                live.append(task)
+                live[task] = task_id
                 # A task cancelled before its coroutine started never reaches its
                 # own `except asyncio.CancelledError`, so record the outcome here.
                 # `finish` is idempotent, so a task that does get there wins.
                 if handle is not None:
                     handle.finish(TaskStatus.CANCELLED, error="Task was cancelled")
 
-        for task in live:
-            # We requested the cancel, so the task acknowledging it is success.
-            with contextlib.suppress(asyncio.CancelledError):
-                await task
+        if not live:
+            return
+
+        # `asyncio.wait` rather than awaiting each task: it returns on timeout
+        # instead of raising, and it never re-raises a task's own exception, so
+        # one subagent's failure cannot stop the others from being waited on.
+        cancelled = set(live)
+        pending: set[asyncio.Task[None]] = cancelled
+        with contextlib.suppress(asyncio.CancelledError):
+            # Suppressed because this runs during the parent's own cancellation,
+            # where a `CancelledError` delivered here belongs to that outer
+            # cancel. Swallowing it is safe only because we stop waiting
+            # immediately after; the outer cancellation continues to propagate
+            # from the `finally` this was called in.
+            _, pending = await asyncio.wait(cancelled, timeout=self.cancel_grace_seconds)
+
+        for task in pending:
+            logger.warning(
+                "Subagent task %s did not unwind within %.1fs of being cancelled; "
+                "leaving it to the event loop",
+                live[task],
+                self.cancel_grace_seconds,
+            )
 
     def cleanup_task(self, task_id: str) -> None:
         """Clean up resources for a completed task.

--- a/src/subagents_pydantic_ai/toolset.py
+++ b/src/subagents_pydantic_ai/toolset.py
@@ -19,6 +19,7 @@ from collections import OrderedDict
 from typing import Any, Literal
 
 from pydantic_ai import Agent, RunContext, UsageLimits
+from pydantic_ai.agent import EventStreamHandler
 from pydantic_ai.models import Model
 from pydantic_ai.toolsets import AbstractToolset, FunctionToolset
 
@@ -39,7 +40,11 @@ from subagents_pydantic_ai.dynamic_agent import (
     CapabilityFactory,
     build_dynamic_agent,
 )
-from subagents_pydantic_ai.message_bus import InMemoryMessageBus, TaskManager
+from subagents_pydantic_ai.message_bus import (
+    DEFAULT_CANCEL_GRACE_SECONDS,
+    InMemoryMessageBus,
+    TaskManager,
+)
 from subagents_pydantic_ai.prompts import (
     ANSWER_SUBAGENT_DESCRIPTION,
     CHECK_TASK_DESCRIPTION,
@@ -60,6 +65,7 @@ from subagents_pydantic_ai.types import (
     AskUserCallback,
     CompiledSubAgent,
     DelegationConfiguration,
+    EventStreamHandlerFactory,
     ExecutionMode,
     MessageType,
     SubAgentConfig,
@@ -345,6 +351,9 @@ class SubAgentToolset(FunctionToolset[Any]):
         max_result_chars: int | None = 2000,
         ask_timeout_seconds: float = DEFAULT_ASK_TIMEOUT_SECONDS,
         contain_errors: bool = True,
+        event_stream_handler: EventStreamHandler[Any] | None = None,
+        event_stream_handler_factory: EventStreamHandlerFactory | None = None,
+        cancel_grace_seconds: float = DEFAULT_CANCEL_GRACE_SECONDS,
     ) -> None:
         """Build the toolset. See `create_subagent_toolset` for the argument reference."""
         super().__init__(id=id or "subagents")
@@ -360,6 +369,9 @@ class SubAgentToolset(FunctionToolset[Any]):
             max_agents=max_agents,
             max_chat_traces=max_chat_traces,
             max_task_handles=max_task_handles,
+            event_stream_handler=event_stream_handler,
+            event_stream_handler_factory=event_stream_handler_factory,
+            cancel_grace_seconds=cancel_grace_seconds,
         )
 
         self._descriptions = descriptions or {}
@@ -375,11 +387,15 @@ class SubAgentToolset(FunctionToolset[Any]):
         self._max_result_chars = max_result_chars
         self._ask_timeout_seconds = ask_timeout_seconds
         self._contain_errors = contain_errors
+        self._event_stream_handler = event_stream_handler
+        self._event_stream_handler_factory = event_stream_handler_factory
 
         self.registry = (
             registry if registry is not None else DynamicAgentRegistry(max_agents=max_agents)
         )
-        self.task_manager = TaskManager(message_bus=InMemoryMessageBus())
+        self.task_manager = TaskManager(
+            message_bus=InMemoryMessageBus(), cancel_grace_seconds=cancel_grace_seconds
+        )
         self._chat_traces = ChatTraceStore(max_traces=max_chat_traces)
         # Usage from evicted handles, so `get_total_usage` survives eviction.
         self._evicted_usage = {"input_tokens": 0, "output_tokens": 0, "requests": 0}
@@ -409,6 +425,9 @@ class SubAgentToolset(FunctionToolset[Any]):
         max_agents: int,
         max_chat_traces: int,
         max_task_handles: int,
+        event_stream_handler: EventStreamHandler[Any] | None,
+        event_stream_handler_factory: EventStreamHandlerFactory | None,
+        cancel_grace_seconds: float,
     ) -> None:
         """Reject a configuration that contradicts itself.
 
@@ -476,6 +495,19 @@ class SubAgentToolset(FunctionToolset[Any]):
 
         if max_agents < 0:
             raise ValueError(f"max_agents must be >= 0, got {max_agents}")
+
+        # Both are callables, so nothing downstream could tell them apart and
+        # one would silently win. Which one is not something a caller should
+        # have to discover from the source.
+        if event_stream_handler is not None and event_stream_handler_factory is not None:
+            raise ValueError(
+                "event_stream_handler and event_stream_handler_factory are mutually "
+                "exclusive. Pass the factory when the handler depends on the task, "
+                "the handler when it does not."
+            )
+
+        if cancel_grace_seconds <= 0:
+            raise ValueError(f"cancel_grace_seconds must be > 0, got {cancel_grace_seconds}")
 
     @property
     def _expose_create_agent(self) -> bool:
@@ -686,6 +718,23 @@ class SubAgentToolset(FunctionToolset[Any]):
 
     # -- delegation ------------------------------------------------------------
 
+    def _resolve_event_stream_handler(
+        self,
+        ctx: RunContext[SubAgentDepsProtocol],
+        config: SubAgentConfig,
+        task_id: str,
+    ) -> EventStreamHandler[Any] | None:
+        """The toolset's handler for one delegation, from the factory or the static one.
+
+        Resolved per delegation rather than baked onto an agent at construction,
+        which is what lets a dynamically created specialist stream: the library
+        builds that agent itself, so there is no instance for the application to
+        attach a handler to.
+        """
+        if self._event_stream_handler_factory is not None:
+            return self._event_stream_handler_factory(ctx, config, task_id)
+        return self._event_stream_handler
+
     async def _execute(
         self,
         ctx: RunContext[SubAgentDepsProtocol],
@@ -730,6 +779,12 @@ class SubAgentToolset(FunctionToolset[Any]):
                 runtime_toolsets.extend(self._toolsets_factory(subagent_deps))
 
         actual_task_id = task_id or uuid.uuid4().hex[:8]
+        # After the task id exists, because that is the argument that makes a
+        # fan-out readable: the events themselves carry nothing to tell three
+        # concurrent specialists apart.
+        resolved_event_stream_handler = self._resolve_event_stream_handler(
+            ctx, config, actual_task_id
+        )
         effective_chat_trace_id = chat_trace_id or uuid.uuid4().hex
         trace_key: ChatTraceKey = (config["name"], effective_chat_trace_id)
 
@@ -803,6 +858,7 @@ class SubAgentToolset(FunctionToolset[Any]):
                     on_message_history=on_history,
                     ask_timeout_seconds=self._ask_timeout_seconds,
                     contain_errors=config.get("contain_errors", self._contain_errors),
+                    event_stream_handler=resolved_event_stream_handler,
                 )
             finally:
                 self._chat_traces.release(trace_key)
@@ -833,6 +889,7 @@ class SubAgentToolset(FunctionToolset[Any]):
                 on_run_finished=lambda: self._chat_traces.release(trace_key),
                 ask_timeout_seconds=self._ask_timeout_seconds,
                 parent_run_id=ctx.run_id,
+                event_stream_handler=resolved_event_stream_handler,
             )
         except BaseException:
             # `_run_async` failed before the background task took ownership.
@@ -1283,6 +1340,9 @@ def create_subagent_toolset(
     max_result_chars: int | None = 2000,
     ask_timeout_seconds: float = DEFAULT_ASK_TIMEOUT_SECONDS,
     contain_errors: bool = True,
+    event_stream_handler: EventStreamHandler[Any] | None = None,
+    event_stream_handler_factory: EventStreamHandlerFactory | None = None,
+    cancel_grace_seconds: float = DEFAULT_CANCEL_GRACE_SECONDS,
 ) -> SubAgentToolset:
     """Create a toolset for delegating tasks to subagents.
 
@@ -1378,19 +1438,39 @@ def create_subagent_toolset(
             `ApprovalRequired`, `Skip*`), `UserError`, and `UsageLimitExceeded`
             always propagate. Individual subagents can
             override this with `SubAgentConfig["contain_errors"]`.
+        event_stream_handler: Streams every delegation's events -- model text,
+            thinking, tool calls and their results -- as they happen, so an
+            application can show what a specialist is doing rather than a
+            spinner. Applies to dynamically created specialists too, which the
+            library builds itself and which therefore cannot carry a handler of
+            their own. An agent passed in as `SubAgentConfig["agent"]` with its
+            own `event_stream_handler` keeps it: the specific choice wins and
+            this is the default for everything else.
+        event_stream_handler_factory: The same, resolved per delegation from the
+            parent run context, the subagent config and the task id. Use it when
+            the handler has to label its events -- a fan-out of three specialists
+            streaming into one callback is otherwise indistinguishable. Mutually
+            exclusive with `event_stream_handler`.
+        cancel_grace_seconds: How long `cancel_all` waits for a cancelled
+            background task to unwind before logging it and moving on. Bounded
+            because the wait happens in the finalizer of the parent run: a
+            subagent that swallows `CancelledError` would otherwise hold the
+            whole run's teardown open.
 
     Returns:
         A `SubAgentToolset` configured with the subagent management tools.
 
     Raises:
         ValueError: If `max_result_chars` or `max_agents` is negative; if
-            `ask_timeout_seconds` is not positive; if `max_chat_traces` or
+            `ask_timeout_seconds` or `cancel_grace_seconds` is not positive; if
+            `max_chat_traces` or
             `max_task_handles` is below 1; if `delegation_configuration` is invalid; if
             `"oneshot_only"` is combined with `subagents` or a `registry`, neither
-            of which is reachable without `task`; or if a mode exposing neither
+            of which is reachable without `task`; if a mode exposing neither
             `create_agent` nor `delegate` is given `allowed_models`,
             `capabilities_map`, or `default_agent_factory`, which only those
-            tools consult.
+            tools consult; or if both `event_stream_handler` and
+            `event_stream_handler_factory` are given.
 
     Example:
         ```python
@@ -1434,4 +1514,7 @@ def create_subagent_toolset(
         max_result_chars=max_result_chars,
         ask_timeout_seconds=ask_timeout_seconds,
         contain_errors=contain_errors,
+        event_stream_handler=event_stream_handler,
+        event_stream_handler_factory=event_stream_handler_factory,
+        cancel_grace_seconds=cancel_grace_seconds,
     )

--- a/src/subagents_pydantic_ai/types.py
+++ b/src/subagents_pydantic_ai/types.py
@@ -19,6 +19,8 @@ from pydantic_ai.models import Model
 from typing_extensions import NotRequired, TypedDict
 
 if TYPE_CHECKING:
+    from pydantic_ai import DeferredToolRequests
+    from pydantic_ai.agent import EventStreamHandler
     from pydantic_ai.messages import FinishReason
     from pydantic_ai.toolsets import AbstractToolset
     from pydantic_ai.usage import RunUsage
@@ -102,6 +104,15 @@ class TaskStatus(_ValueStrEnum):
     RETRYING = "retrying"
     """Task hit a transient error and is waiting to retry."""
 
+    DEFERRED = "deferred"
+    """Task suspended for human approval or a deferred tool call.
+
+    Distinct from `FAILED`: nothing went wrong, the subagent is waiting on a
+    decision this library cannot make. Terminal here because resuming a
+    suspension belongs to whoever holds the deferred requests -- see
+    `TaskHandle.deferred_requests`.
+    """
+
 
 # Type aliases
 ExecutionMode = Literal["sync", "async", "auto"]
@@ -128,7 +139,7 @@ DelegationConfiguration = Literal[
 
 
 TERMINAL_STATUSES: frozenset[TaskStatus] = frozenset(
-    {TaskStatus.COMPLETED, TaskStatus.FAILED, TaskStatus.CANCELLED}
+    {TaskStatus.COMPLETED, TaskStatus.FAILED, TaskStatus.CANCELLED, TaskStatus.DEFERRED}
 )
 """Statuses a task never leaves. The first terminal transition wins."""
 
@@ -336,6 +347,30 @@ subagent config. Return `None` to run that task without explicit limits.
 """
 
 
+EventStreamHandlerFactory = Callable[
+    [RunContext[Any], SubAgentConfig, str], "EventStreamHandler[Any] | None"
+]
+"""Factory resolving the event-stream handler for one delegated subagent task.
+
+Called once per delegation with the parent run context, the selected subagent
+config, and the task id. The task id is the argument that makes a fan-out
+readable: three specialists streaming into one handler are otherwise
+indistinguishable, and the events themselves carry nothing to tell them apart.
+
+Return `None` to run that task without streaming.
+
+Example:
+    ```python
+    def handler_for(ctx: RunContext[object], config: SubAgentConfig, task_id: str):
+        async def on_events(run_ctx: RunContext[object], events: Any) -> None:
+            async for event in events:
+                await socket.send({"task_id": task_id, "subagent": config["name"], "event": event})
+
+        return on_events
+    ```
+"""
+
+
 def _generate_message_id() -> str:
     """Generate a unique message ID."""
     return str(uuid.uuid4())
@@ -393,6 +428,10 @@ class TaskHandle:
         parent_run_id: `run_id` of the parent run that started this task. Tools
             use it to refuse cross-run access, and the capability uses it to
             cancel a run's tasks when that run ends.
+        deferred_requests: The tool calls a `DEFERRED` subagent is suspended on.
+            Set only for that status, and the only place they survive: the
+            delegation raises so the signal reaches the parent run, and a raise
+            carries no result to read them off.
     """
 
     task_id: str
@@ -426,6 +465,7 @@ class TaskHandle:
     retry_count: int = 0
     """Number of transient-failure retries performed for this task."""
     parent_run_id: str | None = None
+    deferred_requests: DeferredToolRequests | None = None
 
     @property
     def is_finished(self) -> bool:

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -14,14 +14,16 @@ from datetime import timezone
 from typing import Any
 
 import pytest
-from pydantic_ai import UsageLimits
+from pydantic_ai import DeferredToolRequests, UsageLimits
 from pydantic_ai.exceptions import (
     ApprovalRequired,
     CallDeferred,
     ModelRetry,
     UnexpectedModelBehavior,
     UsageLimitExceeded,
+    UserError,
 )
+from pydantic_ai.messages import ToolCallPart
 from pydantic_ai.models.test import TestModel
 from pydantic_ai.toolsets import FunctionToolset
 
@@ -67,7 +69,7 @@ class Ctx:
 
 
 class _Run:
-    def __init__(self, output: str) -> None:
+    def __init__(self, output: Any) -> None:
         self.result = _Result(output)
         self.next_node: Any = object()
 
@@ -81,7 +83,7 @@ class _Run:
 
 
 class _Result:
-    def __init__(self, output: str) -> None:
+    def __init__(self, output: Any) -> None:
         self.output = output
 
 
@@ -106,7 +108,7 @@ class StubAgent:
 
     def __init__(
         self,
-        output: str = "done",
+        output: Any = "done",
         error: BaseException | None = None,
         block: asyncio.Event | None = None,
     ) -> None:
@@ -841,12 +843,35 @@ class TestErrorContract:
         with pytest.raises(ValueError, match="bad argument"):
             await toolset.tools["task"].function(Ctx(), "work", "worker")
 
-    async def test_sync_marks_handle_failed_when_signal_propagates(self) -> None:
+    async def test_sync_marks_handle_deferred_when_a_suspension_propagates(self) -> None:
+        """A suspension is not a failure, and the handle has to say which it was.
+
+        `FAILED` sent a caller looking for a defect when what the delegation
+        needs is a person to decide.
+        """
         handle = TaskHandle(task_id="t1", subagent_name="worker", description="d")
 
         with pytest.raises(CallDeferred):
             await _run_sync(
                 agent=StubAgent(error=CallDeferred()),
+                config=_config(),
+                description="work",
+                deps=Deps(),
+                task_id="t1",
+                handle=handle,
+            )
+
+        assert handle.status == TaskStatus.DEFERRED
+        assert handle.error is not None
+        assert handle.error.startswith("CallDeferred:")
+
+    async def test_sync_marks_handle_failed_when_a_non_suspension_signal_propagates(self) -> None:
+        """`UserError` and the `Skip*` signals still propagate as failures."""
+        handle = TaskHandle(task_id="t1", subagent_name="worker", description="d")
+
+        with pytest.raises(UserError):
+            await _run_sync(
+                agent=StubAgent(error=UserError("misconfigured")),
                 config=_config(),
                 description="work",
                 deps=Deps(),
@@ -876,7 +901,7 @@ class TestErrorContract:
         await asyncio.gather(*manager.tasks.values(), return_exceptions=True)
 
         handle = manager.handles["t1"]
-        assert handle.status == TaskStatus.FAILED
+        assert handle.status == TaskStatus.DEFERRED
         assert "cannot run in the background" in (handle.error or "")
         assert "mode='sync'" in (handle.error or "")
 
@@ -1317,3 +1342,396 @@ class _HistoryRecordingAgent:
     def iter(self, prompt: Any = None, **kwargs: Any) -> Any:
         self.seen_history = kwargs.get("message_history")
         return _CM(StubAgent())
+
+
+# --------------------------------------------------------------------------- #
+# Deferred output
+# --------------------------------------------------------------------------- #
+
+
+def _deferred(*, approvals: bool = False, calls: bool = False) -> DeferredToolRequests:
+    """A `DeferredToolRequests` holding whichever kind of parked call is asked for."""
+    return DeferredToolRequests(
+        calls=[ToolCallPart(tool_name="fetch", args={}, tool_call_id="c1")] if calls else [],
+        approvals=(
+            [ToolCallPart(tool_name="send_email", args={}, tool_call_id="a1")] if approvals else []
+        ),
+    )
+
+
+class TestDeferredOutput:
+    """A suspended subagent must not be reported to the parent as a finished one.
+
+    `_ALWAYS_PROPAGATE` guards the exception route, but an agent whose
+    `output_type` includes `DeferredToolRequests` never raises: the run ends
+    normally with the parked calls as its output. That reached `serialize_output`,
+    so the parent read `{"calls": [], "approvals": [...]}` as the subagent's
+    answer and the handle said `completed` -- the exact outcome the module
+    docstring says the design prevents, arriving by the other route.
+    """
+
+    async def test_sync_raises_approval_required_instead_of_answering(self) -> None:
+        handle = TaskHandle(task_id="t1", subagent_name="worker", description="d")
+
+        with pytest.raises(ApprovalRequired):
+            await _run_sync(
+                agent=StubAgent(output=_deferred(approvals=True)),
+                config=_config(),
+                description="send the email",
+                deps=Deps(),
+                task_id="t1",
+                handle=handle,
+            )
+
+        assert handle.status == TaskStatus.DEFERRED
+        assert handle.result is None
+
+    async def test_sync_raises_call_deferred_when_nothing_needs_approval(self) -> None:
+        """Only deferred calls means nobody has to be asked, so `CallDeferred` is the signal."""
+        handle = TaskHandle(task_id="t1", subagent_name="worker", description="d")
+
+        with pytest.raises(CallDeferred):
+            await _run_sync(
+                agent=StubAgent(output=_deferred(calls=True)),
+                config=_config(),
+                description="fetch it",
+                deps=Deps(),
+                task_id="t1",
+                handle=handle,
+            )
+
+        assert handle.status == TaskStatus.DEFERRED
+
+    async def test_an_approval_outranks_a_deferred_call(self) -> None:
+        """A parent told only that a call was deferred would never ask anyone."""
+        with pytest.raises(ApprovalRequired):
+            await _run_sync(
+                agent=StubAgent(output=_deferred(approvals=True, calls=True)),
+                config=_config(),
+                description="both",
+                deps=Deps(),
+                task_id="t1",
+            )
+
+    async def test_the_parked_calls_survive_on_the_handle(self) -> None:
+        """The raise carries no result, so the handle is the only place they can be read."""
+        handle = TaskHandle(task_id="t1", subagent_name="worker", description="d")
+
+        with pytest.raises(ApprovalRequired):
+            await _run_sync(
+                agent=StubAgent(output=_deferred(approvals=True)),
+                config=_config(),
+                description="send the email",
+                deps=Deps(),
+                task_id="t1",
+                handle=handle,
+            )
+
+        assert handle.deferred_requests is not None
+        assert [call.tool_name for call in handle.deferred_requests.approvals] == ["send_email"]
+
+    async def test_a_suspended_run_does_not_save_its_chat_trace(self) -> None:
+        """Resuming a trace saved mid-suspension would replay a point that never resolved."""
+        saved: list[list[Any]] = []
+
+        with pytest.raises(ApprovalRequired):
+            await _run_sync(
+                agent=StubAgent(output=_deferred(approvals=True)),
+                config=_config(),
+                description="send the email",
+                deps=Deps(),
+                task_id="t1",
+                on_message_history=saved.append,
+            )
+
+        assert saved == []
+
+    async def test_an_empty_deferred_output_is_an_ordinary_result(self) -> None:
+        """Nothing is parked, so there is nothing to strand the delegation on."""
+        handle = TaskHandle(task_id="t1", subagent_name="worker", description="d")
+
+        result = await _run_sync(
+            agent=StubAgent(output=DeferredToolRequests()),
+            config=_config(),
+            description="work",
+            deps=Deps(),
+            task_id="t1",
+            handle=handle,
+        )
+
+        assert handle.status == TaskStatus.COMPLETED
+        assert "calls" in result
+
+    async def test_background_records_deferred_rather_than_completed(self) -> None:
+        """No caller is left to hand the parked calls back to, so this is as far as it goes."""
+        manager = TaskManager(message_bus=InMemoryMessageBus())
+
+        await _run_async(
+            agent=StubAgent(output=_deferred(approvals=True)),
+            config=_config(),
+            description="send the email",
+            deps=Deps(),
+            task_id="t1",
+            task_manager=manager,
+            message_bus=manager.message_bus,
+        )
+        await asyncio.gather(*manager.tasks.values(), return_exceptions=True)
+
+        handle = manager.handles["t1"]
+        assert handle.status == TaskStatus.DEFERRED
+        assert handle.result is None
+        assert "mode='sync'" in (handle.error or "")
+        assert handle.deferred_requests is not None
+
+    async def test_a_cancel_that_already_landed_outranks_the_suspension(self) -> None:
+        """First terminal transition wins: a cancelled task does not become deferred."""
+        handle = TaskHandle(task_id="t1", subagent_name="worker", description="d")
+        handle.finish(TaskStatus.CANCELLED, error="Task was cancelled")
+
+        with pytest.raises(ApprovalRequired):
+            await _run_sync(
+                agent=StubAgent(output=_deferred(approvals=True)),
+                config=_config(),
+                description="send the email",
+                deps=Deps(),
+                task_id="t1",
+                handle=handle,
+            )
+
+        assert handle.status == TaskStatus.CANCELLED
+        assert handle.deferred_requests is None
+
+    async def test_a_background_cancel_that_already_landed_outranks_the_suspension(self) -> None:
+        """The same invariant on the background path, where the cancel arrives mid-run."""
+        manager = TaskManager(message_bus=InMemoryMessageBus())
+        block = asyncio.Event()
+
+        await _run_async(
+            agent=StubAgent(output=_deferred(approvals=True), block=block),
+            config=_config(),
+            description="send the email",
+            deps=Deps(),
+            task_id="t1",
+            task_manager=manager,
+            message_bus=manager.message_bus,
+        )
+        await asyncio.sleep(0)
+        manager.handles["t1"].finish(TaskStatus.CANCELLED, error="Task was cancelled")
+        block.set()
+        await asyncio.gather(*manager.tasks.values(), return_exceptions=True)
+
+        handle = manager.handles["t1"]
+        assert handle.status == TaskStatus.CANCELLED
+        assert handle.deferred_requests is None
+
+    async def test_check_task_tells_the_model_a_delegation_is_waiting_on_a_person(self) -> None:
+        """The model reads the outcome, not the status name, so the guidance has to be in it."""
+        toolset = _toolset()
+        toolset._compiled["worker"].agent = StubAgent(output=_deferred(approvals=True))
+
+        with pytest.raises(ApprovalRequired):
+            await toolset.tools["task"].function(Ctx(), "send the email", "worker")
+
+        task_id = next(iter(toolset.task_manager.handles))
+        rendered = await toolset.tools["check_task"].function(Ctx(), task_id)
+
+        assert "Status: deferred" in rendered
+        assert "human decision" in rendered
+
+
+# --------------------------------------------------------------------------- #
+# Event streaming
+# --------------------------------------------------------------------------- #
+
+
+class _StreamingAgent:
+    """Agent stand-in that reports whichever handler `run_with_retry` resolved."""
+
+    def __init__(self, own_handler: Any = None) -> None:
+        if own_handler is not None:
+            self.event_stream_handler = own_handler
+        self.seen_handler: Any = _UNSET
+
+    def iter(self, prompt: Any = None, **kwargs: Any) -> _CM:
+        return _CM(StubAgent())
+
+
+class TestEventStreamHandler:
+    """Streaming a delegation must not require reaching into each agent instance.
+
+    A handler could only be set on the agent object, which a dynamically created
+    specialist does not have -- the library builds it -- so "stream subagents"
+    and "let the model create specialists" were mutually exclusive, undocumented.
+    """
+
+    @staticmethod
+    def _record(calls: list[tuple[str, str]], label: str) -> Any:
+        async def handler(ctx: Any, events: Any) -> None:  # pragma: no cover - never awaited
+            calls.append((label, "streamed"))
+
+        return handler
+
+    async def test_the_toolset_handler_reaches_the_run(self, monkeypatch: Any) -> None:
+        seen: dict[str, Any] = {}
+
+        async def fake_run_with_retry(*args: Any, **kwargs: Any) -> Any:
+            seen["handler"] = kwargs.get("event_stream_handler")
+            return _Run("done").result
+
+        monkeypatch.setattr("subagents_pydantic_ai._execution.run_with_retry", fake_run_with_retry)
+        handler = self._record([], "toolset")
+
+        await _run_sync(
+            agent=StubAgent(),
+            config=_config(),
+            description="work",
+            deps=Deps(),
+            task_id="t1",
+            event_stream_handler=handler,
+        )
+
+        assert seen["handler"] is handler
+
+    async def test_an_agents_own_handler_wins_over_the_toolsets(self, monkeypatch: Any) -> None:
+        """A handler set on one specialist is a deliberate choice about that specialist."""
+        seen: dict[str, Any] = {}
+
+        async def fake_run_with_retry(*args: Any, **kwargs: Any) -> Any:
+            seen["handler"] = kwargs.get("event_stream_handler")
+            return _Run("done").result
+
+        monkeypatch.setattr("subagents_pydantic_ai._execution.run_with_retry", fake_run_with_retry)
+        own = self._record([], "own")
+        toolset_handler = self._record([], "toolset")
+
+        await _run_sync(
+            agent=_StreamingAgent(own_handler=own),
+            config=_config(),
+            description="work",
+            deps=Deps(),
+            task_id="t1",
+            event_stream_handler=toolset_handler,
+        )
+
+        assert seen["handler"] is own
+
+    async def test_a_background_delegation_streams_too(self, monkeypatch: Any) -> None:
+        seen: dict[str, Any] = {}
+
+        async def fake_run_with_retry(*args: Any, **kwargs: Any) -> Any:
+            seen["handler"] = kwargs.get("event_stream_handler")
+            return _Run("done").result
+
+        monkeypatch.setattr("subagents_pydantic_ai._execution.run_with_retry", fake_run_with_retry)
+        manager = TaskManager(message_bus=InMemoryMessageBus())
+        handler = self._record([], "toolset")
+
+        await _run_async(
+            agent=StubAgent(),
+            config=_config(),
+            description="work",
+            deps=Deps(),
+            task_id="t1",
+            task_manager=manager,
+            message_bus=manager.message_bus,
+            event_stream_handler=handler,
+        )
+        await asyncio.gather(*manager.tasks.values(), return_exceptions=True)
+
+        assert seen["handler"] is handler
+
+    async def test_the_factory_receives_the_task_id_that_labels_the_fan_out(self) -> None:
+        """Events carry nothing to tell concurrent specialists apart; the task id does."""
+        seen: list[tuple[str, str]] = []
+
+        def factory(ctx: Any, config: SubAgentConfig, task_id: str) -> Any:
+            seen.append((config["name"], task_id))
+            return None
+
+        toolset = _toolset(event_stream_handler_factory=factory)
+        toolset._compiled["worker"].agent = StubAgent()
+
+        await toolset.tools["task"].function(Ctx(), "work", "worker")
+
+        assert len(seen) == 1
+        name, task_id = seen[0]
+        assert name == "worker"
+        assert task_id in toolset.task_manager.handles
+
+    def test_a_handler_and_a_factory_together_are_refused(self) -> None:
+        """Both are callables, so nothing downstream could tell them apart."""
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            _toolset(
+                event_stream_handler=self._record([], "h"),
+                event_stream_handler_factory=lambda ctx, config, task_id: None,
+            )
+
+
+# --------------------------------------------------------------------------- #
+# Cancellation is bounded
+# --------------------------------------------------------------------------- #
+
+
+class TestCancelGrace:
+    """`cancel_all` runs in the finalizer of a parent run, so its wait must end.
+
+    `CancelledError` can be caught, and a subagent's toolset is arbitrary consumer
+    code. Awaiting each cancelled task with no bound meant one subagent that
+    swallowed the cancel held the parent run's teardown open forever, with
+    nothing logged.
+    """
+
+    @staticmethod
+    async def _uncancellable(started: asyncio.Event, release: asyncio.Event) -> None:
+        started.set()
+        while True:
+            try:
+                await release.wait()
+                return
+            except asyncio.CancelledError:
+                # Exactly the shape a too-wide `suppress` or a shielded client has.
+                continue
+
+    async def test_a_task_that_ignores_cancellation_does_not_hang_the_caller(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        manager = TaskManager(message_bus=InMemoryMessageBus(), cancel_grace_seconds=0.01)
+        started, release = asyncio.Event(), asyncio.Event()
+        handle = TaskHandle(task_id="stuck", subagent_name="worker", description="d")
+        manager.create_task("stuck", self._uncancellable(started, release), handle)
+        await started.wait()
+
+        with caplog.at_level(logging.WARNING):
+            await asyncio.wait_for(manager.cancel_all(), timeout=2)
+
+        assert "did not unwind" in caplog.text
+        assert "stuck" in caplog.text
+        assert handle.status == TaskStatus.CANCELLED
+
+        release.set()
+        await asyncio.sleep(0)
+
+    async def test_a_well_behaved_task_is_still_awaited(self) -> None:
+        """The bound must not turn a clean unwind into a leak report."""
+        manager = TaskManager(message_bus=InMemoryMessageBus(), cancel_grace_seconds=5.0)
+        cleaned = asyncio.Event()
+
+        async def polite() -> None:
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                cleaned.set()
+                raise
+
+        handle = TaskHandle(task_id="polite", subagent_name="worker", description="d")
+        manager.create_task("polite", polite(), handle)
+        await asyncio.sleep(0)
+
+        await manager.cancel_all()
+
+        assert cleaned.is_set()
+        assert manager.tasks["polite"].cancelled()
+
+    def test_a_non_positive_grace_is_refused(self) -> None:
+        with pytest.raises(ValueError, match="cancel_grace_seconds must be > 0"):
+            _toolset(cancel_grace_seconds=0)

--- a/uv.lock
+++ b/uv.lock
@@ -1333,7 +1333,7 @@ wheels = [
 
 [[package]]
 name = "subagents-pydantic-ai"
-version = "0.2.14"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
Closes #64, #65, #66 — all three came out of one integration, and they touch the
same three modules, so they land together.

## What changed

**#64 — a suspended subagent was reported as a completed task.** The headline, and
the one worth reading the diff for. `_ALWAYS_PROPAGATE` guards the exception route,
but an agent whose `output_type` includes `DeferredToolRequests` never raises:
pydantic-ai ends its run normally with the parked calls as the output, exactly as
it does for a top-level run a caller is expected to resume. That reached
`serialize_output`, so the parent agent received

```json
{"calls": [], "approvals": [{"tool_name": "send_email", "tool_call_id": "a1"}], "metadata": {}}
```

as the specialist's answer, summarised it, and carried on — with `handle.status`
saying `completed` and the approval surfaced nowhere. It is the outcome the module
docstring says the design prevents, arriving by the output rather than the
exception.

A deferred output is now the fifth entry in the error contract: `DEFERRED` on the
handle, the parked calls kept on `TaskHandle.deferred_requests` (the raise carries
no result, so the handle is the only place they can survive), and the matching
signal raised — `ApprovalRequired` when anything needs approving, `CallDeferred`
otherwise. A parent told only that a call was deferred would resume it with a tool
result and nobody would ever be asked the question the child stopped for. The
suspended run's chat trace is deliberately **not** saved: continuing it would
resume from a point whose deferred results were never supplied.

**#66 — `cancel_all` waited without a bound, inside a `finally`.** A
`CancelledError` can be caught, and a subagent's toolset is arbitrary consumer
code, so one task that swallowed the cancel held the parent run's teardown open
forever with nothing logged. Now bounded by `cancel_grace_seconds` (5 s default,
configurable on `TaskManager`, `create_subagent_toolset` and
`SubAgentCapability`); anything still alive after it is logged with its task id and
left to the event loop. `asyncio.wait` replaces the per-task `await` — it returns
on timeout instead of raising, and never re-raises a task's own exception, so one
subagent's failure cannot stop the others being waited on.

**#65 — `event_stream_handler` on the toolset and the capability.** Streaming
worked, but only by setting the handler on each agent instance — which a
dynamically created specialist does not have, since the library builds it. So
"stream subagents" and "let the model create specialists" were quietly
incompatible, and neither was documented. The handler is resolved per delegation
now, which fixes both. `event_stream_handler_factory` is the same thing resolved
from `(ctx, config, task_id)`, because events carry nothing to tell a fan-out
apart. The two are mutually exclusive and refused at construction: both are
callables, so nothing downstream could tell them apart and one would silently win.

Precedence: an agent supplied as `SubAgentConfig["agent"]` keeps its own handler —
that is a deliberate choice about one specialist — and the toolset's fills in for
everything else.

## Behaviour change

A human-in-the-loop delegation records `DEFERRED` where both routes previously
recorded `FAILED`. `FAILED` sent a caller looking for a defect when what the
delegation needs is a person to decide, and it made the deferred-output bug harder
to see. `UserError` and the `Skip*` signals still record `FAILED`. The background
message is unchanged and still tells the model to use `mode="sync"`.

Code branching on `TaskStatus.FAILED` to detect a suspended delegation needs
updating — hence **0.3.0** rather than a patch.

## New public API

`TaskStatus.DEFERRED` (in `TERMINAL_STATUSES`) · `TaskHandle.deferred_requests` ·
`EventStreamHandlerFactory` · `DEFAULT_CANCEL_GRACE_SECONDS` ·
`event_stream_handler`, `event_stream_handler_factory` and `cancel_grace_seconds`
on `create_subagent_toolset` and `SubAgentCapability`.

## Verification

- `make all` — 1173 tests, **100% branch coverage**, ruff, pyright strict, mypy
  strict, on the repo's pinned interpreter.
- `uv run mkdocs build --strict`.
- **pydantic-deep against this branch: 2785 passed.** AGENTS.md asks for this
  before a signature or export changes; the couplings it lists
  (`toolset.Agent`, `_compile_subagent`, `task_manager`) are untouched, and
  `TaskManager`'s new field is appended so positional construction is unaffected.

Three existing tests changed rather than being added to, all pinning the
`FAILED`-for-a-suspension behaviour above. Each now states in its docstring what it
pins instead, and a new test covers the `UserError`/`Skip*` half that genuinely
should stay `FAILED` — the previous test was the only thing guarding that path and
loosening it silently would have been the easy mistake here.

## Docs

`docs/advanced/errors.md` gains the deferred-output outcome (four → five),
`docs/advanced/cancellation.md` documents the grace period and what the guarantee
now is, and `docs/advanced/streaming.md` is new — the first documentation that
streaming a subagent is possible at all.