### PR TITLE
fix(toolset): build the general-purpose delegate through the host factory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,51 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.18] - 2026-08-05
+
+`default_model` no longer defaults to a model of the library's choosing. There is
+now **no implicit default**: it defaults to `None`, and anything that would have
+relied on the old fallback is refused instead of run.
+
+The old default was `"openai:gpt-4.1"`. A consumer that never set `default_model`
+got a delegate compiled against that string, which resolves whatever provider
+credential the process environment happens to hold. On a deployment holding no
+such key the build raised; on one that had `OPENAI_API_KEY` set it ran silently --
+in a multi-tenant host, a caller's work on a credential that was not theirs, off
+any per-caller model, budget or vault the host meant to enforce. The general-purpose
+delegate was the sharpest edge: it was always compiled from `default_model` at
+construction, so a host resolving a model per tenant had no single value to give it.
+
+### Changed
+
+- **`default_model` defaults to `None`** on `create_subagent_toolset`,
+  `SubAgentToolset`, `SubAgentCapability` and `create_agent_factory_toolset`. Pass
+  it to name the model subagents fall back on, or leave it unset to require every
+  subagent and every dynamic call to name one.
+- **The general-purpose delegate is now built the way every other subagent is** --
+  through `_compile_subagent`, from `default_model` or from `default_agent_factory`
+  when one is given. A host that resolves a model, a credential and a budget per
+  caller passes a `default_agent_factory` and gets a delegate it can account for,
+  rather than one the library compiled behind its back.
+
+### Fixed
+
+- **`include_general_purpose=True` with neither `default_model` nor
+  `default_agent_factory` now raises at construction**, naming the three ways out,
+  instead of failing later inside the model call (or not failing, on the wrong
+  credential).
+- **A `create_agent`, `delegate` or `task` call that names no model is refused with
+  a tool result** when there is no default -- the model can name one and call again
+  -- instead of the library choosing one for it.
+- **A configured subagent that names no model, and supplies no `agent` or
+  `agent_factory`, is refused when `default_model` is unset**, with a message
+  saying what it needs.
+
+Migration: a consumer relying on the old implicit `"openai:gpt-4.1"` should pass
+`default_model="openai:gpt-4.1"` explicitly. One that already names a model on
+every subagent and every call, or builds its own agents through a factory, needs
+no change.
+
 ## [0.2.16] - 2026-08-03
 
 Security housekeeping. **Nothing in the published package changes**: all five

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ from subagents_pydantic_ai import SubAgentCapability, SubAgentConfig
 agent = Agent(
     "openai:gpt-4.1",
     capabilities=[SubAgentCapability(
+        default_model="openai:gpt-4.1",
         subagents=[
             SubAgentConfig(
                 name="researcher",
@@ -93,7 +94,8 @@ result = await agent.run("Research Python async patterns and write a blog post a
 `SubAgentCapability` automatically:
 - Registers all delegation tools (`task`, `check_task`, `answer_subagent`, `list_active_tasks`, etc.)
 - Injects dynamic system prompt listing available subagents
-- Includes a general-purpose subagent by default
+- Includes a general-purpose subagent when given a `default_model` or a
+  `default_agent_factory` to build it from
 
 ### Alternative: Toolset API
 
@@ -104,6 +106,7 @@ from pydantic_ai import Agent
 from subagents_pydantic_ai import create_subagent_toolset, SubAgentConfig
 
 toolset = create_subagent_toolset(
+    default_model="openai:gpt-4.1",
     subagents=[
         SubAgentConfig(name="researcher", description="Researches topics", instructions="..."),
     ],
@@ -163,6 +166,7 @@ def my_toolsets_factory(deps):
     ]
 
 toolset = create_subagent_toolset(
+    default_model="openai:gpt-4.1",
     subagents=subagents,
     toolsets_factory=my_toolsets_factory,
 )
@@ -184,6 +188,7 @@ agent = Agent(
     "openai:gpt-4o",
     deps_type=Deps,
     toolsets=[create_subagent_toolset(
+        default_model="openai:gpt-4o",
         registry=registry,
         delegation_configuration="persisted",
         allowed_models=["openai:gpt-4o", "openai:gpt-4o-mini"],
@@ -212,6 +217,7 @@ Async task lifecycle tools remain available in every mode. One-shot specialists 
 from subagents_pydantic_ai import create_subagent_toolset
 
 toolset = create_subagent_toolset(
+    default_model="openai:gpt-4o",
     delegation_configuration="persisted_and_oneshot",
     allowed_models=["openai:gpt-4o", "openai:gpt-4o-mini"],
     capabilities_map={
@@ -291,7 +297,7 @@ configs = [spec.to_config() for spec in specs]
 
 # Use with capability
 agent = Agent("openai:gpt-4.1", capabilities=[
-    SubAgentCapability(subagents=configs),
+    SubAgentCapability(default_model="openai:gpt-4.1", subagents=configs),
 ])
 ```
 

--- a/docs/advanced/cancellation.md
+++ b/docs/advanced/cancellation.md
@@ -197,7 +197,7 @@ the event loop. A leaked task that is reported is recoverable; a `finally` that
 never finishes is not.
 
 ```python
-SubAgentCapability(subagents=subagents, cancel_grace_seconds=30.0)
+SubAgentCapability(default_model="openai:gpt-4.1", subagents=subagents, cancel_grace_seconds=30.0)
 ```
 
 Raise it when subagents do real cleanup on the way out; lower it when a fast

--- a/docs/advanced/chat-traces.md
+++ b/docs/advanced/chat-traces.md
@@ -12,6 +12,7 @@ agent = Agent(
     "openai:gpt-4.1",
     capabilities=[
         SubAgentCapability(
+            default_model="openai:gpt-4.1",
             subagents=[
                 SubAgentConfig(
                     name="analyst",
@@ -78,7 +79,7 @@ Histories are kept in memory, bounded by an LRU:
 ```python
 from subagents_pydantic_ai import create_subagent_toolset
 
-toolset = create_subagent_toolset(max_chat_traces=100)
+toolset = create_subagent_toolset(default_model="openai:gpt-4.1", max_chat_traces=100)
 ```
 
 Reading a trace refreshes its recency, so a conversation the orchestrator keeps

--- a/docs/advanced/dynamic-agents.md
+++ b/docs/advanced/dynamic-agents.md
@@ -27,6 +27,7 @@ agent = Agent(
     "openai:gpt-4o",
     deps_type=Deps,
     toolsets=[create_subagent_toolset(
+        default_model="openai:gpt-4o",
         subagents=base_subagents,
         registry=registry,
         delegation_configuration="persisted",
@@ -41,7 +42,7 @@ agent = Agent(
 |-----------|------|---------|-------------|
 | `registry` | `DynamicAgentRegistry \| None` | `None` | Registry for created agents; an internal registry is created when omitted |
 | `allowed_models` | `list[str] \| None` | `None` (all allowed) | Models agents can use |
-| `default_model` | `str \| Model` | `"openai:gpt-4.1"` | Default model for new agents when none is given |
+| `default_model` | `str \| Model \| None` | `None` | Model for a `create_agent` call that names none. No implicit default: when unset, such a call is refused rather than run on a library-chosen model |
 | `max_agents` | `int` | `10` | Maximum dynamic agents |
 | `toolsets_factory` | `ToolsetFactory \| None` | `None` | Factory that builds toolsets for every new agent. Takes priority over `capabilities_map` when both are set |
 | `capabilities_map` | `dict[str, CapabilityFactory] \| None` | `None` | Maps capability names to factory functions, e.g. `{"filesystem": ..., "todo": ...}`. Used when `capabilities` are passed to `create_agent` |
@@ -155,12 +156,14 @@ base_subagents = [
 
 # The subagent toolset receives the registry so task() can find dynamic agents
 subagent_toolset = create_subagent_toolset(
+    default_model="openai:gpt-4.1",
     subagents=base_subagents,
     registry=registry,
 )
 
 # The factory toolset uses the same registry to register new agents
 factory_toolset = create_agent_factory_toolset(
+    default_model="openai:gpt-4.1",
     registry=registry,
     allowed_models=["openai:gpt-4.1", "openai:gpt-4o-mini"],
     max_agents=5,
@@ -316,6 +319,7 @@ Prevent unlimited agent creation when the toolset creates its internal registry:
 
 ```python
 create_subagent_toolset(
+    default_model="openai:gpt-4.1",
     delegation_configuration="persisted",
     max_agents=3,  # Maximum 3 dynamic agents
 )
@@ -342,8 +346,10 @@ agent = Agent(
     toolsets=[
         # Task-only. Creating, listing and removing agents lives in the factory
         # toolset, the only one that exposes `remove_agent`.
-        create_subagent_toolset(registry=registry),
-        create_agent_factory_toolset(registry=registry, max_agents=3),
+        create_subagent_toolset(default_model="openai:gpt-4o", registry=registry),
+        create_agent_factory_toolset(
+            default_model="openai:gpt-4o", registry=registry, max_agents=3
+        ),
     ],
 )
 ```
@@ -397,6 +403,7 @@ and one-shot agents.
 from subagents_pydantic_ai import create_subagent_toolset
 
 toolset = create_subagent_toolset(
+    default_model="openai:gpt-4o",
     delegation_configuration="persisted_and_oneshot",
     allowed_models=["openai:gpt-4o", "openai:gpt-4o-mini"],
     capabilities_map={

--- a/docs/advanced/errors.md
+++ b/docs/advanced/errors.md
@@ -12,6 +12,7 @@ agent = Agent(
     "openai:gpt-4.1",
     capabilities=[
         SubAgentCapability(
+            default_model="openai:gpt-4.1",
             subagents=[
                 SubAgentConfig(
                     name="scraper",
@@ -118,7 +119,7 @@ subagent crash to surface as an exception in your application:
 ```python
 from subagents_pydantic_ai import create_subagent_toolset
 
-toolset = create_subagent_toolset(contain_errors=False)
+toolset = create_subagent_toolset(default_model="openai:gpt-4.1", contain_errors=False)
 ```
 
 Per-subagent overrides win over the toolset default:

--- a/docs/advanced/message-bus.md
+++ b/docs/advanced/message-bus.md
@@ -10,7 +10,7 @@ The library uses `InMemoryMessageBus` by default:
 from subagents_pydantic_ai import create_subagent_toolset
 
 # Uses InMemoryMessageBus internally
-toolset = create_subagent_toolset(subagents=subagents)
+toolset = create_subagent_toolset(default_model="openai:gpt-4.1", subagents=subagents)
 ```
 
 This is suitable for:
@@ -380,7 +380,7 @@ Don't over-engineer. In-memory is fine for most applications:
 
 ```python
 # Simple and effective
-toolset = create_subagent_toolset(subagents=subagents)
+toolset = create_subagent_toolset(default_model="openai:gpt-4.1", subagents=subagents)
 ```
 
 ### 2. Consider Reliability

--- a/docs/advanced/questions.md
+++ b/docs/advanced/questions.md
@@ -105,6 +105,7 @@ async def ask_user(question: str) -> str:
     return input(f"Subagent asks: {question}\n> ")
 
 toolset = create_subagent_toolset(
+    default_model="openai:gpt-4.1",
     subagents=subagents,
     ask_user=ask_user,
 )
@@ -125,7 +126,7 @@ the same argument and forwards it:
 ```python
 from subagents_pydantic_ai import SubAgentCapability
 
-cap = SubAgentCapability(subagents=subagents, ask_user=ask_user)
+cap = SubAgentCapability(default_model="openai:gpt-4.1", subagents=subagents, ask_user=ask_user)
 ```
 
 ### Async Mode
@@ -203,7 +204,7 @@ Always ask before making assumptions about:
     ),
 ]
 
-toolset = create_subagent_toolset(subagents=subagents)
+toolset = create_subagent_toolset(default_model="openai:gpt-4.1", subagents=subagents)
 ```
 
 ## The `answer_subagent` Tool
@@ -288,7 +289,7 @@ Use ask_parent() for each clarification.
     ),
 ]
 
-toolset = create_subagent_toolset(subagents=subagents)
+toolset = create_subagent_toolset(default_model="openai:gpt-4.1", subagents=subagents)
 
 agent = Agent(
     "openai:gpt-4o",

--- a/docs/advanced/streaming.md
+++ b/docs/advanced/streaming.md
@@ -23,6 +23,7 @@ agent = Agent(
     "openai:gpt-4.1",
     capabilities=[
         SubAgentCapability(
+            default_model="openai:gpt-4.1",
             subagents=[
                 SubAgentConfig(
                     name="researcher",
@@ -62,6 +63,7 @@ def handler_for(ctx: RunContext[Any], config: SubAgentConfig, task_id: str) -> A
 
 
 toolset = create_subagent_toolset(
+    default_model="openai:gpt-4.1",
     subagents=subagents,
     event_stream_handler_factory=handler_for,
 )
@@ -99,6 +101,7 @@ a configured one, with no extra wiring.
 
 ```python
 toolset = create_subagent_toolset(
+    default_model="openai:gpt-4.1",
     delegation_configuration="persisted_and_oneshot",
     allowed_models=["openai:gpt-4o-mini"],
     event_stream_handler_factory=handler_for,

--- a/docs/advanced/usage-limits.md
+++ b/docs/advanced/usage-limits.md
@@ -12,6 +12,7 @@ agent = Agent(
     "openai:gpt-4.1",
     capabilities=[
         SubAgentCapability(
+            default_model="openai:gpt-4.1",
             subagents=[
                 SubAgentConfig(
                     name="researcher",
@@ -46,7 +47,7 @@ def limits_for(ctx: RunContext[object], config: SubAgentConfig) -> UsageLimits |
     return UsageLimits(request_limit=10)
 
 
-toolset = create_subagent_toolset(usage_limits=limits_for)
+toolset = create_subagent_toolset(default_model="openai:gpt-4.1", usage_limits=limits_for)
 ```
 
 Returning `None` runs that task without explicit limits, which is how you exempt a

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -91,7 +91,7 @@ subagents = [
     ),
 ]
 
-toolset = create_subagent_toolset(subagents=subagents)
+toolset = create_subagent_toolset(default_model="openai:gpt-4.1", subagents=subagents)
 ```
 
 ### Implementing Dependencies

--- a/docs/api/toolset.md
+++ b/docs/api/toolset.md
@@ -77,6 +77,7 @@ Override default tool descriptions for better LLM behavior:
 
 ```python
 toolset = create_subagent_toolset(
+    default_model="openai:gpt-4.1",
     subagents=subagents,
     descriptions={
         "task": "Assign a task to a specialized subagent",
@@ -97,6 +98,7 @@ def my_toolsets_factory(deps):
     return [create_console_toolset()]
 
 toolset = create_subagent_toolset(
+    default_model="openai:gpt-4.1",
     subagents=subagents,
     toolsets_factory=my_toolsets_factory,
 )
@@ -117,8 +119,9 @@ agent = Agent(
     "openai:gpt-4o",
     deps_type=Deps,
     toolsets=[
-        create_subagent_toolset(subagents=subagents),
+        create_subagent_toolset(default_model="openai:gpt-4.1", subagents=subagents),
         create_agent_factory_toolset(
+            default_model="openai:gpt-4.1",
             registry=registry,
             allowed_models=["openai:gpt-4o", "openai:gpt-4o-mini"],
             max_agents=5,

--- a/docs/concepts/capability.md
+++ b/docs/concepts/capability.md
@@ -23,6 +23,7 @@ from subagents_pydantic_ai import SubAgentCapability, SubAgentConfig
 agent = Agent(
     "openai:gpt-4.1",
     capabilities=[SubAgentCapability(
+        default_model="openai:gpt-4.1",
         subagents=[
             SubAgentConfig(
                 name="researcher",
@@ -39,8 +40,8 @@ agent = Agent(
 ```python
 SubAgentCapability(
     subagents=[...],                    # Subagent configurations
-    default_model="openai:gpt-4.1",    # Default model for subagents
-    include_general_purpose=True,       # Include GP subagent (default: True)
+    default_model="openai:gpt-4.1",    # Fallback model; no implicit default
+    include_general_purpose=True,       # GP subagent (default True; needs default_model or a factory)
     max_nesting_depth=0,                # Allow nested subagents (0 = no nesting)
     toolsets_factory=my_factory,        # Custom toolsets for subagents
     registry=my_registry,              # Dynamic agent registry
@@ -74,6 +75,7 @@ in one call. The specialist is not registered in the dynamic agent registry.
 
 ```python
 SubAgentCapability(
+    default_model="openai:gpt-4.1",
     delegation_configuration="persisted_and_oneshot",
     allowed_models=["openai:gpt-4.1"],
     capabilities_map={"filesystem": lambda deps: [create_fs_toolset(deps.backend)]},
@@ -103,7 +105,7 @@ def limits_for(ctx: RunContext, config: SubAgentConfig) -> UsageLimits | None:
         return UsageLimits(request_limit=20)
     return UsageLimits(request_limit=5)
 
-cap = SubAgentCapability(subagents=[...], usage_limits=limits_for)
+cap = SubAgentCapability(default_model="openai:gpt-4.1", subagents=[...], usage_limits=limits_for)
 ```
 
 ## How It Works
@@ -130,7 +132,7 @@ When you pass `SubAgentCapability` to an agent, pydantic-ai calls:
 Access the task manager for monitoring background tasks:
 
 ```python
-cap = SubAgentCapability(subagents=[...])
+cap = SubAgentCapability(default_model="openai:gpt-4.1", subagents=[...])
 agent = Agent("openai:gpt-4.1", capabilities=[cap])
 
 # After agent runs, check active tasks
@@ -150,7 +152,7 @@ agent = Agent(
     "openai:gpt-4.1",
     capabilities=[
         TodoCapability(enable_subtasks=True),
-        SubAgentCapability(subagents=[...]),
+        SubAgentCapability(default_model="openai:gpt-4.1", subagents=[...]),
     ],
 )
 ```
@@ -170,6 +172,7 @@ from subagents_pydantic_ai import SubAgentCapability, SubAgentConfig
 agent = Agent(
     "openai:gpt-4.1",
     capabilities=[SubAgentCapability(
+        default_model="openai:gpt-4.1",
         subagents=[
             # Pre-built agent
             SubAgentConfig(

--- a/docs/concepts/observability.md
+++ b/docs/concepts/observability.md
@@ -9,6 +9,7 @@ from pydantic_ai import Agent
 from subagents_pydantic_ai import SubAgentCapability, SubAgentConfig
 
 capability = SubAgentCapability(
+    default_model="openai:gpt-4.1",
     subagents=[
         SubAgentConfig(
             name="researcher",
@@ -62,7 +63,7 @@ whose handles were already evicted by `max_task_handles`:
 ```python
 from subagents_pydantic_ai import create_subagent_toolset
 
-toolset = create_subagent_toolset(max_task_handles=500)
+toolset = create_subagent_toolset(default_model="openai:gpt-4.1", max_task_handles=500)
 
 totals = toolset.get_total_usage()
 print(totals["input_tokens"], totals["output_tokens"], totals["requests"])
@@ -103,7 +104,7 @@ from subagents_pydantic_ai import SubAgentCapability
 logfire.configure()
 logfire.instrument_pydantic_ai()
 
-capability = SubAgentCapability()
+capability = SubAgentCapability(default_model="openai:gpt-4.1")
 agent = Agent("openai:gpt-4.1", capabilities=[capability])
 
 await agent.run("Delegate something")
@@ -151,6 +152,7 @@ Two limits keep a long-running orchestrator flat:
 
 ```python
 toolset = create_subagent_toolset(
+    default_model="openai:gpt-4.1",
     max_task_handles=500,  # finished handles retained for status queries
     max_chat_traces=100,  # conversations that a chat_trace_id can still resume
 )

--- a/docs/concepts/toolset.md
+++ b/docs/concepts/toolset.md
@@ -15,7 +15,7 @@ subagents = [
     ),
 ]
 
-toolset = create_subagent_toolset(subagents=subagents)
+toolset = create_subagent_toolset(default_model="openai:gpt-4.1", subagents=subagents)
 ```
 
 ## Factory Parameters
@@ -23,9 +23,9 @@ toolset = create_subagent_toolset(subagents=subagents)
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `subagents` | `list[SubAgentConfig]` | `[]` | List of subagent configurations |
-| `default_model` | `str \| None` | `None` | Default model for subagents |
+| `default_model` | `str \| Model \| None` | `None` | Model a subagent falls back on when it names none. No implicit default: when unset, a subagent or dynamic call naming no model is refused rather than run on a library-chosen one |
 | `toolsets_factory` | `Callable` | `None` | Factory to create toolsets for subagents |
-| `include_general_purpose` | `bool` | `True` | Include the general-purpose subagent |
+| `include_general_purpose` | `bool` | `True` | Include the general-purpose subagent. Needs a `default_model` or `default_agent_factory` to build it from; construction raises without one |
 | `max_nesting_depth` | `int` | `0` | Maximum subagent nesting depth |
 | `registry` | `DynamicAgentRegistry \| None` | `None` | Registry for dynamically created agents |
 | `descriptions` | `dict[str, str] \| None` | `None` | Override default tool descriptions by tool name |
@@ -68,6 +68,7 @@ from pydantic_ai import Agent
 from subagents_pydantic_ai import create_subagent_toolset, SubAgentConfig
 
 toolset = create_subagent_toolset(
+    default_model="openai:gpt-4.1",
     subagents=[
         SubAgentConfig(
             name="custom",
@@ -380,6 +381,7 @@ def my_toolsets_factory(deps):
     ]
 
 toolset = create_subagent_toolset(
+    default_model="openai:gpt-4.1",
     subagents=subagents,
     toolsets_factory=my_toolsets_factory,
 )
@@ -394,12 +396,14 @@ Control how deep subagents can nest:
 ```python
 # Allow subagents to have their own subagents (2 levels deep)
 toolset = create_subagent_toolset(
+    default_model="openai:gpt-4.1",
     subagents=subagents,
     max_nesting_depth=2,
 )
 
 # No nesting - subagents can't delegate
 toolset = create_subagent_toolset(
+    default_model="openai:gpt-4.1",
     subagents=subagents,
     max_nesting_depth=0,
 )
@@ -408,11 +412,14 @@ toolset = create_subagent_toolset(
 ## General-purpose subagent
 
 A `general-purpose` subagent is added by default, so the model has somewhere to
-send work that matches none of your specialists. Turn it off when you want the
-model restricted to the subagents you defined:
+send work that matches none of your specialists. It is built from `default_model`
+(or from a `default_agent_factory`), so one of those must be set while it is on --
+construction raises otherwise. Turn it off when you want the model restricted to
+the subagents you defined:
 
 ```python
 toolset = create_subagent_toolset(
+    default_model="openai:gpt-4.1",
     subagents=subagents,
     include_general_purpose=False,
 )
@@ -423,6 +430,7 @@ with whatever instructions you want:
 
 ```python
 toolset = create_subagent_toolset(
+    default_model="openai:gpt-4.1",
     subagents=[
         *subagents,
         SubAgentConfig(
@@ -441,6 +449,7 @@ Override the default tool descriptions to better guide LLM behavior. This is use
 
 ```python
 toolset = create_subagent_toolset(
+    default_model="openai:gpt-4.1",
     subagents=subagents,
     descriptions={
         "task": "Assign a task to a specialized subagent",

--- a/docs/examples/basic-usage.md
+++ b/docs/examples/basic-usage.md
@@ -12,6 +12,7 @@ from subagents_pydantic_ai import SubAgentCapability, SubAgentConfig
 agent = Agent(
     "openai:gpt-4.1",
     capabilities=[SubAgentCapability(
+        default_model="openai:gpt-4.1",
         subagents=[
             SubAgentConfig(
                 name="researcher",
@@ -48,6 +49,7 @@ Allow subagents to spawn their own subagents:
 agent = Agent(
     "openai:gpt-4.1",
     capabilities=[SubAgentCapability(
+        default_model="openai:gpt-4.1",
         subagents=[...],
         max_nesting_depth=2,  # Subagents can nest 2 levels deep
     )],
@@ -114,7 +116,7 @@ configs = [
     SubAgentConfig(name="researcher", description="Researches topics", instructions="..."),
 ]
 
-toolset = create_subagent_toolset(subagents=configs)
+toolset = create_subagent_toolset(default_model="openai:gpt-4.1", subagents=configs)
 agent = Agent(
     "openai:gpt-4.1",
     toolsets=[toolset],

--- a/docs/examples/nesting.md
+++ b/docs/examples/nesting.md
@@ -89,11 +89,12 @@ def create_manager_toolsets(deps: Deps) -> list:
     delegate to the subagents this toolset exposes. The leaves get no subagent
     toolset at all, which is what stops the hierarchy here.
     """
-    return [create_subagent_toolset(subagents=leaf_subagents)]
+    return [create_subagent_toolset(default_model="openai:gpt-4.1", subagents=leaf_subagents)]
 
 
 # Top-level toolset
 toolset = create_subagent_toolset(
+    default_model="openai:gpt-4.1",
     subagents=manager_subagents,
     toolsets_factory=create_manager_toolsets,
     max_nesting_depth=1,  # Budget handed to Deps.clone_for_subagent
@@ -127,18 +128,21 @@ Use `max_nesting_depth` to limit how deep delegation can go:
 ```python
 # No nesting (depth=0)
 toolset = create_subagent_toolset(
+    default_model="openai:gpt-4.1",
     subagents=subagents,
     max_nesting_depth=0,  # Subagents cannot delegate
 )
 
 # One level (depth=1)
 toolset = create_subagent_toolset(
+    default_model="openai:gpt-4.1",
     subagents=subagents,
     max_nesting_depth=1,  # Subagents can delegate to leaf agents
 )
 
 # Two levels (depth=2)
 toolset = create_subagent_toolset(
+    default_model="openai:gpt-4.1",
     subagents=subagents,
     max_nesting_depth=2,  # Subagents can delegate to agents that can delegate
 )
@@ -214,12 +218,13 @@ ics = [
 
 
 def create_manager_toolsets(deps):
-    return [create_subagent_toolset(subagents=ics, max_nesting_depth=0)]
+    return [create_subagent_toolset(default_model="openai:gpt-4.1", subagents=ics, max_nesting_depth=0)]
 
 
 def create_executive_toolsets(deps):
     return [
         create_subagent_toolset(
+            default_model="openai:gpt-4.1",
             subagents=managers,
             toolsets_factory=create_manager_toolsets,
             max_nesting_depth=1,
@@ -228,6 +233,7 @@ def create_executive_toolsets(deps):
 
 
 toolset = create_subagent_toolset(
+    default_model="openai:gpt-4.1",
     subagents=[executive],
     toolsets_factory=create_executive_toolsets,
     max_nesting_depth=2,

--- a/docs/examples/questions.md
+++ b/docs/examples/questions.md
@@ -40,7 +40,7 @@ Wait for the answer before proceeding.
     ),
 ]
 
-toolset = create_subagent_toolset(subagents=subagents)
+toolset = create_subagent_toolset(default_model="openai:gpt-4.1", subagents=subagents)
 
 agent = Agent(
     "openai:gpt-4o",
@@ -114,7 +114,7 @@ Ask questions using ask_parent().
     ),
 ]
 
-toolset = create_subagent_toolset(subagents=subagents)
+toolset = create_subagent_toolset(default_model="openai:gpt-4.1", subagents=subagents)
 
 agent = Agent(
     "openai:gpt-4o",

--- a/docs/examples/research-team.md
+++ b/docs/examples/research-team.md
@@ -92,7 +92,7 @@ Produce professional-quality output.
     ),
 ]
 
-toolset = create_subagent_toolset(subagents=subagents)
+toolset = create_subagent_toolset(default_model="openai:gpt-4.1", subagents=subagents)
 
 agent = Agent(
     "openai:gpt-4o",

--- a/docs/examples/sync-async.md
+++ b/docs/examples/sync-async.md
@@ -32,7 +32,7 @@ subagents = [
     ),
 ]
 
-toolset = create_subagent_toolset(subagents=subagents)
+toolset = create_subagent_toolset(default_model="openai:gpt-4.1", subagents=subagents)
 
 agent = Agent(
     "openai:gpt-4o",
@@ -88,7 +88,7 @@ subagents = [
     ),
 ]
 
-toolset = create_subagent_toolset(subagents=subagents)
+toolset = create_subagent_toolset(default_model="openai:gpt-4.1", subagents=subagents)
 
 agent = Agent(
     "openai:gpt-4o",
@@ -156,7 +156,7 @@ subagents = [
     ),
 ]
 
-toolset = create_subagent_toolset(subagents=subagents)
+toolset = create_subagent_toolset(default_model="openai:gpt-4.1", subagents=subagents)
 
 agent = Agent(
     "openai:gpt-4o",

--- a/docs/examples/toolsets.md
+++ b/docs/examples/toolsets.md
@@ -71,6 +71,7 @@ Write clean, well-documented code.
 ]
 
 toolset = create_subagent_toolset(
+    default_model="openai:gpt-4.1",
     subagents=subagents,
     toolsets_factory=my_toolsets_factory,
 )
@@ -163,6 +164,7 @@ subagents = [
 ]
 
 toolset = create_subagent_toolset(
+    default_model="openai:gpt-4.1",
     subagents=subagents,
     toolsets_factory=backend_toolsets_factory,
 )

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,6 +49,7 @@ from subagents_pydantic_ai import SubAgentCapability, SubAgentConfig
 agent = Agent(
     "openai:gpt-4.1",
     capabilities=[SubAgentCapability(
+        default_model="openai:gpt-4.1",
         subagents=[
             SubAgentConfig(
                 name="researcher",
@@ -63,7 +64,8 @@ result = await agent.run("Research Python async patterns")
 ```
 
 `SubAgentCapability` automatically registers all tools and injects a dynamic system
-prompt listing available subagents. A general-purpose subagent is included by default.
+prompt listing available subagents. A general-purpose subagent is included when a
+`default_model` or `default_agent_factory` is given to build it from.
 
 ### Alternative: Toolset API
 
@@ -72,6 +74,7 @@ from pydantic_ai import Agent
 from subagents_pydantic_ai import create_subagent_toolset, SubAgentConfig
 
 toolset = create_subagent_toolset(
+    default_model="openai:gpt-4.1",
     subagents=[SubAgentConfig(name="researcher", description="...", instructions="...")],
 )
 agent = Agent("openai:gpt-4.1", toolsets=[toolset])

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -72,7 +72,7 @@ subagents = [
     ),
 ]
 
-toolset = create_subagent_toolset(subagents=subagents)
+toolset = create_subagent_toolset(default_model="openai:gpt-4.1", subagents=subagents)
 agent = Agent(
     "openai:gpt-4o-mini",
     deps_type=Deps,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "subagents-pydantic-ai"
-version = "0.2.17"
+version = "0.2.18"
 description = "Subagent toolset for pydantic-ai with dual-mode execution and dynamic agent creation"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/subagents_pydantic_ai/capability.py
+++ b/src/subagents_pydantic_ai/capability.py
@@ -11,6 +11,7 @@ Example:
     agent = Agent(
         "openai:gpt-4.1",
         capabilities=[SubAgentCapability(
+            default_model="openai:gpt-4.1",
             subagents=[
                 SubAgentConfig(
                     name="researcher",
@@ -62,6 +63,7 @@ class SubAgentCapability(AbstractCapability[Any]):
         from subagents_pydantic_ai import SubAgentCapability, SubAgentConfig
 
         cap = SubAgentCapability(
+            default_model="openai:gpt-4.1",
             subagents=[
                 SubAgentConfig(
                     name="researcher",
@@ -75,8 +77,16 @@ class SubAgentCapability(AbstractCapability[Any]):
 
     Attributes:
         subagents: List of subagent configurations.
-        default_model: Default model for subagents.
-        include_general_purpose: Include general-purpose subagent.
+        default_model: Default model for subagents that name none, for the
+            general-purpose subagent, and for a dynamic call that names no model.
+            There is no implicit default: leave it unset and each of those is
+            refused rather than run on a model the library picked, which resolves
+            whatever provider credential the process environment happens to hold.
+        include_general_purpose: Include general-purpose subagent. Needs
+            `default_model` or `default_agent_factory` to build it from — see
+            `Raises`. A `default_agent_factory` is what builds it when present,
+            so a consumer that resolves a model, a credential and a budget per
+            caller gets a delegate it can account for.
         max_nesting_depth: Max depth for nested subagents.
         toolsets_factory: Factory for subagent toolsets.
         registry: Dynamic agent registry.
@@ -89,9 +99,10 @@ class SubAgentCapability(AbstractCapability[Any]):
             `Raises`.
         allowed_models: Optional model allow-list for dynamic specialists.
         capabilities_map: Optional capability factories for dynamic specialists.
-        default_agent_factory: Optional custom agent factory for dynamic specialists.
-            Do not attach an `ask_parent` toolset in the factory; the toolset
-            injects it at run time when needed.
+        default_agent_factory: Optional custom agent factory for dynamic
+            specialists, and for the general-purpose subagent when
+            `include_general_purpose` is on. Do not attach an `ask_parent` toolset
+            in the factory; the toolset injects it at run time when needed.
         max_agents: Maximum number of persistent dynamic agents, applied to the
             registry the toolset creates for `create_agent`. Ignored when
             `registry` is set — that registry keeps its own `max_agents`.
@@ -121,11 +132,15 @@ class SubAgentCapability(AbstractCapability[Any]):
             self-contradictory — an invalid `delegation_configuration`, one
             whose hidden tools make `subagents`, `registry`, `allowed_models`,
             `capabilities_map`, or `default_agent_factory` unreachable, or both
-            an `event_stream_handler` and an `event_stream_handler_factory`.
+            an `event_stream_handler` and an `event_stream_handler_factory` —
+            and when a subagent has no model to run on: `include_general_purpose`
+            with neither `default_model` nor `default_agent_factory`, or a
+            `subagents` entry naming no `model` and supplying no `agent` or
+            `agent_factory` while `default_model` is unset.
     """
 
     subagents: list[SubAgentConfig] | None = None
-    default_model: Any = "openai:gpt-4.1"
+    default_model: Any = None
     include_general_purpose: bool = True
     max_nesting_depth: int = 0
     toolsets_factory: ToolsetFactory | None = None

--- a/src/subagents_pydantic_ai/factory.py
+++ b/src/subagents_pydantic_ai/factory.py
@@ -25,7 +25,7 @@ from subagents_pydantic_ai.types import ToolsetFactory
 def create_agent_factory_toolset(
     registry: DynamicAgentRegistry,
     allowed_models: list[str] | None = None,
-    default_model: str | Model = "openai:gpt-4.1",
+    default_model: str | Model | None = None,
     max_agents: int = 10,
     toolsets_factory: ToolsetFactory | None = None,
     capabilities_map: dict[str, CapabilityFactory] | None = None,
@@ -42,7 +42,11 @@ def create_agent_factory_toolset(
         registry: Registry to store created agents.
         allowed_models: List of allowed model names. If None, any model
             is allowed.
-        default_model: Default model to use when not specified.
+        default_model: Model to use for a `create_agent` call that names none.
+            There is no implicit default: leave it unset and such a call is
+            refused, rather than creating an agent on a model the library picked
+            and therefore on whatever provider credential the process environment
+            happens to hold.
         max_agents: Maximum number of dynamic agents allowed. This is written
             onto `registry.max_agents`, so it wins over whatever cap the
             registry was constructed with — pass it explicitly when the limit
@@ -105,12 +109,18 @@ def create_agent_factory_toolset(
     # decorator: an `f"""..."""` as the first statement of the function body is
     # NOT a docstring (`__doc__` stays `None`) — it would be evaluated and
     # discarded on every call, throwing away the computed models/capabilities.
+    # A model told there is a default will happily omit one, so only say so when
+    # the consumer named it.
+    default_desc = (
+        f"Default model when none is given: {default_model}."
+        if default_model is not None
+        else "There is no default model: name the model to use in every call."
+    )
     create_agent_description = (
         "Create a new specialized agent at runtime.\n\n"
         "Creates a new agent with the specified configuration. The agent "
         "will be available for delegation via the task tool.\n\n"
-        f"{models_desc}\n{caps_desc}\n\n"
-        f"Default model when none is given: {default_model}."
+        f"{models_desc}\n{caps_desc}\n\n{default_desc}"
     )
 
     @toolset.tool(description=create_agent_description)
@@ -145,6 +155,17 @@ def create_agent_factory_toolset(
             return f"Error: Agent '{name}' already exists"
 
         actual_model = model or default_model
+        if actual_model is None:
+            # A tool result rather than an exception: the model named nothing and
+            # can name something on its next turn. The fallback this replaces put
+            # the agent on a model of the library's choosing, and so on whichever
+            # provider credential the environment held.
+            allowed = f" Allowed models: {', '.join(allowed_models)}." if allowed_models else ""
+            return (
+                "Error: no model was given and there is no default model. "
+                f"Name the model to use and try again.{allowed}"
+            )
+
         result = build_dynamic_agent(
             ctx,
             name=name,
@@ -227,7 +248,7 @@ def create_agent_factory_toolset(
         info = [
             f"Agent: {name}",
             f"Description: {config['description']}",
-            f"Model: {config.get('model', default_model)}",
+            f"Model: {config.get('model') or default_model or 'not configured'}",
             f"Can ask questions: {config.get('can_ask_questions', True)}",
             "",
             "Instructions:",

--- a/src/subagents_pydantic_ai/toolset.py
+++ b/src/subagents_pydantic_ai/toolset.py
@@ -151,19 +151,45 @@ def _already_finished(task_id: str, handle: TaskHandle | None) -> str:
     )
 
 
-def _create_general_purpose_config() -> SubAgentConfig:
-    """Create the default general-purpose subagent config."""
-    return SubAgentConfig(
+def _create_general_purpose_config(
+    default_model: str | Model | None,
+    agent_factory: AgentFactory | None,
+) -> SubAgentConfig:
+    """Create the default general-purpose subagent config.
+
+    Both arguments are the toolset's, carried onto the config so that this
+    delegate is built the same way every other one is -- through
+    `_compile_subagent`, from the consumer's own factory when there is one. It
+    used to carry neither, so it was always compiled from `default_model`: a
+    deployment that resolves a model per tenant (its own credential, its own
+    budget) has no single `default_model` to give, and the library's own fallback
+    put this delegate on whatever provider key happened to be in the process
+    environment. The toolset refuses to build it when neither is available, so at
+    least one of the two is always set here.
+
+    Args:
+        default_model: The toolset's default model, written onto the config so a
+            factory reading `config["model"]` sees the same value the library
+            would have compiled from. `None` when the consumer supplied none.
+        agent_factory: The toolset's `default_agent_factory`, if any. Takes
+            priority over `model` in `_compile_subagent`.
+    """
+    config = SubAgentConfig(
         name="general-purpose",
         description=DEFAULT_GENERAL_PURPOSE_DESCRIPTION,
         instructions=SUBAGENT_SYSTEM_PROMPT,
         can_ask_questions=True,
     )
+    if default_model is not None:
+        config["model"] = default_model
+    if agent_factory is not None:
+        config["agent_factory"] = agent_factory
+    return config
 
 
 def _compile_subagent(
     config: SubAgentConfig,
-    default_model: str | Model,
+    default_model: str | Model | None,
 ) -> CompiledSubAgent:
     """Compile a subagent configuration into a ready-to-use agent.
 
@@ -174,10 +200,17 @@ def _compile_subagent(
 
     Args:
         config: The subagent configuration.
-        default_model: Default model to use if not specified in config.
+        default_model: Default model to use if not specified in config. `None`
+            means the consumer named none, and a config that supplies no model,
+            agent or factory of its own is then refused rather than compiled
+            against a model the library picked.
 
     Returns:
         CompiledSubAgent with agent instance.
+
+    Raises:
+        ValueError: If nothing in the config or `default_model` says which model
+            this subagent runs on.
     """
     prebuilt = config.get("agent")
     if prebuilt is not None:
@@ -197,6 +230,17 @@ def _compile_subagent(
             config=config,
         )
 
+    model = config.get("model", default_model)
+    if model is None:
+        raise ValueError(
+            f"Subagent '{config['name']}' says nothing about which model it runs on: "
+            "its config sets no 'model', 'agent' or 'agent_factory', and the toolset "
+            "was given no 'default_model'. Name a model, or build the agent yourself. "
+            "The library used to fall back on a model of its own choosing, which "
+            "resolves whatever provider credential is in the process environment -- "
+            "in a multi-tenant deployment, not the caller's."
+        )
+
     # `can_ask_questions=False` has to remove the tool, not just tell the subagent
     # not to use it. `_execute` already honours the flag when it injects
     # `ask_parent` at run time; leaving it out here meant a configured subagent
@@ -208,7 +252,7 @@ def _compile_subagent(
     toolsets.extend(config.get("toolsets") or [])
 
     agent: Agent[Any, str] = Agent(
-        config.get("model", default_model),
+        model,
         system_prompt=config["instructions"],
         toolsets=toolsets,
         **config.get("agent_kwargs", {}),
@@ -329,6 +373,7 @@ class SubAgentToolset(FunctionToolset[Any]):
         from subagents_pydantic_ai import SubAgentConfig, SubAgentToolset
 
         toolset = SubAgentToolset(
+            default_model="openai:gpt-4.1",
             subagents=[
                 SubAgentConfig(
                     name="researcher",
@@ -344,7 +389,7 @@ class SubAgentToolset(FunctionToolset[Any]):
     def __init__(
         self,
         subagents: list[SubAgentConfig] | None = None,
-        default_model: str | Model = "openai:gpt-4.1",
+        default_model: str | Model | None = None,
         toolsets_factory: ToolsetFactory | None = None,
         include_general_purpose: bool = True,
         max_nesting_depth: int = 0,
@@ -373,6 +418,8 @@ class SubAgentToolset(FunctionToolset[Any]):
             delegation_configuration=delegation_configuration,
             subagents=subagents,
             registry=registry,
+            include_general_purpose=include_general_purpose,
+            default_model=default_model,
             allowed_models=allowed_models,
             capabilities_map=capabilities_map,
             default_agent_factory=default_agent_factory,
@@ -413,8 +460,8 @@ class SubAgentToolset(FunctionToolset[Any]):
         self._evicted_usage = {"input_tokens": 0, "output_tokens": 0, "requests": 0}
 
         configs: list[SubAgentConfig] = list(subagents) if subagents else []
-        if include_general_purpose and self._expose_task:
-            configs.append(_create_general_purpose_config())
+        if self._general_purpose:
+            configs.append(_create_general_purpose_config(default_model, default_agent_factory))
         self._compiled: dict[str, CompiledSubAgent] = {
             config["name"]: _compile_subagent(config, default_model) for config in configs
         }
@@ -429,6 +476,8 @@ class SubAgentToolset(FunctionToolset[Any]):
         delegation_configuration: DelegationConfiguration,
         subagents: list[SubAgentConfig] | None,
         registry: DynamicAgentRegistry | None,
+        include_general_purpose: bool,
+        default_model: str | Model | None,
         allowed_models: list[str] | None,
         capabilities_map: dict[str, CapabilityFactory] | None,
         default_agent_factory: AgentFactory | None,
@@ -457,37 +506,32 @@ class SubAgentToolset(FunctionToolset[Any]):
             )
 
         self._delegation_configuration = delegation_configuration
+        # Asking for the delegate without the tool that reaches it is not a
+        # contradiction worth raising over -- `task` is what names subagents, so
+        # a mode that hides it hides this one too, and always has.
+        self._general_purpose = include_general_purpose and self._expose_task
 
-        if not self._expose_task:
-            if subagents:
-                raise ValueError(
-                    f"delegation_configuration={delegation_configuration!r} cannot be combined "
-                    "with non-empty subagents; configured subagents would be unreachable "
-                    "without the task tool. Omit subagents, or use a mode that exposes task."
-                )
-            if registry is not None:
-                raise ValueError(
-                    f"delegation_configuration={delegation_configuration!r} cannot be combined "
-                    "with a registry; registry-backed agents are only reachable through the "
-                    "task tool. Omit registry, or use a mode that exposes task."
-                )
+        if self._general_purpose and default_model is None and default_agent_factory is None:
+            raise ValueError(
+                "include_general_purpose=True needs something to build the general-purpose "
+                "subagent from, and neither 'default_model' nor 'default_agent_factory' was "
+                "given. The library used to compile it from a model of its own choosing, "
+                "which resolves whatever provider credential is in the process environment: "
+                "on a deployment holding no such key the build raises, and on one that has "
+                "it in its environment a caller's work runs on a credential that is not "
+                "theirs. Pass 'default_model' to say which model this delegate runs on, pass "
+                "'default_agent_factory' to build it yourself, or set "
+                "include_general_purpose=False."
+            )
 
-        if not self._expose_create_agent and not self._expose_delegate:
-            unreachable = [
-                name
-                for name, value in (
-                    ("allowed_models", allowed_models),
-                    ("capabilities_map", capabilities_map),
-                    ("default_agent_factory", default_agent_factory),
-                )
-                if value is not None
-            ]
-            if unreachable:
-                raise ValueError(
-                    f"delegation_configuration={delegation_configuration!r} exposes no "
-                    f"dynamic-agent tool, so {', '.join(unreachable)} would be ignored. "
-                    "Use 'persisted', 'persisted_and_oneshot', or 'oneshot_only'."
-                )
+        self._reject_unreachable_configuration(
+            delegation_configuration=delegation_configuration,
+            subagents=subagents,
+            registry=registry,
+            allowed_models=allowed_models,
+            capabilities_map=capabilities_map,
+            default_agent_factory=default_agent_factory,
+        )
 
         if max_result_chars is not None and max_result_chars < 0:
             raise ValueError(f"max_result_chars must be >= 0 or None, got {max_result_chars}")
@@ -521,6 +565,54 @@ class SubAgentToolset(FunctionToolset[Any]):
         if cancel_grace_seconds <= 0:
             raise ValueError(f"cancel_grace_seconds must be > 0, got {cancel_grace_seconds}")
 
+    def _reject_unreachable_configuration(
+        self,
+        *,
+        delegation_configuration: DelegationConfiguration,
+        subagents: list[SubAgentConfig] | None,
+        registry: DynamicAgentRegistry | None,
+        allowed_models: list[str] | None,
+        capabilities_map: dict[str, CapabilityFactory] | None,
+        default_agent_factory: AgentFactory | None,
+    ) -> None:
+        """Reject configuration meant for a tool the chosen mode does not expose.
+
+        Reads the `_expose_*` and `_general_purpose` flags `_validate` has already
+        set. A mode that hides `task` hides the subagents and registry it reaches;
+        a mode that exposes no dynamic-agent tool leaves the arguments only those
+        tools read with nowhere to take effect.
+        """
+        if not self._expose_task:
+            if subagents:
+                raise ValueError(
+                    f"delegation_configuration={delegation_configuration!r} cannot be combined "
+                    "with non-empty subagents; configured subagents would be unreachable "
+                    "without the task tool. Omit subagents, or use a mode that exposes task."
+                )
+            if registry is not None:
+                raise ValueError(
+                    f"delegation_configuration={delegation_configuration!r} cannot be combined "
+                    "with a registry; registry-backed agents are only reachable through the "
+                    "task tool. Omit registry, or use a mode that exposes task."
+                )
+
+        if not self._expose_create_agent and not self._expose_delegate:
+            candidates: list[tuple[str, Any]] = [
+                ("allowed_models", allowed_models),
+                ("capabilities_map", capabilities_map),
+            ]
+            # `default_agent_factory` also builds the general-purpose delegate, so
+            # it is only unread when that delegate is not being built either.
+            if not self._general_purpose:
+                candidates.append(("default_agent_factory", default_agent_factory))
+            unreachable = [name for name, value in candidates if value is not None]
+            if unreachable:
+                raise ValueError(
+                    f"delegation_configuration={delegation_configuration!r} exposes no "
+                    f"dynamic-agent tool, so {', '.join(unreachable)} would be ignored. "
+                    "Use 'persisted', 'persisted_and_oneshot', or 'oneshot_only'."
+                )
+
     @property
     def _expose_create_agent(self) -> bool:
         return self._delegation_configuration in {"persisted", "persisted_and_oneshot"}
@@ -544,10 +636,14 @@ class SubAgentToolset(FunctionToolset[Any]):
             if self._capabilities_map
             else "No predefined capabilities available"
         )
-        dynamic_agent_desc = (
-            f"{models_desc}\n{caps_desc}\n\n"
+        # A model that is told there is a default will happily omit one. There is
+        # no default to omit unless the consumer named it, so say which it is.
+        default_desc = (
             f"Default model when none is given: {self._default_model}."
+            if self._default_model is not None
+            else "There is no default model: name the model to use in every call."
         )
+        dynamic_agent_desc = f"{models_desc}\n{caps_desc}\n\n{default_desc}"
 
         if self._expose_create_agent:
             self.add_function(
@@ -596,6 +692,24 @@ class SubAgentToolset(FunctionToolset[Any]):
     def _describe(self, tool_name: str) -> str:
         """The caller's description override for a tool, or the built-in default."""
         return self._descriptions.get(tool_name, _DEFAULT_TOOL_DESCRIPTIONS[tool_name])
+
+    def _refuse_without_model(self) -> str:
+        """Refuse a dynamic-agent call that named no model when there is no default.
+
+        A tool result rather than an exception, like every other refusal these two
+        tools make: the model named nothing, and it can name something and call
+        again. What it replaces is worse than a refusal -- the library filled the
+        gap with a model of its own choosing, so a specialist nobody chose a
+        provider for ran on whichever provider credential the process environment
+        happened to hold.
+        """
+        allowed = (
+            f" Allowed models: {', '.join(self._allowed_models)}." if self._allowed_models else ""
+        )
+        return (
+            "Error: no model was given and there is no default model. "
+            f"Name the model to use and try again.{allowed}"
+        )
 
     # -- observability surface -------------------------------------------------
 
@@ -935,6 +1049,9 @@ class SubAgentToolset(FunctionToolset[Any]):
             return f"Error: Agent '{name}' already exists"
 
         actual_model = model or self._default_model
+        if actual_model is None:
+            return self._refuse_without_model()
+
         result = build_dynamic_agent(
             ctx,
             name=name,
@@ -1064,6 +1181,10 @@ class SubAgentToolset(FunctionToolset[Any]):
             requires_user_context: Whether task needs ongoing user interaction.
             may_need_clarification: Whether task might need clarifying questions.
         """
+        chosen_model = model or self._default_model
+        if chosen_model is None:
+            return self._refuse_without_model()
+
         task_id = uuid.uuid4().hex[:8]
         agent_description = description[:120] or "Ephemeral specialist"
 
@@ -1072,7 +1193,7 @@ class SubAgentToolset(FunctionToolset[Any]):
             name=name,
             description=agent_description,
             instructions=instructions,
-            model=model or self._default_model,
+            model=chosen_model,
             can_ask_questions=can_ask_questions,
             capabilities=capabilities,
             allowed_models=self._allowed_models,
@@ -1340,7 +1461,7 @@ class SubAgentToolset(FunctionToolset[Any]):
 
 def create_subagent_toolset(
     subagents: list[SubAgentConfig] | None = None,
-    default_model: str | Model = "openai:gpt-4.1",
+    default_model: str | Model | None = None,
     toolsets_factory: ToolsetFactory | None = None,
     include_general_purpose: bool = True,
     max_nesting_depth: int = 0,
@@ -1382,11 +1503,20 @@ def create_subagent_toolset(
     Args:
         subagents: List of subagent configurations. If None, only
             general-purpose subagent will be available.
-        default_model: Default model for subagents that don't specify one.
+        default_model: Default model for subagents that don't specify one, for the
+            general-purpose subagent, and for a `create_agent` or `delegate` call
+            that names no model. There is **no** implicit default: leave it unset
+            and anything that would have relied on one is refused instead, rather
+            than running on a model the library picked and therefore on whatever
+            provider credential the process environment happens to hold.
         toolsets_factory: Factory function that creates toolsets for subagents.
             Called with deps when running a task.
         include_general_purpose: Whether to include the default general-purpose
             subagent. Set to False if you want only specialized subagents.
+            Needs `default_model` or `default_agent_factory` to build it from --
+            see `Raises`. When a `default_agent_factory` is given it is what
+            builds this delegate, so a consumer resolving a model, a credential
+            and a budget per caller gets one it can account for.
         max_nesting_depth: Depth budget handed to `deps.clone_for_subagent`, which
             decides what a subagent may delegate to in turn. This library does not
             itself stop a nested toolset from delegating further -- the gate is
@@ -1427,9 +1557,10 @@ def create_subagent_toolset(
         capabilities_map: Optional capability factories for dynamically created
             specialists.
         default_agent_factory: Optional custom agent factory for dynamically
-            created specialists. When set, requested `capabilities` are rejected.
-            Do not attach an `ask_parent` toolset in the factory; the toolset
-            injects it at run time when needed.
+            created specialists, and for the general-purpose subagent when
+            `include_general_purpose` is on. When set, requested `capabilities`
+            are rejected. Do not attach an `ask_parent` toolset in the factory;
+            the toolset injects it at run time when needed.
         max_agents: Maximum number of persistent dynamic agents, applied to the
             registry this toolset creates for `create_agent`. `0` rejects every
             `create_agent` call. Ignored when `registry` is passed — that registry
@@ -1480,7 +1611,11 @@ def create_subagent_toolset(
         A `SubAgentToolset` configured with the subagent management tools.
 
     Raises:
-        ValueError: If `max_result_chars` or `max_agents` is negative; if
+        ValueError: If `include_general_purpose` is on (and `task` exposed) with
+            neither `default_model` nor `default_agent_factory` to build that
+            delegate from; if a `subagents` entry names no `model` and supplies no
+            `agent` or `agent_factory` while `default_model` is unset; if
+            `max_result_chars` or `max_agents` is negative; if
             `ask_timeout_seconds` or `cancel_grace_seconds` is not positive; if
             `max_chat_traces` or
             `max_task_handles` is below 1; if `delegation_configuration` is invalid; if

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -34,7 +34,7 @@ class TestCreateAgentFactoryToolset:
 
     def test_creates_toolset(self, registry: DynamicAgentRegistry):
         """Test toolset creation."""
-        toolset = create_agent_factory_toolset(registry=registry)
+        toolset = create_agent_factory_toolset(registry=registry, default_model="test")
 
         tool_names = list(toolset.tools.keys())
         assert "create_agent" in tool_names
@@ -54,6 +54,7 @@ class TestCreateAgentFactoryToolset:
         """Test that max_agents is updated in registry."""
         create_agent_factory_toolset(
             registry=registry,
+            default_model="test",
             max_agents=5,
         )
         assert registry.max_agents == 5
@@ -61,7 +62,7 @@ class TestCreateAgentFactoryToolset:
     @pytest.mark.asyncio
     async def test_create_agent_success(self, registry: DynamicAgentRegistry):
         """Test successful agent creation."""
-        toolset = create_agent_factory_toolset(registry=registry)
+        toolset = create_agent_factory_toolset(registry=registry, default_model="test")
         create_tool = toolset.tools["create_agent"]
 
         ctx = MockRunContext(deps=MockDeps())
@@ -79,9 +80,37 @@ class TestCreateAgentFactoryToolset:
         assert registry.exists("test-agent")
 
     @pytest.mark.asyncio
+    async def test_create_agent_without_a_model_or_default_is_refused(
+        self, registry: DynamicAgentRegistry
+    ):
+        """A `create_agent` call naming no model is refused when there is no default.
+
+        A tool result, not an exception: the model can name one and call again. The
+        allow-list is named in the message so it knows what it may choose from.
+        """
+        toolset = create_agent_factory_toolset(
+            registry=registry,
+            default_model=None,
+            allowed_models=["openai:gpt-4"],
+        )
+        create_tool = toolset.tools["create_agent"]
+
+        ctx = MockRunContext(deps=MockDeps())
+        result = await create_tool.function(
+            ctx,
+            name="modelless",
+            description="Names no model",
+            instructions="Do testing",
+        )
+
+        assert "no model was given and there is no default model" in result
+        assert "openai:gpt-4" in result
+        assert not registry.exists("modelless")
+
+    @pytest.mark.asyncio
     async def test_create_agent_invalid_name(self, registry: DynamicAgentRegistry):
         """Test agent creation with invalid name."""
-        toolset = create_agent_factory_toolset(registry=registry)
+        toolset = create_agent_factory_toolset(registry=registry, default_model="test")
         create_tool = toolset.tools["create_agent"]
 
         ctx = MockRunContext(deps=MockDeps())
@@ -107,7 +136,7 @@ class TestCreateAgentFactoryToolset:
     @pytest.mark.asyncio
     async def test_create_agent_duplicate(self, registry: DynamicAgentRegistry):
         """Test creating duplicate agent fails."""
-        toolset = create_agent_factory_toolset(registry=registry)
+        toolset = create_agent_factory_toolset(registry=registry, default_model="test")
         create_tool = toolset.tools["create_agent"]
 
         ctx = MockRunContext(deps=MockDeps())
@@ -170,6 +199,7 @@ class TestCreateAgentFactoryToolset:
 
         toolset = create_agent_factory_toolset(
             registry=registry,
+            default_model="test",
             capabilities_map={
                 "filesystem": mock_capability_factory,
             },
@@ -202,6 +232,7 @@ class TestCreateAgentFactoryToolset:
         """Test creating agent with invalid capability."""
         toolset = create_agent_factory_toolset(
             registry=registry,
+            default_model="test",
             capabilities_map={
                 "filesystem": lambda deps: [],
             },
@@ -230,6 +261,7 @@ class TestCreateAgentFactoryToolset:
 
         toolset = create_agent_factory_toolset(
             registry=registry,
+            default_model="test",
             toolsets_factory=mock_factory,
         )
         create_tool = toolset.tools["create_agent"]
@@ -256,7 +288,7 @@ class TestCreateAgentFactoryToolset:
     @pytest.mark.asyncio
     async def test_list_agents_empty(self, registry: DynamicAgentRegistry):
         """Test listing agents when empty."""
-        toolset = create_agent_factory_toolset(registry=registry)
+        toolset = create_agent_factory_toolset(registry=registry, default_model="test")
         list_tool = toolset.tools["list_agents"]
 
         ctx = MockRunContext(deps=MockDeps())
@@ -267,7 +299,7 @@ class TestCreateAgentFactoryToolset:
     @pytest.mark.asyncio
     async def test_list_agents_with_agents(self, registry: DynamicAgentRegistry):
         """Test listing agents when some exist."""
-        toolset = create_agent_factory_toolset(registry=registry)
+        toolset = create_agent_factory_toolset(registry=registry, default_model="test")
         create_tool = toolset.tools["create_agent"]
         list_tool = toolset.tools["list_agents"]
 
@@ -298,7 +330,7 @@ class TestCreateAgentFactoryToolset:
     @pytest.mark.asyncio
     async def test_remove_agent_success(self, registry: DynamicAgentRegistry):
         """Test removing agent successfully."""
-        toolset = create_agent_factory_toolset(registry=registry)
+        toolset = create_agent_factory_toolset(registry=registry, default_model="test")
         create_tool = toolset.tools["create_agent"]
         remove_tool = toolset.tools["remove_agent"]
 
@@ -324,7 +356,7 @@ class TestCreateAgentFactoryToolset:
     @pytest.mark.asyncio
     async def test_remove_agent_not_found(self, registry: DynamicAgentRegistry):
         """Test removing non-existent agent."""
-        toolset = create_agent_factory_toolset(registry=registry)
+        toolset = create_agent_factory_toolset(registry=registry, default_model="test")
         remove_tool = toolset.tools["remove_agent"]
 
         ctx = MockRunContext(deps=MockDeps())
@@ -336,7 +368,7 @@ class TestCreateAgentFactoryToolset:
     @pytest.mark.asyncio
     async def test_get_agent_info_success(self, registry: DynamicAgentRegistry):
         """Test getting agent info successfully."""
-        toolset = create_agent_factory_toolset(registry=registry)
+        toolset = create_agent_factory_toolset(registry=registry, default_model="test")
         create_tool = toolset.tools["create_agent"]
         info_tool = toolset.tools["get_agent_info"]
 
@@ -365,7 +397,7 @@ class TestCreateAgentFactoryToolset:
     @pytest.mark.asyncio
     async def test_get_agent_info_not_found(self, registry: DynamicAgentRegistry):
         """Test getting info for non-existent agent."""
-        toolset = create_agent_factory_toolset(registry=registry)
+        toolset = create_agent_factory_toolset(registry=registry, default_model="test")
         info_tool = toolset.tools["get_agent_info"]
 
         ctx = MockRunContext(deps=MockDeps())
@@ -377,7 +409,7 @@ class TestCreateAgentFactoryToolset:
     @pytest.mark.asyncio
     async def test_get_agent_info_long_instructions(self, registry: DynamicAgentRegistry):
         """Test getting info for agent with long instructions."""
-        toolset = create_agent_factory_toolset(registry=registry)
+        toolset = create_agent_factory_toolset(registry=registry, default_model="test")
         create_tool = toolset.tools["create_agent"]
         info_tool = toolset.tools["get_agent_info"]
 
@@ -406,7 +438,9 @@ class TestCreateAgentFactoryToolset:
     async def test_create_agent_max_reached(self):
         """Test creating agent when max limit reached."""
         registry = DynamicAgentRegistry(max_agents=1)
-        toolset = create_agent_factory_toolset(registry=registry, max_agents=1)
+        toolset = create_agent_factory_toolset(
+            registry=registry, default_model="test", max_agents=1
+        )
         create_tool = toolset.tools["create_agent"]
 
         ctx = MockRunContext(deps=MockDeps())
@@ -436,7 +470,7 @@ class TestCreateAgentFactoryToolset:
     @pytest.mark.asyncio
     async def test_create_agent_value_error(self, registry: DynamicAgentRegistry):
         """Test handling of ValueError during agent creation."""
-        toolset = create_agent_factory_toolset(registry=registry)
+        toolset = create_agent_factory_toolset(registry=registry, default_model="test")
         create_tool = toolset.tools["create_agent"]
 
         ctx = MockRunContext(deps=MockDeps())
@@ -457,7 +491,7 @@ class TestCreateAgentFactoryToolset:
     @pytest.mark.asyncio
     async def test_create_agent_generic_exception(self, registry: DynamicAgentRegistry):
         """Test handling of generic exception during agent creation."""
-        toolset = create_agent_factory_toolset(registry=registry)
+        toolset = create_agent_factory_toolset(registry=registry, default_model="test")
         create_tool = toolset.tools["create_agent"]
 
         ctx = MockRunContext(deps=MockDeps())
@@ -482,6 +516,7 @@ class TestCreateAgentFactoryToolset:
 
         toolset = create_agent_factory_toolset(
             registry=registry,
+            default_model="test",
             default_agent_factory=factory,
         )
         create_tool = toolset.tools["create_agent"]
@@ -514,6 +549,7 @@ class TestCreateAgentFactoryToolset:
 
         toolset = create_agent_factory_toolset(
             registry=registry,
+            default_model="test",
             default_agent_factory=factory,
             capabilities_map={
                 "filesystem": lambda deps: [MagicMock()],

--- a/tests/test_toolset.py
+++ b/tests/test_toolset.py
@@ -198,11 +198,37 @@ class TestCreateGeneralPurposeConfig:
 
     def test_creates_config(self):
         """Test general purpose config creation."""
-        config = _create_general_purpose_config()
+        config = _create_general_purpose_config("openai:gpt-4", None)
 
         assert config["name"] == "general-purpose"
         assert "general-purpose" in config["description"].lower()
         assert config.get("can_ask_questions") is True
+
+    def test_carries_the_default_model_so_it_compiles_like_any_other(self):
+        """A `default_model` is written onto the config, not compiled from behind it.
+
+        `_compile_subagent` reads `config["model"]`, so carrying it here is what
+        makes this delegate build the same way a configured one does.
+        """
+        config = _create_general_purpose_config("openai:gpt-4", None)
+
+        assert config["model"] == "openai:gpt-4"
+        assert "agent_factory" not in config
+
+    def test_carries_the_factory_so_a_consumer_builds_it_with_its_own_credential(self):
+        """With a factory the config carries that, not a model.
+
+        The factory is what a consumer resolving a model, a credential and a budget
+        per caller hands in; `_compile_subagent` prefers it over `model`.
+        """
+
+        def factory(config: SubAgentConfig) -> object:
+            return MagicMock()
+
+        config = _create_general_purpose_config(None, factory)
+
+        assert config["agent_factory"] is factory
+        assert "model" not in config
 
 
 class TestCompileSubagent:
@@ -226,6 +252,24 @@ class TestCompileSubagent:
             assert compiled.description == "Test agent"
             assert compiled.agent is not None
             assert compiled.config == config
+
+    def test_a_config_naming_no_model_with_no_default_is_refused_not_guessed(self):
+        """A subagent that says nothing about its model is refused when there is no default.
+
+        The library used to fall back on a model of its own choosing here, which
+        resolves whatever provider credential the process environment holds -- in a
+        multi-tenant deployment, not the caller's. Failing loud is the point.
+        """
+        from subagents_pydantic_ai.toolset import _compile_subagent
+
+        config = SubAgentConfig(
+            name="rudderless",
+            description="Names no model",
+            instructions="Do work",
+        )
+
+        with pytest.raises(ValueError, match="says nothing about which model it runs on"):
+            _compile_subagent(config, None)
 
     def test_compile_with_custom_model(self):
         """Test compiling subagent with custom model."""
@@ -505,7 +549,7 @@ class TestCreateSubagentToolset:
             "subagents_pydantic_ai.toolset._compile_subagent",
             return_value=_make_mock_compiled_subagent(config),
         ):
-            toolset = create_subagent_toolset()
+            toolset = create_subagent_toolset(default_model="test")
 
             assert "task" in toolset.tools
             assert "check_task" in toolset.tools
@@ -564,7 +608,7 @@ class TestCreateSubagentToolset:
             "subagents_pydantic_ai.toolset._compile_subagent",
             return_value=_make_mock_compiled_subagent(config),
         ):
-            toolset = create_subagent_toolset(id="custom_subagents")
+            toolset = create_subagent_toolset(default_model="test", id="custom_subagents")
             assert toolset.id == "custom_subagents"
 
     @pytest.mark.asyncio
@@ -4177,6 +4221,7 @@ class TestDelegationConfiguration:
     @pytest.mark.asyncio
     async def test_create_agent_registers_reusable_agent(self, registry):
         toolset = create_subagent_toolset(
+            default_model="test",
             delegation_configuration="persisted",
             registry=registry,
             include_general_purpose=False,
@@ -4204,8 +4249,35 @@ class TestDelegationConfiguration:
         assert task_result.startswith("persisted result\n\nChat Trace ID: ")
 
     @pytest.mark.asyncio
+    async def test_create_agent_without_a_model_or_default_is_refused(self, registry):
+        """A `create_agent` call naming no model is refused when the toolset has no default.
+
+        The sibling of the `task` and `delegate` refusals: the model named nothing,
+        there is no default to fall back on, and it can name one and call again --
+        rather than the library running it on a model it never chose.
+        """
+        toolset = create_subagent_toolset(
+            default_model=None,
+            delegation_configuration="persisted",
+            registry=registry,
+            include_general_purpose=False,
+        )
+        ctx = MockRunContext(deps=MockDeps())
+
+        result = await toolset.tools["create_agent"].function(
+            ctx,
+            name="analyst",
+            description="Analyzes data",
+            instructions="You are a data analyst.",
+        )
+
+        assert "no model was given and there is no default model" in result
+        assert not registry.exists("analyst")
+
+    @pytest.mark.asyncio
     async def test_create_agent_duplicate_name(self, registry):
         toolset = create_subagent_toolset(
+            default_model="test",
             delegation_configuration="persisted",
             registry=registry,
             include_general_purpose=False,
@@ -4234,6 +4306,7 @@ class TestDelegationConfiguration:
     async def test_create_agent_register_max_agents(self):
         registry = DynamicAgentRegistry(max_agents=1)
         toolset = create_subagent_toolset(
+            default_model="test",
             delegation_configuration="persisted",
             registry=registry,
             include_general_purpose=False,
@@ -4262,6 +4335,7 @@ class TestDelegationConfiguration:
     @pytest.mark.asyncio
     async def test_create_agent_validation_error(self, registry):
         toolset = create_subagent_toolset(
+            default_model="test",
             delegation_configuration="persisted",
             registry=registry,
             include_general_purpose=False,
@@ -4282,6 +4356,7 @@ class TestDelegationConfiguration:
     @pytest.mark.asyncio
     async def test_delegate_sync_success(self):
         toolset = create_subagent_toolset(
+            default_model="test",
             delegation_configuration="persisted_and_oneshot",
             include_general_purpose=False,
         )
@@ -4309,6 +4384,7 @@ class TestDelegationConfiguration:
         specialist was for.
         """
         toolset = create_subagent_toolset(
+            default_model="test",
             delegation_configuration="persisted_and_oneshot",
             include_general_purpose=False,
         )
@@ -4334,6 +4410,7 @@ class TestDelegationConfiguration:
     async def test_delegate_rejects_an_invalid_name(self):
         """Names go through the same validation as `create_agent`."""
         toolset = create_subagent_toolset(
+            default_model="test",
             delegation_configuration="persisted_and_oneshot",
             include_general_purpose=False,
         )
@@ -4353,6 +4430,7 @@ class TestDelegationConfiguration:
     async def test_delegate_does_not_register_agent(self, registry):
         registry.max_agents = 1
         toolset = create_subagent_toolset(
+            default_model="test",
             delegation_configuration="persisted_and_oneshot",
             registry=registry,
             include_general_purpose=False,
@@ -4384,6 +4462,7 @@ class TestDelegationConfiguration:
             MagicMock(),
         )
         toolset = create_subagent_toolset(
+            default_model="test",
             delegation_configuration="persisted_and_oneshot",
             registry=registry,
             include_general_purpose=False,
@@ -4406,6 +4485,7 @@ class TestDelegationConfiguration:
     @pytest.mark.asyncio
     async def test_delegate_async_success(self):
         toolset = create_subagent_toolset(
+            default_model="test",
             delegation_configuration="persisted_and_oneshot",
             include_general_purpose=False,
         )
@@ -4457,6 +4537,7 @@ class TestDelegationConfiguration:
     @pytest.mark.asyncio
     async def test_delegate_invalid_capability(self):
         toolset = create_subagent_toolset(
+            default_model="test",
             delegation_configuration="persisted_and_oneshot",
             include_general_purpose=False,
             capabilities_map={"filesystem": lambda deps: []},
@@ -4478,6 +4559,7 @@ class TestDelegationConfiguration:
     @pytest.mark.asyncio
     async def test_delegate_execution_error(self):
         toolset = create_subagent_toolset(
+            default_model="test",
             delegation_configuration="persisted_and_oneshot",
             include_general_purpose=False,
         )
@@ -4498,6 +4580,7 @@ class TestDelegationConfiguration:
     async def test_delegate_async_reports_no_chat_trace(self):
         """An async one-shot handle carries no trace, so neither listing shows one."""
         toolset = create_subagent_toolset(
+            default_model="test",
             delegation_configuration="persisted_and_oneshot",
             include_general_purpose=False,
         )

--- a/uv.lock
+++ b/uv.lock
@@ -1333,7 +1333,7 @@ wheels = [
 
 [[package]]
 name = "subagents-pydantic-ai"
-version = "0.2.16"
+version = "0.2.18"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## What this fixes

`default_model` defaulted to `"openai:gpt-4.1"`, so a consumer that never set it
got every fallback subagent — and always the general-purpose one, compiled at
construction — running on that model. That string resolves whatever provider
credential the process environment happens to hold: on a deployment with no such
key the build raised; on one with `OPENAI_API_KEY` set it ran a caller's work on
a credential that was not theirs, off any per-caller model, budget or vault the
host meant to enforce. A host that resolves a model per tenant had no single
`default_model` to give the general-purpose delegate at all.

Fixes it the way the tracking issue's first option describes: **there is no
implicit default any more.** `default_model` defaults to `None`, and the
general-purpose delegate is built the way every other subagent is — from
`default_model` or from a `default_agent_factory`.

Refs vstorm-co/agenticos#174.

## What changed

- `src/subagents_pydantic_ai/toolset.py`
  - `default_model` defaults to `None` on `create_subagent_toolset`,
    `SubAgentToolset` (and `SubAgentCapability`).
  - `_create_general_purpose_config` carries `default_model` /
    `default_agent_factory` onto the config, so the delegate is compiled through
    `_compile_subagent` — from the host's own factory when there is one.
  - `include_general_purpose=True` with neither raises at construction, naming
    the three ways out.
  - `create_agent`, `delegate` and `task` refuse a call that names no model
    (tool result) when there is no default; `_compile_subagent` raises for a
    configured subagent that names no model, agent or factory.
  - Split the general-purpose / reachability guards into
    `_reject_unreachable_configuration` to keep `_validate` under the complexity
    ceiling — no behaviour change in the move.
- `src/subagents_pydantic_ai/factory.py` — `default_model` defaults to `None`;
  `create_agent` refuses a call naming no model when there is no default.
- `capability.py` — the dataclass default and docstrings.
- Docs: parameter tables, the general-purpose section, and every quickstart /
  example snippet that relied on the implicit model now pass `default_model`
  explicitly (the front door was `SubAgentCapability(subagents=[...])`, which now
  raises without one).
- `CHANGELOG.md`, `pyproject.toml`, `uv.lock` — released as **0.2.18**.

## How it failed before

`include_general_purpose` shipped `True` by default, so the single most-shown
pattern — `create_subagent_toolset(subagents=[...])` — built a general-purpose
delegate from a library-chosen model with no involvement from the host. See the
issue for the two concrete failure modes (build raises / silent wrong-credential
run).

## Testing

- `make lint`, `pyright`, `mypy` (strict) — clean.
- `make test` — 1182 passing, **100% branch coverage** (the gate). New tests
  cover each refusal (`_compile_subagent`, factory `create_agent`, toolset
  `create_agent`) and both general-purpose build paths (model-carry,
  factory-carry).
- `tests/test_docs.py` — 658 passing (every snippet compiles, every kwarg is
  real). `uv run mkdocs build --strict` — clean.
- **Downstream check** (`AGENTS.md`): ran the full pydantic-deep suite against
  this branch's `src` — **2784 passed, 1 failed**. The one failure is a
  pydantic-deep *test* (`test_create_with_custom_subagents`) that constructs
  `create_subagent_toolset(subagents=[...])` with no model and relies on the old
  implicit default; pydantic-deep's *product* code already passes `default_model`
  and `include_general_purpose=False` and is unaffected. It needs a one-line test
  update when it adopts 0.2.18.

## Noticed, not fixed

- **The 0.2.17 release has no `CHANGELOG.md` entry.** The changelog jumps 0.2.16
  → 0.2.18 (this one). Left as-is rather than backfilling someone else's release
  in this PR — worth a separate `docs` fix.
- **pydantic-deep** needs the one-line test update above; a separate PR in that
  repo, once this is on PyPI.
