### PR TITLE
fix: a caller-supplied subagent honours can_ask_questions

### DIFF
--- a/docs/concepts/toolset.md
+++ b/docs/concepts/toolset.md
@@ -93,6 +93,13 @@ toolset = create_subagent_toolset(
 See [SubAgentConfig](types.md#subagentconfig) for full documentation of the `agent` and
 `agent_factory` fields.
 
+A caller-supplied agent (`agent` or `agent_factory`) is used exactly as given, so the
+`ask_parent` tool the default branch would attach is not compiled into it. `task`
+injects that tool at run time instead when the subagent's `can_ask_questions` allows it,
+so a pre-built or factory-built subagent asks questions on the same terms as a
+default-built one. If your factory attaches its own `ask_parent`, leave
+`can_ask_questions` off to avoid a duplicate.
+
 ## Available Tools
 
 The toolset provides these tools to your agent:

--- a/src/subagents_pydantic_ai/toolset.py
+++ b/src/subagents_pydantic_ai/toolset.py
@@ -222,6 +222,18 @@ def _compile_subagent(
     )
 
 
+def _agent_supplied_by_caller(config: SubAgentConfig) -> bool:
+    """Whether the caller handed in a ready agent rather than letting us build one.
+
+    Both the `agent` and `agent_factory` branches of `_compile_subagent` return the
+    caller's agent as-is, so neither reaches the point where an `ask_parent` toolset
+    is appended to a freshly built `Agent`. Only the default branch does that. A
+    caller-supplied agent that honours `can_ask_questions` therefore has to have the
+    tool injected at run time instead -- see the configured branch of `task`.
+    """
+    return config.get("agent") is not None or config.get("agent_factory") is not None
+
+
 def _create_ask_parent_toolset() -> FunctionToolset[Any]:
     """Create a toolset with the `ask_parent` tool a subagent uses to reach its parent."""
     toolset: FunctionToolset[Any] = FunctionToolset(id="ask_parent")
@@ -982,7 +994,14 @@ class SubAgentToolset(FunctionToolset[Any]):
         """
         if subagent_type in self._compiled:
             subagent = self._compiled[subagent_type]
-            inject_ask_parent = False
+            # A configured subagent whose agent we built already has `ask_parent`
+            # compiled in when `can_ask_questions` allows it. One that supplied its
+            # own agent (`agent` or `agent_factory`) skipped that step, so it is
+            # injected at run time instead -- `_execute` still gates on
+            # `can_ask_questions`, so a caller-supplied agent asks only when its
+            # config opts in. Without this such a subagent could never ask, whatever
+            # its `can_ask_questions` said.
+            inject_ask_parent = _agent_supplied_by_caller(subagent.config)
         elif (registry_subagent := self.registry.get_compiled(subagent_type)) is not None:
             subagent = registry_subagent
             inject_ask_parent = True

--- a/tests/test_toolset.py
+++ b/tests/test_toolset.py
@@ -2307,6 +2307,106 @@ class TestAskParentEdgeCases:
         assert "no communication channel" in result
 
 
+def _ask_parent_injected(agent: FakeAgent) -> bool:
+    """Whether the delegation's first run received an `ask_parent` toolset at run time."""
+    injected = agent.iter_calls[0].get("toolsets") or []
+    return any(getattr(toolset, "id", None) == "ask_parent" for toolset in injected)
+
+
+class TestConfiguredSubagentQuestions:
+    """A caller-supplied configured subagent honours `can_ask_questions` too.
+
+    `_compile_subagent` appends `ask_parent` only to an agent it builds itself, so a
+    subagent whose agent the caller supplied (`agent` or `agent_factory`) skips that
+    step. `task` makes up for it by injecting the tool at run time for those, still
+    gated on `can_ask_questions`. Without this a caller-supplied subagent -- which is
+    every delegate in a consumer like agenticos -- could never ask, whatever its
+    config said.
+    """
+
+    @pytest.mark.asyncio
+    async def test_prebuilt_subagent_may_ask_when_its_config_allows(self):
+        agent = FakeAgent(result=MockResult("done"))
+        config = SubAgentConfig(
+            name="researcher",
+            description="Researches",
+            instructions="Research",
+            agent=agent,
+            can_ask_questions=True,
+        )
+        toolset = create_subagent_toolset(subagents=[config], include_general_purpose=False)
+
+        ctx = MockRunContext(deps=MockDeps())
+        await toolset.tools["task"].function(ctx, "find X", "researcher", "sync")
+
+        assert _ask_parent_injected(agent)
+
+    @pytest.mark.asyncio
+    async def test_prebuilt_subagent_cannot_ask_when_its_config_forbids(self):
+        agent = FakeAgent(result=MockResult("done"))
+        config = SubAgentConfig(
+            name="summariser",
+            description="Summarises",
+            instructions="Summarise",
+            agent=agent,
+            can_ask_questions=False,
+        )
+        toolset = create_subagent_toolset(subagents=[config], include_general_purpose=False)
+
+        ctx = MockRunContext(deps=MockDeps())
+        await toolset.tools["task"].function(ctx, "summarise X", "summariser", "sync")
+
+        assert not _ask_parent_injected(agent)
+
+    @pytest.mark.asyncio
+    async def test_factory_built_subagent_may_ask_when_its_config_allows(self):
+        agent = FakeAgent(result=MockResult("done"))
+        config = SubAgentConfig(
+            name="factory-made",
+            description="Built by a factory",
+            instructions="Work",
+            agent_factory=lambda _config: agent,
+            can_ask_questions=True,
+        )
+        toolset = create_subagent_toolset(subagents=[config], include_general_purpose=False)
+
+        ctx = MockRunContext(deps=MockDeps())
+        await toolset.tools["task"].function(ctx, "do X", "factory-made", "sync")
+
+        assert _ask_parent_injected(agent)
+
+    @pytest.mark.asyncio
+    async def test_library_built_subagent_is_not_injected_again_at_run_time(self):
+        """A library-built agent already carries `ask_parent` from compile time.
+
+        Its config names no `agent`/`agent_factory`, so `task` must leave the run-time
+        injection off -- adding a second `ask_parent` toolset would duplicate the id.
+        """
+        agent = FakeAgent(result=MockResult("done"))
+        config = SubAgentConfig(
+            name="built-here",
+            description="Built by the library",
+            instructions="Work",
+            can_ask_questions=True,
+        )
+        compiled = CompiledSubAgent(
+            name=config["name"],
+            description=config["description"],
+            config=config,
+            agent=agent,
+        )
+        with patch(
+            "subagents_pydantic_ai.toolset._compile_subagent",
+            return_value=compiled,
+        ):
+            toolset = create_subagent_toolset(subagents=[config], include_general_purpose=False)
+
+            ctx = MockRunContext(deps=MockDeps())
+            await toolset.tools["task"].function(ctx, "do X", "built-here", "sync")
+
+        assert not _ask_parent_injected(agent)
+
+
 class TestToolsetFunctionsCoverage:
     """Tests to cover remaining toolset functions."""
 


### PR DESCRIPTION
## What this fixes

A subagent whose agent the caller supplies — `SubAgentConfig["agent"]` or
`agent_factory` — could never ask the parent a question, whatever its
`can_ask_questions` said.

`_compile_subagent` attaches the `ask_parent` toolset only to an agent it builds
itself; a caller-supplied agent is used as-is and skips that step. `task` then
hardcoded `inject_ask_parent=False` for the configured path, so the run-time
injection that would have made up for it never happened. Consumers that hand every
delegate over pre-built (agenticos does — each delegate arrives as
`SubAgentConfig["agent"]`) therefore had no delegate that could ask, ever.

## What changed

- `src/subagents_pydantic_ai/toolset.py` — `task` now decides `inject_ask_parent`
  from whether the caller supplied the agent (`_agent_supplied_by_caller`), instead
  of hardcoding `False` for the configured path. `_execute` already gates the
  injection on `can_ask_questions`, so the tool appears only when the subagent's
  config opts in.
- `tests/test_toolset.py` — four tests through `create_subagent_toolset` and a real
  run.
- `docs/concepts/toolset.md` — note that a caller-supplied agent honours
  `can_ask_questions` via run-time injection.

## Behaviour

| Subagent | `can_ask_questions` | `ask_parent` before | after |
|---|---|---|---|
| Prebuilt (`agent=`) | `True` | never | ✅ injected at run time |
| Prebuilt (`agent=`) | `False` | never | not injected |
| Factory (`agent_factory=`) | `True` | never | ✅ injected at run time |
| Default (library-built) | `True` | compiled in | unchanged — not injected again |

No double injection: a default-built agent still gets the tool exactly once, at
compile time.

## Testing

- `tests/test_toolset.py::TestConfiguredSubagentQuestions` — 4 new tests, all green.
- Full suite: 1177 passed, **100% coverage** (the gate).
- `ruff format --check`, `ruff check`, `pyright` (strict) and `mkdocs build
  --strict` all clean.

## Why now

Unblocks vstorm-co/agenticos#184 — letting a `sync` delegate ask the person already
waiting on its parent. agenticos will set `can_ask_questions` per its own
author-facing config once this ships; the dynamic (model-invented) entry points
there stay closed regardless.
