### PR TITLE
fix(toolset): name the exception's class in a task-status answer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.20] - 2026-08-17
+
+### Fixed
+
+- **`check_task` and `wait_tasks` no longer hand a delegate's provider text to
+  the model.** Both composed their failure lines from `handle.error`, which
+  embeds the exception's own message -- and a model client's message carries the
+  failing request URL with the key still in its query string on a custom
+  `base_url`. What a status tool returns is a tool *return*, which a host stores
+  whole and renders to everyone who can read the run, so the key landed on a
+  stored transcript row. The four lines (`Error:`, `Retry N:`, `Outcome:` in
+  `check_task`, and the terminal line in `wait_tasks`) now name the exception's
+  class, taken from `TaskHandle.exception`. `handle.error` is unchanged and still
+  holds the whole thing for a host to log.
+
+  The `RETRYING` line leaked for delegations that eventually **succeed**:
+  `finish` clears `error` on completion, but a model that polled mid-retry
+  already had the answer on a transcript row.
+
+  The `usage limit exceeded` marker survives -- it is this library's own text,
+  and it is what tells a model to stop delegating rather than retry.
+
+  **Behaviour change** for a host that read those strings expecting the
+  exception's message: it is on `handle.error`, and `handle.exception` is the
+  supported way to compose your own.
+
 ## [0.2.19] - 2026-08-16
 
 ### Added

--- a/docs/advanced/errors.md
+++ b/docs/advanced/errors.md
@@ -170,8 +170,14 @@ Task: a1b2c3d4
 Subagent: scraper
 Status: failed
 Description: Fetch the pricing page
