### PR TITLE
chore(deps): close five advisories and give CI least privilege

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,12 @@ on:
 env:
   COLUMNS: 150
 
+# Least privilege for every job below: this workflow only reads the checkout.
+# Without it each job inherits the repository default, which can be write, and
+# an action compromised anywhere in the matrix would inherit it too.
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,43 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.16] - 2026-08-03
+
+Security housekeeping. **Nothing in the published package changes**: all five
+advisories are against development and documentation dependencies -- `pytest`,
+`requests`, `urllib3`, `pygments`, `pymdown-extensions` -- none of which this
+library depends on at run time. Its runtime dependencies are still `pydantic`,
+`pydantic-ai-slim` and `typing-extensions`. The exposure was this repository's CI
+and a maintainer's docs build, not anybody's install.
+
+### Security
+
+- **`urllib3` 2.6.3 -> 2.7.0**, closing two high-severity advisories:
+  decompression-bomb safeguards bypassed in parts of the streaming API, and
+  sensitive headers forwarded across origins in proxied low-level redirects.
+- **`pymdown-extensions` 10.20 -> 11.0.1**, closing two: path traversal in the
+  `b64` extension letting `<img src>` read files outside `base_path`, and a
+  regression reintroducing the sibling-prefix traversal bypass in
+  `pymdownx.snippets` despite `restrict_base_path`. A major bump, so the docs
+  build was checked for rendered output rather than just an exit code -- the
+  changelog page is a `pymdownx.snippets` include of `CHANGELOG.md` from outside
+  `docs/`, which is exactly what the second advisory tightened.
+- **`requests` 2.32.5 -> 2.34.2**, closing insecure temporary-file reuse in
+  `extract_zipped_paths()`.
+- **`pytest` 9.0.2 -> 9.1.1**, closing vulnerable `tmpdir` handling.
+- **`pygments` 2.19.2 -> 2.20.0**, closing a ReDoS in the GUID-matching regex.
+- **`.github/workflows/ci.yml` declares `permissions: contents: read`.** It had no
+  permissions block at all, so all four of its jobs inherited the repository
+  default -- which can be write -- and an action compromised anywhere in the test
+  matrix would have inherited it too. Four CodeQL `actions/missing-workflow-permissions`
+  alerts, closed by one top-level block. The other three workflows already
+  declared theirs.
+
+Version constraints in `pyproject.toml` are deliberately unchanged: CI installs
+from the lockfile, which is what both Dependabot and Renovate patch, and raising
+a floor for a transitive dependency states a fact about a resolution rather than
+about this package.
+
 ## [0.2.15] - 2026-08-02
 
 Three defects found integrating the library into a platform where every agent is

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "subagents-pydantic-ai"
-version = "0.2.15"
+version = "0.2.16"
 description = "Subagent toolset for pydantic-ai with dual-mode execution and dynamic agent creation"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -1105,24 +1105,24 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.19.2"
+version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
 ]
 
 [[package]]
 name = "pymdown-extensions"
-version = "10.20"
+version = "11.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3e/35/e3814a5b7df295df69d035cfb8aab78b2967cdf11fcfae7faed726b66664/pymdown_extensions-10.20.tar.gz", hash = "sha256:5c73566ab0cf38c6ba084cb7c5ea64a119ae0500cce754ccb682761dfea13a52", size = 852774, upload-time = "2025-12-31T19:59:42.211Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/a9/5f0c535ba3b08fe09270c16808e053a968868242ecbd5676d4e3a488bf28/pymdown_extensions-11.0.1.tar.gz", hash = "sha256:dd2905ae6fc5b75582fafb139a1266ffc754705efa902aa50067fa7ff4f94ec0", size = 857113, upload-time = "2026-07-02T17:59:22.955Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ea/10/47caf89cbb52e5bb764696fd52a8c591a2f0e851a93270c05a17f36000b5/pymdown_extensions-10.20-py3-none-any.whl", hash = "sha256:ea9e62add865da80a271d00bfa1c0fa085b20d133fb3fc97afdc88e682f60b2f", size = 268733, upload-time = "2025-12-31T19:59:40.652Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/54/da572c98c0b77626a91b5d3b89f0231d8bff5125c225420908632f8b342d/pymdown_extensions-11.0.1-py3-none-any.whl", hash = "sha256:db3943a62bab7e03af1364f0c4083e64b91fb097675a4b6cceccfbe9a77e5eb2", size = 269455, upload-time = "2026-07-02T17:59:21.271Z" },
 ]
 
 [[package]]
