### PR TITLE
feat: carry the exception behind a handle's error text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.19] - 2026-08-16
+
+### Added
+
+- **`TaskHandle.exception` carries the exception behind `error`.** It is set
+  wherever `error` embeds an exception's own text -- a contained crash, an
+  exhausted retry budget, a usage limit, a propagated crash with
+  `contain_errors=False`, and each transient retry -- and cleared by the
+  winning terminal transition, so a completion leaves it `None`. A host that
+  must not surface a foreign message (a provider error can carry the failing
+  request URL, key included, in its text) reads the class from here, composes
+  its own sentence, and logs the original instead of parsing `error`.
+  `finish()` takes the exception as a keyword for the same reason.
+
 ## [0.2.18] - 2026-08-05
 
 `default_model` no longer defaults to a model of the library's choosing. There is

--- a/docs/concepts/types.md
+++ b/docs/concepts/types.md
@@ -172,6 +172,7 @@ class TaskHandle:
     completed_at: datetime | None # When finished
     result: str | None        # Result (if completed)
     error: str | None         # Error (if failed)
+    exception: BaseException | None  # The exception behind `error`, when one caused it
     pending_question: str | None  # Question waiting for answer
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "subagents-pydantic-ai"
-version = "0.2.18"
+version = "0.2.19"
 description = "Subagent toolset for pydantic-ai with dual-mode execution and dynamic agent creation"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/subagents_pydantic_ai/_execution.py
