### PR TITLE
chore: release 0.2.15, not 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.3.0] - 2026-08-02
+## [0.2.15] - 2026-08-02
 
 Three defects found integrating the library into a platform where every agent is
 built with `output_type=[str, DeferredToolRequests]`, which made the first one the
 default path rather than an edge case.
 
-The minor bump is for the status change: a suspended delegation now reports
+One entry changes observable behaviour: a suspended delegation now reports
 `deferred` where it used to report `completed` (a real defect) or `failed` (an
 honest but wrong label). Code branching on `TaskStatus.FAILED` to detect a
 human-in-the-loop delegation needs updating.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "subagents-pydantic-ai"
-version = "0.3.0"
+version = "0.2.15"
 description = "Subagent toolset for pydantic-ai with dual-mode execution and dynamic agent creation"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -1333,7 +1333,7 @@ wheels = [
 
 [[package]]
 name = "subagents-pydantic-ai"
-version = "0.3.0"
+version = "0.2.15"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
Corrects the version before the release is cut. Nothing was published under
0.3.0 — no tag, no GitHub release, no PyPI artifact — so this is a number in
three files, not a yank.

- `pyproject.toml`: `0.3.0` → `0.2.15`
- `uv.lock`: regenerated with `uv lock`
- `CHANGELOG.md`: heading, and the paragraph that framed the status change as
  the reason for a minor bump. The change itself is unchanged and still called
  out — code branching on `TaskStatus.FAILED` to detect a human-in-the-loop
  delegation needs updating.

`make lint`, 1173 tests at 100% branch coverage, and `mkdocs build --strict`
all pass.