@@ -1149,7 +1149,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.2"
+version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -1160,9 +1160,9 @@ dependencies = [
     { name = "pygments" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]
@@ -1283,7 +1283,7 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.32.5"
+version = "2.34.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -1291,9 +1291,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
 ]
 
 [[package]]
@@ -1333,7 +1333,7 @@ wheels = [
 
 [[package]]
 name = "subagents-pydantic-ai"
-version = "0.2.15"
+version = "0.2.16"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },
@@ -1483,11 +1483,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Supersedes #69, #70, #71, #72, #73 and #74 with one lockfile resolution, and adds
the CodeQL finding none of them covered. Released as **0.2.16**.

## Nothing in the published package changes

All five advisories are against development and documentation dependencies. This
library's runtime dependencies are still `pydantic`, `pydantic-ai-slim` and
`typing-extensions` — none of `pytest`, `requests`, `urllib3`, `pygments` or
`pymdown-extensions` is among them. What was exposed is this repository's CI and a
maintainer's docs build, not anybody's install. Saying so plainly so the release is
not read as urgent by people depending on it.

## Dependabot alerts

| Alert | Package | | Advisory |
|---|---|---|---|
| #4, #5 · **high** | `urllib3` | 2.6.3 → **2.7.0** | Decompression-bomb safeguards bypassed in parts of the streaming API; sensitive headers forwarded across origins in proxied low-level redirects |
| #6, #7 · moderate | `pymdown-extensions` | 10.20 → **11.0.1** | Path traversal in the `b64` extension; regression reintroducing sibling-prefix traversal in `pymdownx.snippets` despite `restrict_base_path` |
| #1 · moderate | `requests` | 2.32.5 → **2.34.2** | Insecure temp-file reuse in `extract_zipped_paths()` |
| #3 · moderate | `pytest` | 9.0.2 → **9.1.1** | Vulnerable `tmpdir` handling |
| #2 · low | `pygments` | 2.19.2 → **2.20.0** | ReDoS in the GUID-matching regex |

Two resolved above the minimum the advisory names: `pymdown-extensions` to 11.0.1
(one advisory is patched in 10.21.3, the other only in 11.0.0, so 11.x is required
to clear both) and `pytest` to 9.1.1 rather than 9.0.3.

## CodeQL alerts #1–#4

`ci.yml` had no `permissions` block at all, so all four of its jobs inherited the
repository default — which can be write — and an action compromised anywhere in the
test matrix would have inherited it too. One top-level `permissions: contents: read`
closes all four. `publish.yml`, `docs.yml` and `add-to-project.yml` already declared
theirs, so this brings the last workflow in line rather than introducing a pattern.

## What was checked rather than trusted

- **`pymdown-extensions` is a major bump**, and `docs/changelog.md` is a
  `pymdownx.snippets` include of `CHANGELOG.md` from *outside* `docs/` — precisely
  the path the second advisory tightened. A snippets change of that kind fails by
  rendering an empty page, not by a non-zero exit, so the build was verified by
  grepping the rendered HTML for the changelog body and for a leaked `--8<--`
  marker. Content is intact.
- **`pytest` jumped a minor**, past what the advisory asked for. Full suite passes
  on it.

## Deliberately not done

Version constraints in `pyproject.toml` are untouched. CI installs from the
lockfile, which is what both bots patch, and raising a floor for a transitive
dependency states a fact about one resolution rather than about this package.
`pytest` is the only direct dependency among the five and `>=9.0.0` still resolves
to the patched release.

## Verification

`make lint`, `make typecheck-both` (pyright + mypy strict), **1173 tests at 100%
branch coverage**, `mkdocs build --strict` with rendered output checked. No source
file changed, so the couplings AGENTS.md lists are untouched and pydantic-deep was
not re-run.