-Error: ConnectionError: Connection reset by peer
+Error: ConnectionError
 ```
+
+**The class, not the message.** What `check_task` and `wait_tasks` return is a tool
+*return*, which a host stores whole on the parent's transcript and shows to everyone
+who can read the run -- and a model client's message carries the failing request URL
+with the key still in its query string. So the answer names the class, read off
+`handle.exception`; `handle.error` keeps the whole thing for your logs.
 
 Cancellation is separate: a cancelled task reaches `cancelled`, and
 `asyncio.CancelledError` is re-raised so the task really stops. See

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "subagents-pydantic-ai"
-version = "0.2.19"
+version = "0.2.20"
 description = "Subagent toolset for pydantic-ai with dual-mode execution and dynamic agent creation"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/subagents_pydantic_ai/_execution.py
+++ b/src/subagents_pydantic_ai/_execution.py
@@ -118,6 +118,27 @@ explanations of one rule.
 """
 
 
+def error_for_model(handle: TaskHandle) -> str | None:
+    """A handle's failure in this library's own words, with no foreign text in it.
+
+    `handle.error` embeds the exception's own message exactly when
+    `handle.exception` is set, and a model client's message can carry the failing
+    request URL with the key still in its query string. The task-status tools hand
+    their answer to the model, where a host stores a tool return whole and streams
+    it to everyone who can read the run -- so what goes back names the class, and
+    the original stays on `handle.error` for the host to log.
+
+    The usage-limit marker survives, because it is text this library chose rather
+    than text a provider sent; only the part after it is replaced.
+    """
+    if handle.exception is None:
+        return handle.error
+    name = type(handle.exception).__name__
+    if handle.error is not None and handle.error.startswith(_USAGE_LIMIT_MARKER):
+        return f"{_USAGE_LIMIT_MARKER}: {name}"
+    return name
+
+
 def _deferred_requests(output: object) -> DeferredToolRequests | None:
     """The parked tool calls in a run's output, when it suspended rather than answered.
 

--- a/src/subagents_pydantic_ai/toolset.py
+++ b/src/subagents_pydantic_ai/toolset.py
@@ -24,7 +24,11 @@ from pydantic_ai.models import Model
 from pydantic_ai.toolsets import AbstractToolset, FunctionToolset
 
 from subagents_pydantic_ai._chat_trace import ChatTraceKey, ChatTraceStore
-from subagents_pydantic_ai._execution import DEFAULT_ASK_TIMEOUT_SECONDS, drain_steering_messages
+from subagents_pydantic_ai._execution import (
+    DEFAULT_ASK_TIMEOUT_SECONDS,
+    drain_steering_messages,
+    error_for_model,
+)
 from subagents_pydantic_ai._execution import _run_async as _run_async
 from subagents_pydantic_ai._execution import _run_sync as _run_sync
 from subagents_pydantic_ai._observability import (
@@ -1253,16 +1257,16 @@ class SubAgentToolset(FunctionToolset[Any]):
         if handle.status == TaskStatus.COMPLETED:
             status_info.append(f"Result: {handle.result}")
         elif handle.status == TaskStatus.FAILED:
-            status_info.append(f"Error: {handle.error}")
+            status_info.append(f"Error: {error_for_model(handle)}")
         elif handle.status == TaskStatus.WAITING_FOR_ANSWER:
             status_info.append(f"Question: {handle.pending_question}")
         elif handle.is_finished:
             # CANCELLED. Every terminal status has to report its outcome here;
             # falling through to the elapsed-time line would tell the model a
             # finished task is still running, and hide why it stopped.
-            status_info.append(f"Outcome: {handle.error}")
+            status_info.append(f"Outcome: {error_for_model(handle)}")
         elif handle.status == TaskStatus.RETRYING:
-            status_info.append(f"Retry {handle.retry_count}: {handle.error}")
+            status_info.append(f"Retry {handle.retry_count}: {error_for_model(handle)}")
         elif handle.started_at:
             elapsed = (utcnow() - handle.started_at).total_seconds()
             status_info.append(f"Running for: {elapsed:.1f}s")
@@ -1403,7 +1407,7 @@ class SubAgentToolset(FunctionToolset[Any]):
                 finished_count += 1
                 lines.append(
                     f"- {tid} ({handle.subagent_name}): "
-                    f"{handle.status.value.upper()} - {handle.error}"
+                    f"{handle.status.value.upper()} - {error_for_model(handle)}"
                 )
             else:
                 lines.append(f"- {tid} ({handle.subagent_name}): {handle.status}")

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -277,6 +277,115 @@ class TestStatusRendering:
 
 
 # --------------------------------------------------------------------------- #
+# What a status answer may say about a failure
+# --------------------------------------------------------------------------- #
+
+
+_KEYED_URL = "https://acme.example/v1/chat?api-key=sk-live-4f2b"
+
+
+def _failed(status: TaskStatus = TaskStatus.FAILED, **extra: Any) -> TaskHandle:
+    """A handle whose `error` embeds a model client's own message, as a real one does."""
+    exception = RuntimeError(f"401 Unauthorized calling {_KEYED_URL}")
+    return TaskHandle(
+        task_id="t1",
+        subagent_name="worker",
+        description="dig",
+        status=status,
+        error=f"{type(exception).__name__}: {exception}",
+        exception=exception,
+        **extra,
+    )
+
+
+class TestAStatusAnswerNamesTheTypeNotTheMessage:
+    """A task-status tool's answer is stored and shown, so it carries no vendor text.
+
+    A host stores a `ToolReturnPart` whole -- it is the tool's own answer, not a
+    retry prompt something can scrub -- and renders it to everyone who can read the
+    run. A model client's message carries the failing request URL with the key still
+    in its query string on a custom `base_url`, so handing `handle.error` to the
+    model put that key on a transcript row. The class is named instead, and
+    `handle.error` keeps the original for the host to log.
+    """
+
+    async def test_check_task_on_a_failed_task_names_the_class(self) -> None:
+        toolset = _toolset()
+        toolset.task_manager.handles["t1"] = _failed()
+
+        result = await toolset.tools["check_task"].function(Ctx(), "t1")
+
+        assert "Error: RuntimeError" in result
+        assert _KEYED_URL not in result
+        assert "401" not in result
+
+    async def test_check_task_mid_retry_names_the_class_and_keeps_the_count(self) -> None:
+        """This one leaks for a delegation that eventually succeeds.
+
+        `finish` clears `error` on completion, but the model may have polled while
+        the task was retrying, and by then the answer is already a transcript row.
+        """
+        toolset = _toolset()
+        toolset.task_manager.handles["t1"] = _failed(
+            TaskStatus.RETRYING, started_at=utcnow(), retry_count=2
+        )
+
+        result = await toolset.tools["check_task"].function(Ctx(), "t1")
+
+        assert "Retry 2: RuntimeError" in result
+        assert _KEYED_URL not in result
+
+    async def test_check_task_on_a_cancellation_that_carried_one_names_the_class(self) -> None:
+        toolset = _toolset()
+        toolset.task_manager.handles["t1"] = _failed(TaskStatus.CANCELLED)
+
+        result = await toolset.tools["check_task"].function(Ctx(), "t1")
+
+        assert "Outcome: RuntimeError" in result
+        assert _KEYED_URL not in result
+
+    async def test_wait_tasks_names_the_class(self) -> None:
+        toolset = _toolset()
+        toolset.task_manager.handles["t1"] = _failed()
+
+        result = await toolset.tools["wait_tasks"].function(Ctx(), ["t1"])
+
+        assert "FAILED - RuntimeError" in result
+        assert _KEYED_URL not in result
+
+    async def test_a_budget_that_ran_out_still_says_so(self) -> None:
+        """The marker is this library's own text, so replacing it would lose the
+        one thing that tells a model to stop delegating rather than retry."""
+        toolset = _toolset()
+        exhausted = UsageLimitExceeded("The next request would exceed the limit")
+        toolset.task_manager.handles["t1"] = TaskHandle(
+            task_id="t1",
+            subagent_name="worker",
+            description="dig",
+            status=TaskStatus.FAILED,
+            error=f"usage limit exceeded: {exhausted}",
+            exception=exhausted,
+        )
+
+        result = await toolset.tools["check_task"].function(Ctx(), "t1")
+
+        assert "Error: usage limit exceeded: UsageLimitExceeded" in result
+        assert "The next request would exceed the limit" not in result
+
+    async def test_the_handle_keeps_the_original_for_the_host_to_log(self) -> None:
+        """Scrubbing the answer must not scrub the record. #699's contract is that
+        `error` holds the whole thing and `exception` is how a host composes its own."""
+        toolset = _toolset()
+        handle = _failed()
+        toolset.task_manager.handles["t1"] = handle
+
+        await toolset.tools["check_task"].function(Ctx(), "t1")
+
+        assert handle.error is not None
+        assert _KEYED_URL in handle.error
+
+
+# --------------------------------------------------------------------------- #
 # Run isolation
 # --------------------------------------------------------------------------- #
 

--- a/tests/test_toolset.py
+++ b/tests/test_toolset.py
@@ -2666,7 +2666,10 @@ class TestToolsetFunctionsCoverage:
             # Check task status
             status = await check_tool.function(ctx, task_id)
             assert "failed" in status.lower()
-            assert "Task crashed" in status
+            # The class, not the message: a return is stored whole on the parent's
+            # transcript and a provider's text carries the keyed request URL.
+            assert "Error: Exception" in status
+            assert "Task crashed" not in status
 
     @pytest.mark.asyncio
     async def test_answer_subagent_success(self):
@@ -2873,8 +2876,8 @@ class TestToolsetFunctionsCoverage:
             await asyncio.sleep(0.1)
 
             result = await wait_tool.function(ctx, [tid1], 5.0)
-            assert "FAILED" in result
-            assert "Search API down" in result
+            assert "FAILED - Exception" in result
+            assert "Search API down" not in result
 
     @pytest.mark.asyncio
     async def test_wait_tasks_not_found(self):

--- a/uv.lock
+++ b/uv.lock
@@ -1333,7 +1333,7 @@ wheels = [
 
 [[package]]
 name = "subagents-pydantic-ai"
-version = "0.2.19"
+version = "0.2.20"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
`check_task` and `wait_tasks` composed their failure lines straight from
`handle.error`:

```python
f"Error: {handle.error}"                              # check_task, FAILED
f"Retry {handle.retry_count}: {handle.error}"         # check_task, RETRYING
f"Outcome: {handle.error}"                            # check_task, CANCELLED
f"{handle.status.value.upper()} - {handle.error}"     # wait_tasks
```

`handle.error` embeds the exception's own message — `f"{type(exc).__name__}: {exc}"`,
`f"Transient error (retry {n}): {exc}"` — and a model client's message carries the
failing request URL with the key still in its query string when the profile has a
custom `base_url`.

## Why this one is worse than the frame it looks like

What a status tool returns is a tool **return**. A host stores a `ToolReturnPart`
whole — deliberately, because a return is the tool's own answer rather than
something the framework composed — and renders it to everyone who can read the run.
So this is the surface a host's scrubber cannot reach: it can strip a
`RetryPromptPart`, and several do, but not this.

The `RETRYING` line also leaks for delegations that **eventually succeed**. `finish`
clears `error` on completion, but by then a model that polled mid-retry already has
the answer on a stored row.

## The fix

One helper, `error_for_model`, reading `TaskHandle.exception` — the field 0.2.19
added for exactly this — and all four lines go through it. The class is named; the
message is not. `handle.error` is untouched and still carries the whole thing, which
is the contract #80 established: a host reads the class from `exception`, composes
its own sentence, and logs the original.

The `usage limit exceeded` marker survives. It is this library's own text, not a
provider's, and it is the thing that tells a model to stop delegating rather than
retry — so `usage limit exceeded: <exc text>` becomes
`usage limit exceeded: UsageLimitExceeded` rather than losing the words.

## Behaviour change

A host that read those returned strings expecting the exception's message will stop
finding it. It is on `handle.error`, and `handle.exception` is the supported way to
compose your own — both documented since 0.2.19. Noted in the changelog.

## Verified

`make lint`, `make typecheck` (pyright strict) and `make test` clean — 1192 passed,
coverage 100%.

Two existing tests asserted the leak: `test_check_task_failed` wanted `Task crashed`
in the answer and `test_wait_tasks_with_failure` wanted `Search API down`. Both now
assert the class is named and the message is absent. Six new tests in
`tests/test_lifecycle.py` cover the four lines, the usage-limit marker, and that the
handle still holds the original afterwards.

`docs/advanced/errors.md` showed the old `Error: ConnectionError: Connection reset
by peer` output; updated, with a paragraph saying why the class is what a status
tool returns.

Refs vstorm-co/agenticos#819
