### PR TITLE
chore: release 0.2.17

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "subagents-pydantic-ai"
-version = "0.2.16"
+version = "0.2.17"
 description = "Subagent toolset for pydantic-ai with dual-mode execution and dynamic agent creation"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
Bumps the version so the caller-supplied-subagent `ask_parent` fix (#76) can ship.

0.2.17 = 0.2.16 + #76 (a pre-built/factory-built configured subagent now honours `can_ask_questions`, injecting `ask_parent` at run time). No other changes.

Merge, then publish the `0.2.17` GitHub release to trigger PyPI.