+++ b/src/subagents_pydantic_ai/_execution.py
@@ -283,13 +283,13 @@ async def _run_sync(
         _fail(handle, "propagated")
         raise
     except UsageLimitExceeded as exc:
-        _fail(handle, f"{_USAGE_LIMIT_MARKER}: {exc}")
+        _fail(handle, f"{_USAGE_LIMIT_MARKER}: {exc}", exception=exc)
         raise
     except (ModelRetry, UnexpectedModelBehavior) as exc:
         return _degrade(handle, config, task_id, exc, crashed=False)
     except Exception as exc:
         if not contain_errors:
-            _fail(handle, str(exc))
+            _fail(handle, str(exc), exception=exc)
             raise
         return _degrade(handle, config, task_id, exc, crashed=True)
 
@@ -326,13 +326,14 @@ def _retry_recorder(handle: TaskHandle | None) -> OnRetryCallback | None:
         handle.status = TaskStatus.RETRYING
         handle.retry_count = attempt
         handle.error = f"Transient error (retry {attempt}): {exc}"
+        handle.exception = exc
 
     return on_retry
 
 
-def _fail(handle: TaskHandle | None, error: str) -> None:
+def _fail(handle: TaskHandle | None, error: str, exception: BaseException | None = None) -> None:
     if handle is not None:
-        handle.finish(TaskStatus.FAILED, error=error)
+        handle.finish(TaskStatus.FAILED, error=error, exception=exception)
 
 
 def _suspend(
@@ -375,7 +376,7 @@ def _degrade(
     which case the parent receives that as an ordinary tool result.
     """
     name = config["name"]
-    _fail(handle, f"{type(exc).__name__}: {exc}")
+    _fail(handle, f"{type(exc).__name__}: {exc}", exception=exc)
     if crashed:
         # Contained, but loud: the exception rides the retry message and is logged,
         # and the tool's retry budget still turns repeated crashes into an abort.
@@ -511,7 +512,7 @@ async def _run_async(
             handle.finish(TaskStatus.CANCELLED, error="Task was cancelled")
             raise
         except UsageLimitExceeded as exc:
-            handle.finish(TaskStatus.FAILED, error=f"{_USAGE_LIMIT_MARKER}: {exc}")
+            handle.finish(TaskStatus.FAILED, error=f"{_USAGE_LIMIT_MARKER}: {exc}", exception=exc)
         except _HUMAN_IN_THE_LOOP as exc:
             handle.finish(
                 TaskStatus.DEFERRED,
@@ -521,7 +522,7 @@ async def _run_async(
             logger.warning(
                 "Background subagent %r failed (task %s)", config["name"], task_id, exc_info=exc
             )
-            handle.finish(TaskStatus.FAILED, error=f"{type(exc).__name__}: {exc}")
+            handle.finish(TaskStatus.FAILED, error=f"{type(exc).__name__}: {exc}", exception=exc)
         finally:
             if handle.completed_at is None:  # pragma: no cover - every path finishes above
                 handle.completed_at = utcnow()

--- a/src/subagents_pydantic_ai/types.py
+++ b/src/subagents_pydantic_ai/types.py
@@ -419,6 +419,11 @@ class TaskHandle:
         completed_at: When execution finished
         result: Task result (if completed)
         error: Error message (if failed)
+        exception: The underlying exception, set whenever `error` embeds an
+            exception's own text. A host that must not surface a foreign
+            message -- a provider error can carry the failing request URL,
+            key included -- reads the class from here, composes its own
+            sentence, and logs the original.
         pending_question: Question waiting for answer (if any)
         chat_trace_id: Chat trace ID for continuing this subagent conversation
         run_id: Pydantic AI run ID for the subagent run
@@ -444,6 +449,7 @@ class TaskHandle:
     completed_at: datetime | None = None
     result: str | None = None
     error: str | None = None
+    exception: BaseException | None = None
     pending_question: str | None = None
     chat_trace_id: str | None = None
     usage: RunUsage | None = None
@@ -478,6 +484,7 @@ class TaskHandle:
         *,
         result: str | None = None,
         error: str | None = None,
+        exception: BaseException | None = None,
     ) -> bool:
         """Record a terminal outcome, first terminal transition winning.
 
@@ -490,6 +497,9 @@ class TaskHandle:
             status: The terminal status to record.
             result: Result text, for a completed task.
             error: Error text, for a failed or cancelled task.
+            exception: The exception behind `error`, when there is one. Set
+                unconditionally on the winning transition, so a completion
+                clears whatever a transient retry recorded.
 
         Returns:
             Whether this call recorded the outcome.
@@ -499,6 +509,7 @@ class TaskHandle:
         self.status = status
         self.result = result
         self.error = error
+        self.exception = exception
         self.completed_at = utcnow()
         return True
 

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -759,10 +759,11 @@ class TestErrorContract:
     async def test_sync_propagates_usage_limit(self) -> None:
         """Containing an exhausted budget would let the parent keep delegating."""
         handle = TaskHandle(task_id="t1", subagent_name="worker", description="d")
+        exhausted = UsageLimitExceeded("out of tokens")
 
         with pytest.raises(UsageLimitExceeded):
             await _run_sync(
-                agent=StubAgent(error=UsageLimitExceeded("out of tokens")),
+                agent=StubAgent(error=exhausted),
                 config=_config(),
                 description="work",
                 deps=Deps(),
@@ -773,6 +774,7 @@ class TestErrorContract:
 
         assert handle.status == TaskStatus.FAILED
         assert handle.error == "usage limit exceeded: out of tokens"
+        assert handle.exception is exhausted
 
     async def test_async_records_usage_limit_under_the_same_marker(self) -> None:
         """A background delegation has no caller to raise into, so it records instead.
@@ -781,8 +783,9 @@ class TestErrorContract:
         made telemetry depend on knowing how a delegation had been dispatched.
         """
         toolset = _toolset()
+        exhausted = UsageLimitExceeded("out of tokens")
         await _run_async(
-            agent=StubAgent(error=UsageLimitExceeded("out of tokens")),
+            agent=StubAgent(error=exhausted),
             config=_config(),
             description="work",
             deps=Deps(),
@@ -795,6 +798,7 @@ class TestErrorContract:
         handle = toolset.task_manager.handles["t1"]
         assert handle.status == TaskStatus.FAILED
         assert handle.error == "usage limit exceeded: out of tokens"
+        assert handle.exception is exhausted
 
     @pytest.mark.parametrize(
         "error",
@@ -842,6 +846,50 @@ class TestErrorContract:
 
         with pytest.raises(ValueError, match="bad argument"):
             await toolset.tools["task"].function(Ctx(), "work", "worker")
+
+    async def test_a_failed_delegation_hands_the_host_the_exception_behind_the_text(self) -> None:
+        """`TaskHandle.exception` carries the exception whose text `error` embeds.
+
+        A provider error's message can carry the failing request URL with the
+        key still in its query string. A host that must not surface foreign
+        text reads the class from here, composes its own sentence and logs the
+        original (agenticos#699).
+        """
+        boom = RuntimeError("401 from https://llm.example.com/v1?api_key=sk-secret")
+        handle = TaskHandle(task_id="t1", subagent_name="worker", description="d")
+
+        with pytest.raises(ModelRetry):
+            await _run_sync(
+                agent=StubAgent(error=boom),
+                config=_config(),
+                description="work",
+                deps=Deps(),
+                task_id="t1",
+                handle=handle,
+            )
+
+        assert handle.status == TaskStatus.FAILED
+        assert handle.exception is boom
+
+    async def test_a_background_failure_records_the_exception_too(self) -> None:
+        """Both dispatch modes fill `TaskHandle.exception`, like `error` itself."""
+        boom = RuntimeError("401 from https://llm.example.com/v1?api_key=sk-secret")
+        manager = TaskManager(message_bus=InMemoryMessageBus())
+
+        await _run_async(
+            agent=StubAgent(error=boom),
+            config=_config(),
+            description="work",
+            deps=Deps(),
+            task_id="t1",
+            task_manager=manager,
+            message_bus=manager.message_bus,
+        )
+        await asyncio.gather(*manager.tasks.values(), return_exceptions=True)
+
+        handle = manager.handles["t1"]
+        assert handle.status == TaskStatus.FAILED
+        assert handle.exception is boom
 
     async def test_sync_marks_handle_deferred_when_a_suspension_propagates(self) -> None:
         """A suspension is not a failure, and the handle has to say which it was.

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -511,6 +511,7 @@ async def test_run_async_retries_then_completes() -> None:
     assert handle.retry_count == 1
     # Transient error message cleared after eventual success.
     assert handle.error is None
+    assert handle.exception is None
 
 
 async def test_run_async_completes_when_observability_attrs_missing() -> None:
@@ -614,6 +615,7 @@ async def test_run_async_retries_exhausted_fails() -> None:
     assert handle.status == TaskStatus.FAILED
     assert handle.retry_count == 1
     assert "503" in str(handle.error)
+    assert isinstance(handle.exception, ModelHTTPError)
 
 
 async def test_run_async_soft_cancel_marks_handle_cancelled() -> None:
@@ -1092,6 +1094,7 @@ async def test_run_sync_records_retries_on_the_handle() -> None:
     assert handle.retry_count == 1
     # Transient error message cleared after eventual success.
     assert handle.error is None
+    assert handle.exception is None
 
 
 async def test_run_sync_records_retries_before_failing() -> None:
@@ -1125,6 +1128,7 @@ async def test_run_sync_records_retries_before_failing() -> None:
     assert handle.status == TaskStatus.FAILED
     assert handle.retry_count == 1
     assert "503" in str(handle.error)
+    assert isinstance(handle.exception, ModelHTTPError)
 
 
 async def test_run_sync_without_a_handle_still_retries() -> None:

--- a/tests/test_toolset.py
+++ b/tests/test_toolset.py
@@ -1027,7 +1027,8 @@ class TestRunSync:
     @pytest.mark.asyncio
     async def test_run_sync_crash_returns_on_failure_message(self):
         """`on_failure` turns a crash into a steering message instead of a retry."""
-        mock_agent = FakeAgent(error=Exception("boom"))
+        boom = Exception("boom")
+        mock_agent = FakeAgent(error=boom)
         config = SubAgentConfig(
             name="test",
             description="Test agent",
@@ -1048,16 +1049,19 @@ class TestRunSync:
         assert result == "Summarise from what you already have."
         assert handle.status == TaskStatus.FAILED
         assert handle.error == "Exception: boom"
+        assert handle.exception is boom
 
     @pytest.mark.asyncio
     async def test_run_sync_propagates_crash_when_not_contained(self):
         """`contain_errors=False` lets the original exception reach the parent run."""
-        mock_agent = FakeAgent(error=ValueError("bad tool argument"))
+        bad = ValueError("bad tool argument")
+        mock_agent = FakeAgent(error=bad)
         config = SubAgentConfig(
             name="test",
             description="Test agent",
             instructions="Do test",
         )
+        handle = TaskHandle(task_id="task-123", subagent_name="test", description="d")
 
         with pytest.raises(ValueError, match="bad tool argument"):
             await _run_sync(
@@ -1066,8 +1070,12 @@ class TestRunSync:
                 description="do the thing",
                 deps=MockDeps(),
                 task_id="task-123",
+                handle=handle,
                 contain_errors=False,
             )
+
+        assert handle.status == TaskStatus.FAILED
+        assert handle.exception is bad
 
     @pytest.mark.asyncio
     async def test_run_sync_propagates_control_flow_signals(self):

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -154,7 +154,25 @@ class TestTaskHandle:
         assert handle.completed_at is None
         assert handle.result is None
         assert handle.error is None
+        assert handle.exception is None
         assert handle.pending_question is None
+
+    def test_finish_carries_the_exception_behind_the_error(self):
+        """A host reads the class from `exception` instead of parsing `error`."""
+        handle = TaskHandle(task_id="t", subagent_name="s", description="d")
+        boom = RuntimeError("boom")
+
+        assert handle.finish(TaskStatus.FAILED, error="RuntimeError: boom", exception=boom)
+        assert handle.exception is boom
+
+    def test_finish_clears_a_retry_time_exception_on_completion(self):
+        """`finish` sets `exception` unconditionally, so a completion clears
+        whatever the retry recorder left behind."""
+        handle = TaskHandle(task_id="t", subagent_name="s", description="d")
+        handle.exception = RuntimeError("transient")
+
+        assert handle.finish(TaskStatus.COMPLETED, result="done")
+        assert handle.exception is None
 
     def test_handle_with_result(self):
         """Test handle with completed result."""

--- a/uv.lock
+++ b/uv.lock
@@ -1333,7 +1333,7 @@ wheels = [
 
 [[package]]
 name = "subagents-pydantic-ai"
-version = "0.2.18"
+version = "0.2.19"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## What

`TaskHandle.exception` carries the underlying exception wherever `error` embeds an exception's own text: a contained crash, an exhausted retry budget, a usage limit in both dispatch modes, a propagated crash with `contain_errors=False`, and each transient retry. `finish()` takes it as a keyword and sets it unconditionally on the winning terminal transition, so a completion clears whatever the retry recorder left behind.

## Why

A host cannot safely render `error`: the embedded text is whatever the delegate's model client raised, and a provider error routinely carries the failing request URL — key included — for a profile on a custom `base_url`. Until now the host's options were parsing the library's formatted string or surfacing it verbatim (vstorm-co/agenticos#699 is the second one happening). With the exception on the handle, the host reads the class, composes its own sentence, and logs the original.

## Verification

- `make lint`, `make typecheck-both` (pyright + mypy strict) clean.
- 1186 tests, 100% branch coverage: identity assertions on every listed site, plus the clearing behaviour on both eventual-success retry paths.
- `mkdocs build --strict` clean (`docs/concepts/types.md` gained the field).

Ships as 0.2.19.
